### PR TITLE
ci: only run hosted macOS on push, not on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,19 +87,10 @@ jobs:
           path: playwright-report/
           retention-days: 30
 
-  e2e-tests-hosted:
-    # GitHub-hosted macOS + Windows running the full 5-project Playwright
-    # matrix. Added to compare against the self-hosted macOS runner, which
-    # has been showing browserContext.newPage 30s timeouts on WebKit/Mobile.
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: macos-latest
-            artifact-name: playwright-report-hosted-macos
-          - os: windows-latest
-            artifact-name: playwright-report-hosted-windows
-    runs-on: ${{ matrix.os }}
+  e2e-tests-hosted-windows:
+    # GitHub-hosted Windows running the full 5-project Playwright matrix
+    # on every PR.
+    runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -123,7 +114,42 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: ${{ matrix.artifact-name }}
+          name: playwright-report-hosted-windows
+          path: playwright-report/
+          retention-days: 30
+
+  e2e-tests-hosted-macos:
+    # GitHub-hosted macOS runs the full 5-project matrix on push to main
+    # (and other configured push branches) but NOT on pull_request events.
+    # macOS minutes count at 10x on the OSS quota, so per-PR runs were
+    # burning ~90 minutes apiece; running post-merge keeps regression
+    # signal without the per-PR cost.
+    if: github.event_name == 'push'
+    runs-on: macos-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+
+      - name: Run Playwright tests
+        run: npm run test:e2e
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: playwright-report-hosted-macos
           path: playwright-report/
           retention-days: 30
 


### PR DESCRIPTION
## Summary

GitHub-hosted macOS runner minutes count at **10x** on the OSS quota. Every PR was burning ~90 quota-minutes on the macOS hosted job. This PR moves macOS to push events only (post-merge to main, via the existing workflow trigger), keeping the regression signal without the per-PR cost.

## What stays the same on every PR

- \`e2e-tests-linux\` — chromium baseline on ubuntu (~1.5 min)
- \`e2e-tests-hosted-windows\` — full 5-project Playwright matrix (~10-15 min)
- \`build\`, \`bundle-size\`, \`cross-platform-test\` (18, 20), \`lint-and-typecheck\`, \`unit-tests\`

## What runs after merge to main (or develop/alpha)

- \`e2e-tests-hosted-macos\` — full 5-project matrix on macos-latest

The single \`e2e-tests-hosted\` matrix job was split into two named jobs (\`-windows\` and \`-macos\`) for clarity. The macOS job carries \`if: github.event_name == 'push'\` so PR-triggered runs skip it entirely.

## Context

This PR is the cost-trim follow-up to #37 (which already retired the broken self-hosted macOS runner). Hosted macOS proved reliable but expensive; this lands the right balance.

## Test plan

- [ ] CI \`e2e-tests-hosted-macos\` is absent from PR #52's checks (it should be — this PR is a PR event)
- [ ] CI \`e2e-tests-hosted-windows\` runs on this PR and passes
- [ ] After merge: \`e2e-tests-hosted-macos\` appears and runs on the resulting push to main
- [ ] No regression in other jobs

Refs #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)