### PR TITLE
ci: enforce bundle-size budget via size-limit (#39)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,29 @@ jobs:
           path: dist/
           retention-days: 7
 
+  bundle-size:
+    # Enforces a gzipped bundle budget so refactors can't silently bloat
+    # the library. Budgets live in package.json under "size-limit".
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build library
+        run: npm run build
+
+      - name: Check bundle size against budget
+        run: npm run size
+
   cross-platform-test:
     strategy:
       matrix:

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "@semantic-release/github": "^11.0.5",
         "@semantic-release/npm": "^12.0.2",
         "@semantic-release/release-notes-generator": "^14.0.3",
+        "@size-limit/file": "^12.1.0",
         "@types/jsdom": "^21.1.7",
         "@types/node": "^24.3.0",
         "@typescript-eslint/eslint-plugin": "^8.41.0",
@@ -39,6 +40,7 @@
         "rimraf": "^6.0.1",
         "rollup-plugin-dts": "^6.2.3",
         "semantic-release": "^24.2.7",
+        "size-limit": "^12.1.0",
         "typedoc": "^0.28.12",
         "typedoc-plugin-markdown": "^4.8.1",
         "typescript": "^5.9.2",
@@ -2667,6 +2669,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@size-limit/file": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
+      "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
@@ -3507,6 +3522,16 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
+    },
+    "node_modules/bytes-iec": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
+      "integrity": "sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cac": {
       "version": "6.7.14",
@@ -6721,6 +6746,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lilconfig": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antonk52"
+      }
+    },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -7274,6 +7312,16 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nanospinner": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
+      "integrity": "sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picocolors": "^1.1.1"
       }
     },
     "node_modules/natural-compare": {
@@ -10452,10 +10500,11 @@
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
@@ -11642,6 +11691,34 @@
         "node": ">=18"
       }
     },
+    "node_modules/size-limit": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+      "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/skin-tone": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
@@ -12181,13 +12258,14 @@
       "dev": true
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -44,8 +44,33 @@
     "semantic-release": "semantic-release",
     "docs:build": "typedoc",
     "docs:serve": "npx http-server docs -p 8080",
-    "docs:clean": "rimraf docs"
+    "docs:clean": "rimraf docs",
+    "size": "size-limit",
+    "size:build": "npm run build && npm run size"
   },
+  "size-limit": [
+    {
+      "name": "ESM (gzip)",
+      "path": "dist/sortable.es.js",
+      "limit": "20 kB",
+      "gzip": true,
+      "brotli": false
+    },
+    {
+      "name": "CJS (gzip)",
+      "path": "dist/sortable.cjs.js",
+      "limit": "12 kB",
+      "gzip": true,
+      "brotli": false
+    },
+    {
+      "name": "UMD (gzip)",
+      "path": "dist/sortable.umd.js",
+      "limit": "12 kB",
+      "gzip": true,
+      "brotli": false
+    }
+  ],
   "keywords": [
     "sortable",
     "drag-and-drop",
@@ -85,6 +110,7 @@
     "@semantic-release/github": "^11.0.5",
     "@semantic-release/npm": "^12.0.2",
     "@semantic-release/release-notes-generator": "^14.0.3",
+    "@size-limit/file": "^12.1.0",
     "@types/jsdom": "^21.1.7",
     "@types/node": "^24.3.0",
     "@typescript-eslint/eslint-plugin": "^8.41.0",
@@ -101,6 +127,7 @@
     "rimraf": "^6.0.1",
     "rollup-plugin-dts": "^6.2.3",
     "semantic-release": "^24.2.7",
+    "size-limit": "^12.1.0",
     "typedoc": "^0.28.12",
     "typedoc-plugin-markdown": "^4.8.1",
     "typescript": "^5.9.2",


### PR DESCRIPTION
## Summary

- Adds \`size-limit\` + \`@size-limit/file\` dev deps
- Adds \`size-limit\` config in \`package.json\` with gzipped budgets per output format
- Adds new \`bundle-size\` CI job that builds the library and fails if any bundle exceeds budget
- Locks in the floor before #29 (fallback system) work potentially bloats the bundle

## Budgets (gzipped)

| Bundle | Current | Budget | Headroom |
|---|---|---|---|
| ESM | 18.44 kB | 20 kB | 7.8% |
| CJS | 10.88 kB | 12 kB | 9.3% |
| UMD | 10.96 kB | 12 kB | 8.7% |

Tight enough to catch real regressions, loose enough to avoid noise from minor whitespace changes. Constitution target was <50 kB gz; plan target was <25 kB gz — both still satisfied with plenty of headroom for the fallback system to land in #29.

## Test plan

- [ ] \`npm run size\` passes locally
- [ ] CI \`bundle-size\` job appears on this PR and goes green
- [ ] All other jobs (lint/type-check/unit/e2e-linux/e2e-hosted) stay green
- [ ] Verify failure mode: temporarily lower a budget below current size and confirm CI fails (will not be done in this PR, but documented for future verification)

Closes #39
Refs #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)