### PR TITLE
fix: recognize empty containers as drop targets in pointer drag (#32)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,36 +111,9 @@ Sortable (Main Class)
 - Group memberships
 - Pull/put permissions
 
-## The Empty Container Problem
+## Empty Container Drop Targets
 
-### Current Issue
-When a container is empty:
-1. No draggable children exist
-2. `event.target.closest(draggable)` returns null
-3. Container isn't recognized as a valid drop zone
-4. Items can't be dropped
-
-### Current (Broken) Solution Attempt
-```typescript
-// In DragManager.onDragOver
-const draggableChildren = Array.from(this.zone.element.children).filter(
-  child => child.matches(this.draggable)
-)
-if (draggableChildren.length === 0) {
-  // Handle empty container
-  this.zone.element.appendChild(placeholder)
-}
-```
-
-### Why It's Not Working
-1. The check happens but the placeholder isn't persisting
-2. The drop event might not be firing correctly
-3. The container itself isn't being recognized as a drop target
-
-### Proposed Solution
-1. **Explicit Drop Zones**: Mark containers with a data attribute or class
-2. **Container-Level Events**: Attach dragover/drop handlers to containers, not just items
-3. **Empty State Handling**: Special logic when `children.length === 0`
+Resolved in #32. When the pointer-based drag handler's `elementFromPoint(...).closest(draggable)` returns null, `DragManager.onPointerMove` falls back to `findSortableContainerUnder(elementUnderMouse)`, which walks up the ancestor chain looking for an element registered in `dragManagerRegistry`. If found and group-compatible, the dragged item is appended via `targetZoneElement.insertBefore(item, null)`. Regression coverage lives in `tests/e2e/empty-container.spec.ts`.
 
 ## Configuration
 

--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -870,12 +870,20 @@ export class DragManager implements DragManagerInterface {
 
     // Find the element under the mouse cursor
     const elementUnderMouse = document.elementFromPoint(e.clientX, e.clientY)
-    const over = elementUnderMouse?.closest(this.draggable) as HTMLElement
+    const over = elementUnderMouse?.closest(
+      this.draggable
+    ) as HTMLElement | null
 
-    if (!over) return
-
-    // Find which zone the element we're hovering over belongs to
-    const targetZoneElement = over.parentElement
+    // Resolve the target sortable container. When `over` is non-null this is
+    // simply its parent. When it's null we may still be hovering over an
+    // empty sortable container — walk up `elementUnderMouse` ancestors and
+    // look for one registered with the drag-manager registry (#32).
+    let targetZoneElement: HTMLElement | null
+    if (over) {
+      targetZoneElement = over.parentElement
+    } else {
+      targetZoneElement = this.findSortableContainerUnder(elementUnderMouse)
+    }
     if (!targetZoneElement) return
 
     // Find all Sortable instances and see which one manages this zone
@@ -938,7 +946,10 @@ export class DragManager implements DragManagerInterface {
           ? currentActiveDrag.clones[0]
           : this.dragElement
 
-      if (over !== movingElement) {
+      // Same-zone movement only meaningful when hovering over a draggable
+      // sibling. With an empty container or padding hit, `over` is null —
+      // there's no reorder to do, skip.
+      if (over && over !== movingElement) {
         // Find the target DragManager's zone for proper index tracking
         const targetDragManager = this.findDragManagerForZone(targetZoneElement)
         const targetZone = targetDragManager?.zone ?? this.zone
@@ -1107,6 +1118,22 @@ export class DragManager implements DragManagerInterface {
   /** Find the DragManager instance that manages a specific zone */
   private findDragManagerForZone(targetZone: HTMLElement): DragManager | null {
     return dragManagerRegistry.get(targetZone) || null
+  }
+
+  /**
+   * Walk up the ancestor chain of `el` and return the first element that's
+   * registered as a sortable container. Used by pointer-based drag detection
+   * to recognise empty containers as valid drop targets (#32).
+   */
+  private findSortableContainerUnder(el: Element | null): HTMLElement | null {
+    let cur: Element | null = el
+    while (cur) {
+      if (cur instanceof HTMLElement && dragManagerRegistry.has(cur)) {
+        return cur
+      }
+      cur = cur.parentElement
+    }
+    return null
   }
 
   /** Get the selection manager for this drag manager */

--- a/tests/e2e/empty-container.spec.ts
+++ b/tests/e2e/empty-container.spec.ts
@@ -1,0 +1,91 @@
+import { expect, test, Page } from '@playwright/test'
+
+/**
+ * Regression coverage for #32 — items must drop into empty sortable containers.
+ *
+ * ARCHITECTURE.md flagged this as an unresolved issue: when a container has
+ * no draggable children, the pointer-based drag handler bails because
+ * `elementFromPoint(...).closest(draggable)` returns null.
+ *
+ * NOTE: We drive the drag with `page.mouse` (not `page.dragAndDrop`) because
+ * Playwright's high-level helper does not always dispatch intermediate
+ * pointermove events to the target when the target is a container — and the
+ * library's drag logic lives in `pointermove`.
+ */
+async function pointerDrag(
+  page: Page,
+  fromSelector: string,
+  toSelector: string,
+  steps = 10
+): Promise<void> {
+  // page.mouse uses viewport coordinates, so make sure both endpoints are
+  // actually inside the viewport before reading bounding boxes.
+  await page.locator(fromSelector).scrollIntoViewIfNeeded()
+  await page.locator(toSelector).scrollIntoViewIfNeeded()
+
+  const fromBox = await page.locator(fromSelector).boundingBox()
+  const toBox = await page.locator(toSelector).boundingBox()
+  if (!fromBox || !toBox) throw new Error('missing bounding box')
+
+  const fromX = fromBox.x + fromBox.width / 2
+  const fromY = fromBox.y + fromBox.height / 2
+  const toX = toBox.x + toBox.width / 2
+  const toY = toBox.y + toBox.height / 2
+
+  await page.mouse.move(fromX, fromY)
+  await page.mouse.down()
+  // Multiple intermediate pointermoves so the drag logic observes the path.
+  await page.mouse.move(fromX, fromY, { steps })
+  await page.mouse.move(toX, toY, { steps })
+  await page.mouse.up()
+}
+
+test.describe('Empty Container Drop Target (#32)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForFunction(() => window.resortableLoaded === true)
+    await expect(page.locator('#shared-a-1 .sortable-item')).toHaveCount(4)
+    await expect(page.locator('#shared-a-2 .sortable-item')).toHaveCount(4)
+
+    // Empty list a-1 by detaching every draggable child. Both lists share a
+    // group ('shared-a'), so a-2's items remain eligible to drop into a-1.
+    await page.evaluate(() => {
+      const list = document.getElementById('shared-a-1')!
+      list.querySelectorAll('.sortable-item').forEach((el) => el.remove())
+    })
+
+    await expect(page.locator('#shared-a-1 .sortable-item')).toHaveCount(0)
+    await expect(page.locator('#shared-a-2 .sortable-item')).toHaveCount(4)
+  })
+
+  test('drops item from non-empty list into empty list', async ({
+    page,
+  }, testInfo) => {
+    test.skip(testInfo.project.name === 'Mobile Chrome', 'Tracked in #48')
+
+    await pointerDrag(page, '#shared-a-2 [data-id="a-5"]', '#shared-a-1')
+
+    await expect(page.locator('#shared-a-1 .sortable-item')).toHaveCount(1)
+    await expect(page.locator('#shared-a-2 .sortable-item')).toHaveCount(3)
+    await expect(
+      page.locator('#shared-a-1 .sortable-item').first()
+    ).toHaveAttribute('data-id', 'a-5')
+  })
+
+  test('can drop multiple items into a previously-empty list sequentially', async ({
+    page,
+  }, testInfo) => {
+    test.skip(testInfo.project.name === 'Mobile Chrome', 'Tracked in #48')
+
+    await pointerDrag(page, '#shared-a-2 [data-id="a-5"]', '#shared-a-1')
+    await expect(page.locator('#shared-a-1 .sortable-item')).toHaveCount(1)
+
+    await pointerDrag(
+      page,
+      '#shared-a-2 [data-id="a-6"]',
+      '#shared-a-1 [data-id="a-5"]'
+    )
+    await expect(page.locator('#shared-a-1 .sortable-item')).toHaveCount(2)
+    await expect(page.locator('#shared-a-2 .sortable-item')).toHaveCount(2)
+  })
+})


### PR DESCRIPTION
## Summary

Resolves the long-standing \"Empty Container Problem\" flagged in \`ARCHITECTURE.md\`. When the pointer-based drag handler's \`elementFromPoint(...).closest(draggable)\` returned null — the exact case of hovering over a container with no draggable children — \`onPointerMove\` bailed at \`if (!over) return\` and the dragged item was never delivered to the empty target.

## Fix

When \`over\` is null, walk up the ancestor chain of \`elementUnderMouse\` looking for an element registered with \`dragManagerRegistry\`. If found and group-compatible, the existing cross-zone \`insertBefore(item, null)\` path now appends the item to the otherwise-empty container.

### Changes

- New private helper \`findSortableContainerUnder(el)\` on \`DragManager\`
- \`onPointerMove\` resolves \`targetZoneElement\` via the helper when \`over\` is null
- Same-zone branch tightened to no-op when \`over\` is null (prevents \`indexOf(null) → -1\` issues)
- \`ARCHITECTURE.md\` updated to remove the \"Empty Container Problem\" section and point at the new test

## Test coverage

New \`tests/e2e/empty-container.spec.ts\` with two scenarios:
1. Drop an item from a populated list into an emptied sibling list
2. Drop multiple items into a previously-empty list back-to-back

The new spec drives the drag with \`page.mouse\` rather than \`page.dragAndDrop\` because the high-level helper does not always dispatch intermediate pointermove events to a container target — and the library's logic lives in \`pointermove\`. Both tests skip on Mobile Chrome pending #48.

## Results

| | Before | After |
|---|---|---|
| chromium tests passed (\`CI=1\`) | 116 | **118** |
| Failures introduced | 0 | 0 |
| Skipped | 46 | 46 |

Unit tests: 196 passed (unchanged).

## Test plan

- [ ] All CI jobs green (Linux + hosted macOS + Windows e2e + bundle-size + lint/types/unit)
- [ ] \`empty-container.spec.ts\` appears as 2 new passing tests in the chromium project
- [ ] No regression on other browsers in the hosted matrix

Closes #32
Refs #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)