### PR TITLE
feat: wire fallbackOnBody + fallbackOffset into ghost positioning (#29)

### DIFF
--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -54,17 +54,18 @@ export class DragManager implements DragManagerInterface {
   // truth for the fallback ghost.
   private _forceFallback: boolean
   private _fallbackClass?: string
-  // @ts-expect-error - Will be implemented in fallback system
-
+  // `_fallbackOnBody` chooses where the pointer-driven ghost is appended:
+  // `true` → `document.body` (legacy `fallbackOnBody: true`); `false`
+  // (default) → the sortable zone's root element. See PR2 #29.
   private _fallbackOnBody: boolean
   // @ts-expect-error - Will be implemented in fallback system
 
   private _fallbackTolerance: number
-  // @ts-expect-error - Will be implemented in fallback system
-
+  // `_fallbackOffsetX` / `_fallbackOffsetY` shift the ghost by a fixed pixel
+  // offset relative to the cursor. Positive values move it right / down;
+  // negative values move it left / up. Matches legacy `fallbackOffset.x` /
+  // `fallbackOffset.y` direction. See PR2 #29.
   private _fallbackOffsetX: number
-  // @ts-expect-error - Will be implemented in fallback system
-
   private _fallbackOffsetY: number
   private _dragoverBubble: boolean
   private _dropBubble: boolean
@@ -76,8 +77,11 @@ export class DragManager implements DragManagerInterface {
   private _removeCloneOnHide: boolean
   private _emptyInsertThreshold: number
   private preventOnFilter: boolean
-  // @ts-expect-error - Will be implemented in data management
-
+  // `_dataIdAttr` is the configured `data-*` attribute name used as the
+  // identity column by toArray() / sort(). It is also forwarded to
+  // GhostManager so the ghost clone can strip the original's identity
+  // attribute and avoid duplicate matches in DOM queries when the ghost
+  // lives inside the zone (PR2 #29 — `fallbackOnBody: false` default).
   private _dataIdAttr: string
   private _setData?: (dataTransfer: DataTransfer, dragEl: HTMLElement) => void
   private ghostManager: GhostManager
@@ -855,17 +859,28 @@ export class DragManager implements DragManagerInterface {
     this.events.emit('choose', evt)
 
     // Create ghost element for visual feedback. `fallbackClass` is applied
-    // alongside `ghostClass` so fallback-mode styles can target a stable
-    // hook (legacy parity for `forceFallback` UX).
+    // alongside `ghostClass` so fallback-mode styles can target a stable hook
+    // (legacy parity for `forceFallback` UX). `fallbackOnBody` selects the
+    // ghost's parent — `document.body` when true, the sortable zone's root
+    // element when false (legacy default). `fallbackOffsetX` /
+    // `fallbackOffsetY` shift the ghost relative to the cursor (additive,
+    // matching legacy `fallbackOffset.x` / `.y`).
+    const ghostOptions = {
+      fallbackClass: this._fallbackClass,
+      appendTo: this._fallbackOnBody ? document.body : this.zone.element,
+      offsetX: this._fallbackOffsetX,
+      offsetY: this._fallbackOffsetY,
+      dataIdAttr: this._dataIdAttr,
+    }
     if (this.draggedItems.length > 1) {
       this.ghostManager.createStackedGhost(
         target,
         this.draggedItems.length,
         e,
-        this._fallbackClass
+        ghostOptions
       )
     } else {
-      this.ghostManager.createGhost(target, e, this._fallbackClass)
+      this.ghostManager.createGhost(target, e, ghostOptions)
     }
     this.ghostManager.createPlaceholder(target)
 

--- a/src/core/GhostManager.ts
+++ b/src/core/GhostManager.ts
@@ -1,12 +1,70 @@
 /**
+ * Options accepted by {@link GhostManager.createGhost} and
+ * {@link GhostManager.createStackedGhost}.
+ *
+ * Promoted from a positional `fallbackClass?: string` parameter (PR1 #29)
+ * to an options bag when `fallbackOnBody` and `fallbackOffset{X,Y}` joined
+ * the fallback option family in PR2 #29. Future additions (e.g.
+ * `fallbackTolerance` pre-commit motion in PR3) should slot in here.
+ */
+export interface CreateGhostOptions {
+  /**
+   * Class added to the ghost element alongside `ghostClass` so fallback-mode
+   * styles can target a stable hook (legacy parity for `forceFallback`).
+   */
+  fallbackClass?: string
+  /**
+   * Parent element the ghost is appended to. Defaults to `document.body`,
+   * matching the legacy `fallbackOnBody: true` behaviour. Callers wanting the
+   * legacy `fallbackOnBody: false` semantics should pass the sortable zone's
+   * root element instead.
+   *
+   * Note: when the chosen parent has `overflow: hidden`, the ghost will be
+   * clipped at the zone boundary. This is the legacy behaviour, not a bug.
+   */
+  appendTo?: HTMLElement
+  /**
+   * Horizontal pixel offset applied to the ghost relative to the cursor.
+   * Positive values shift the ghost to the right of where it would otherwise
+   * sit; negative values shift it to the left. Matches legacy
+   * `fallbackOffset.x` direction (see `legacy-sortable/src/Sortable.js`
+   * `_onTouchMove`).
+   */
+  offsetX?: number
+  /**
+   * Vertical pixel offset applied to the ghost relative to the cursor.
+   * Positive values shift the ghost down; negative values shift it up.
+   * Matches legacy `fallbackOffset.y` direction.
+   */
+  offsetY?: number
+  /**
+   * The data-attribute name configured by `dataIdAttr` on the parent
+   * Sortable. When the ghost lives inside the sortable zone (legacy
+   * `fallbackOnBody: false`, the new PR2 default), it would otherwise share
+   * this attribute with the original element — yielding duplicate matches in
+   * DOM queries like `[data-id="foo"]`. The attribute is stripped from the
+   * ghost clone so identity queries continue to address only the real item.
+   */
+  dataIdAttr?: string
+}
+
+/**
  * GhostManager handles the creation and management of ghost elements during drag operations.
  * The ghost element is a visual clone that follows the cursor during dragging.
  */
 export class GhostManager {
   private ghostElement: HTMLElement | null = null
   private placeholderElement: HTMLElement | null = null
-  private offsetX: number = 0
-  private offsetY: number = 0
+  // Distance from the cursor at drag start to the dragged element's top-left.
+  // Captured once in createGhost and reused on every updateGhostPosition call
+  // so the ghost tracks the cursor without snapping.
+  private cursorOffsetX: number = 0
+  private cursorOffsetY: number = 0
+  // Configured `fallbackOffsetX` / `fallbackOffsetY` — additive shift applied
+  // on top of the cursor-tracking position. Mirrors legacy `fallbackOffset`
+  // (positive x = ghost moves right of cursor; positive y = down).
+  private fallbackOffsetX: number = 0
+  private fallbackOffsetY: number = 0
   private ghostClass: string
   private chosenClass: string
   private dragClass: string
@@ -22,24 +80,50 @@ export class GhostManager {
   }
 
   /**
-   * Creates a ghost element from the dragged element
+   * Creates a ghost element from the dragged element.
+   *
    * @param draggedElement - The element being dragged
    * @param event - The drag event containing position information
-   * @param fallbackClass - Optional class added when running in fallback mode.
-   *   Applied alongside the configured `ghostClass` so styles intended for the
-   *   fallback ghost can target a stable, fallback-only hook.
+   * @param options - Optional configuration. See {@link CreateGhostOptions}.
+   *   When omitted, the ghost is appended to `document.body` with no
+   *   fallback class and zero offset (the pre-PR2 default).
    * @returns The created ghost element
    */
   createGhost(
     draggedElement: HTMLElement,
     event: MouseEvent | DragEvent | PointerEvent,
-    fallbackClass?: string
+    options?: CreateGhostOptions
   ): HTMLElement {
+    const fallbackClass = options?.fallbackClass
+    const appendTo = options?.appendTo ?? document.body
+    this.fallbackOffsetX = options?.offsetX ?? 0
+    this.fallbackOffsetY = options?.offsetY ?? 0
+    const dataIdAttr = options?.dataIdAttr ?? 'data-id'
     // Clean up any existing ghost
     this.destroyGhost()
 
     // Clone the dragged element
     this.ghostElement = draggedElement.cloneNode(true) as HTMLElement
+
+    // Strip identity attributes from the clone. With `fallbackOnBody: false`
+    // (PR2 default — legacy parity), the ghost lives inside the sortable
+    // zone, so any attribute that uniquely identifies the original would
+    // otherwise produce duplicate matches in DOM queries (notably
+    // `[data-id="..."]` lookups in tests and consumer code). Duplicate `id`
+    // is invalid HTML in any case; the ARIA / tabindex state describes the
+    // *real* element's user-facing semantics and has no meaning on a
+    // visual-only ghost clone (which is also `pointer-events: none`).
+    this.ghostElement.removeAttribute('id')
+    this.ghostElement.removeAttribute(dataIdAttr)
+    this.ghostElement.removeAttribute('aria-grabbed')
+    this.ghostElement.removeAttribute('aria-selected')
+    this.ghostElement.removeAttribute('aria-posinset')
+    this.ghostElement.removeAttribute('aria-setsize')
+    this.ghostElement.removeAttribute('tabindex')
+    // Descendant `id`s would also be duplicated; clear them too.
+    this.ghostElement
+      .querySelectorAll<HTMLElement>('[id]')
+      .forEach((el) => el.removeAttribute('id'))
 
     // Get computed styles from the original element
     const computedStyle = window.getComputedStyle(draggedElement)
@@ -108,14 +192,21 @@ export class GhostManager {
     this.ghostElement.style.transition = 'none' // Disable transitions during drag
 
     // Calculate offset from cursor to element top-left
-    this.offsetX = event.clientX - rect.left
-    this.offsetY = event.clientY - rect.top
+    this.cursorOffsetX = event.clientX - rect.left
+    this.cursorOffsetY = event.clientY - rect.top
 
     // Set initial position
     this.updateGhostPosition(event.clientX, event.clientY)
 
-    // Add to document body
-    document.body.appendChild(this.ghostElement)
+    // Append to the configured parent (defaults to document.body — matches
+    // legacy `fallbackOnBody: true`). When `fallbackOnBody` is false, callers
+    // pass the sortable zone's root element instead. The ghost uses
+    // `position: fixed` so layout positioning is unaffected by the parent;
+    // however, an ancestor with `overflow: hidden` (or a `transform` /
+    // `filter` / `will-change: transform` style that establishes a containing
+    // block for fixed-position descendants) will clip the ghost. That is the
+    // legacy behaviour as well — documented in PR2 #29.
+    appendTo.appendChild(this.ghostElement)
 
     // Apply chosen class to the original element
     draggedElement.classList.add(this.chosenClass)
@@ -134,10 +225,10 @@ export class GhostManager {
     anchorElement: HTMLElement,
     itemCount: number,
     event: MouseEvent | DragEvent | PointerEvent,
-    fallbackClass?: string
+    options?: CreateGhostOptions
   ): HTMLElement {
     // Create the base ghost from anchor
-    const ghost = this.createGhost(anchorElement, event, fallbackClass)
+    const ghost = this.createGhost(anchorElement, event, options)
 
     // Add stacked class
     ghost.classList.add('sortable-ghost-stacked')
@@ -205,8 +296,13 @@ export class GhostManager {
   updateGhostPosition(clientX: number, clientY: number): void {
     if (!this.ghostElement) return
 
-    this.ghostElement.style.left = `${clientX - this.offsetX}px`
-    this.ghostElement.style.top = `${clientY - this.offsetY}px`
+    // Position = cursor minus the grab offset (so the ghost tracks the cursor
+    // relative to where it was grabbed) plus the configured fallback offset.
+    // Legacy adds fallbackOffset.x / .y to the resulting position
+    // (see `_onTouchMove` in `legacy-sortable/src/Sortable.js`), so positive
+    // offsets shift the ghost right / down of the cursor.
+    this.ghostElement.style.left = `${clientX - this.cursorOffsetX + this.fallbackOffsetX}px`
+    this.ghostElement.style.top = `${clientY - this.cursorOffsetY + this.fallbackOffsetY}px`
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -655,10 +655,16 @@ export class Sortable {
       case 'invertedSwapThreshold':
       case 'direction':
       case 'forceFallback':
-      case 'fallbackClass': {
+      case 'fallbackClass':
+      case 'fallbackOnBody':
+      case 'fallbackOffsetX':
+      case 'fallbackOffsetY': {
         // Re-create drag manager with new options. `forceFallback` changes
         // which DOM listeners get registered, so a setter at runtime must
         // tear down and rebuild — there is no in-place reconfigure path.
+        // The remaining fallback options are baked into the ghost on drag
+        // start, so a rebuild is the simplest way to apply them on the next
+        // drag without introducing setters for every field.
         this.dragManager.detach()
         this.dragManager = new DragManager(
           this.dropZone,
@@ -682,6 +688,9 @@ export class Sortable {
             direction: this.options.direction,
             forceFallback: this.options.forceFallback,
             fallbackClass: this.options.fallbackClass,
+            fallbackOnBody: this.options.fallbackOnBody,
+            fallbackOffsetX: this.options.fallbackOffsetX,
+            fallbackOffsetY: this.options.fallbackOffsetY,
             ghostClass: this.options.ghostClass,
             chosenClass: this.options.chosenClass,
             dragClass: this.options.dragClass,
@@ -717,6 +726,9 @@ export class Sortable {
             direction: this.options.direction,
             forceFallback: this.options.forceFallback,
             fallbackClass: this.options.fallbackClass,
+            fallbackOnBody: this.options.fallbackOnBody,
+            fallbackOffsetX: this.options.fallbackOffsetX,
+            fallbackOffsetY: this.options.fallbackOffsetY,
             ghostClass: this.options.ghostClass,
             chosenClass: this.options.chosenClass,
             dragClass: this.options.dragClass,

--- a/tests/e2e/fallback-mode.spec.ts
+++ b/tests/e2e/fallback-mode.spec.ts
@@ -28,11 +28,18 @@ async function center(
   return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
 }
 
+// `.sortable-item` items inside the fallback zone, excluding the ghost
+// (which is a deep-clone of the dragged item — so it also carries the
+// `.sortable-item` class). PR2 changed the default `fallbackOnBody` from
+// implicit-true to false, so the ghost now lives inside the zone and would
+// otherwise show up in item-order queries.
+const FALLBACK_REAL_ITEMS = `${FALLBACK_LIST} .sortable-item:not(.sortable-ghost)`
+
 test.describe('forceFallback (#29 PR1)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/')
     await page.waitForFunction(() => window.resortableLoaded === true)
-    await expect(page.locator(`${FALLBACK_LIST} .sortable-item`)).toHaveCount(4)
+    await expect(page.locator(FALLBACK_REAL_ITEMS)).toHaveCount(4)
   })
 
   test('ghost has both ghostClass and fallbackClass during drag', async ({
@@ -56,9 +63,11 @@ test.describe('forceFallback (#29 PR1)', () => {
     await page.mouse.move(from.x, from.y, { steps: 3 })
     await page.mouse.move(to.x, to.y, { steps: 10 })
 
-    // The ghost is created on drag start and appended to document.body with
-    // both `ghostClass` and `fallbackClass`. Locate it before we release.
-    const ghost = page.locator('body > .sortable-ghost.sortable-fallback')
+    // The ghost is created on drag start and appended to the sortable zone
+    // (PR2 #29: `fallbackOnBody` defaults to false, matching legacy). It
+    // carries both `ghostClass` and `fallbackClass`. Locate the (single)
+    // ghost anywhere on the page before releasing.
+    const ghost = page.locator('.sortable-ghost.sortable-fallback')
     await expect(ghost).toHaveCount(1)
     await expect(ghost).toHaveClass(/sortable-ghost/)
     await expect(ghost).toHaveClass(/sortable-fallback/)
@@ -76,7 +85,7 @@ test.describe('forceFallback (#29 PR1)', () => {
 
     // Sanity check the starting order.
     const initialOrder = await page
-      .locator(`${FALLBACK_LIST} .sortable-item`)
+      .locator(FALLBACK_REAL_ITEMS)
       .evaluateAll((els) => els.map((el) => el.getAttribute('data-id')))
     expect(initialOrder).toEqual(['fb-1', 'fb-2', 'fb-3', 'fb-4'])
 
@@ -102,10 +111,210 @@ test.describe('forceFallback (#29 PR1)', () => {
     // order depends on insert-before vs after semantics, but fb-1 must no
     // longer be at index 0.
     const finalOrder = await page
-      .locator(`${FALLBACK_LIST} .sortable-item`)
+      .locator(FALLBACK_REAL_ITEMS)
       .evaluateAll((els) => els.map((el) => el.getAttribute('data-id')))
     expect(finalOrder[0]).not.toBe('fb-1')
     expect(finalOrder).toContain('fb-1')
     expect(finalOrder).toHaveLength(4)
+  })
+})
+
+/**
+ * Coverage for #29 (PR2) — `fallbackOnBody`, `fallbackOffsetX`,
+ * `fallbackOffsetY`. These options control where the pointer-driven ghost
+ * gets appended and how it is shifted relative to the cursor.
+ *
+ * Fixtures are created on the fly with `page.evaluate` so we don't have to
+ * extend `index.html` with three additional permutations.
+ */
+test.describe('fallback positioning (#29 PR2)', () => {
+  const PR2_LIST = '#pr2-fallback-list'
+  const PR2_ITEM = (id: string): string => `${PR2_LIST} [data-id="${id}"]`
+
+  type FallbackInit = {
+    fallbackOnBody?: boolean
+    fallbackOffsetX?: number
+    fallbackOffsetY?: number
+  }
+
+  // Build a fresh sortable list configured with the supplied fallback
+  // options. Lives at a fixed position (top-left 50,50) so the test can
+  // reason about absolute coordinates without scrolling concerns.
+  async function buildList(page: Page, opts: FallbackInit): Promise<void> {
+    await page.evaluate((opts) => {
+      // Tear down any prior fixture so re-runs are clean.
+      document.getElementById('pr2-fallback-list')?.remove()
+      const container = document.createElement('div')
+      container.id = 'pr2-fallback-list'
+      container.style.position = 'absolute'
+      container.style.top = '50px'
+      container.style.left = '50px'
+      container.style.width = '300px'
+      container.style.background = '#eef'
+      container.innerHTML = `
+        <div class="sortable-item" data-id="pr2-1"
+             style="width:200px;height:40px;background:#ccc;">Item 1</div>
+        <div class="sortable-item" data-id="pr2-2"
+             style="width:200px;height:40px;background:#ddd;">Item 2</div>
+        <div class="sortable-item" data-id="pr2-3"
+             style="width:200px;height:40px;background:#ccc;">Item 3</div>
+      `
+      document.body.appendChild(container)
+
+      interface WindowWithSortable extends Window {
+        Sortable?: typeof import('../../src/index.js').Sortable
+      }
+      const win = window as WindowWithSortable
+      const Sortable = win.Sortable
+      if (!Sortable) throw new Error('Sortable not loaded on window')
+      new Sortable(container, {
+        animation: 0,
+        forceFallback: true,
+        fallbackClass: 'sortable-fallback',
+        fallbackOnBody: opts.fallbackOnBody,
+        fallbackOffsetX: opts.fallbackOffsetX,
+        fallbackOffsetY: opts.fallbackOffsetY,
+      })
+    }, opts)
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForFunction(() => window.resortableLoaded === true)
+  })
+
+  test('fallbackOnBody: false appends ghost as child of sortable zone', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    await buildList(page, { fallbackOnBody: false })
+
+    const from = await center(page, PR2_ITEM('pr2-1'))
+    const to = await center(page, PR2_ITEM('pr2-3'))
+
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(from.x, from.y, { steps: 3 })
+    await page.mouse.move(to.x, to.y, { steps: 8 })
+
+    // Mid-drag the ghost should live inside the zone, not document.body.
+    const ghostParentId = await page
+      .locator('.sortable-ghost.sortable-fallback')
+      .first()
+      .evaluate((el) => el.parentElement?.id ?? '')
+    expect(ghostParentId).toBe('pr2-fallback-list')
+
+    await page.mouse.up()
+  })
+
+  test('fallbackOnBody: true appends ghost to document.body', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    await buildList(page, { fallbackOnBody: true })
+
+    const from = await center(page, PR2_ITEM('pr2-1'))
+    const to = await center(page, PR2_ITEM('pr2-3'))
+
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(from.x, from.y, { steps: 3 })
+    await page.mouse.move(to.x, to.y, { steps: 8 })
+
+    // Ghost should be a direct child of <body>, never inside the zone.
+    const ghost = page.locator('body > .sortable-ghost.sortable-fallback')
+    await expect(ghost).toHaveCount(1)
+
+    await page.mouse.up()
+  })
+
+  test('fallbackOffsetX shifts ghost X position by configured pixels', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    const OFFSET = 40
+    // Use fallbackOnBody:true so the ghost lives at a predictable parent
+    // (document.body); its `left` style is then absolute viewport pixels.
+    await buildList(page, { fallbackOffsetX: OFFSET, fallbackOnBody: true })
+
+    const from = await center(page, PR2_ITEM('pr2-1'))
+    // Capture the original element's rect BEFORE the drag, since the item
+    // can move in the DOM mid-drag and skew any after-the-fact measurement.
+    const origLeft = await page
+      .locator(PR2_ITEM('pr2-1'))
+      .evaluate((el) => el.getBoundingClientRect().left)
+
+    // Drag mostly sideways with a small vertical nudge so we cleanly clear
+    // the dragstart threshold without triggering a vertical reorder.
+    const target = { x: from.x + 80, y: from.y + 5 }
+
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(from.x, from.y, { steps: 3 })
+    await page.mouse.move(target.x, target.y, { steps: 10 })
+
+    // GhostManager formula:
+    //   ghost.left = cursor.x - (startCursor.x - origRect.left) + offsetX
+    //             = target.x - from.x + origRect.left + offsetX
+    const expectedLeft = target.x - from.x + origLeft + OFFSET
+
+    const ghostLeft = await page
+      .locator('body > .sortable-ghost.sortable-fallback')
+      .evaluate((el) => parseFloat((el as HTMLElement).style.left))
+
+    // 2px slack for sub-pixel rounding in the mouse-step pipeline.
+    expect(Math.abs(ghostLeft - expectedLeft)).toBeLessThanOrEqual(2)
+
+    await page.mouse.up()
+  })
+
+  test('fallbackOffsetY shifts ghost Y position by configured pixels', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    const OFFSET = -25 // shift up
+    await buildList(page, { fallbackOffsetY: OFFSET, fallbackOnBody: true })
+
+    const from = await center(page, PR2_ITEM('pr2-1'))
+    const origTop = await page
+      .locator(PR2_ITEM('pr2-1'))
+      .evaluate((el) => el.getBoundingClientRect().top)
+
+    // A small downward drag — enough motion to clear the start threshold,
+    // not enough to reorder past the next item (which would change which
+    // element is "pr2-1" inside the locator).
+    const target = { x: from.x, y: from.y + 15 }
+
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(from.x, from.y, { steps: 3 })
+    await page.mouse.move(target.x, target.y, { steps: 10 })
+
+    // ghost.top = target.y - from.y + origTop + offsetY
+    const expectedTop = target.y - from.y + origTop + OFFSET
+
+    const ghostTop = await page
+      .locator('body > .sortable-ghost.sortable-fallback')
+      .evaluate((el) => parseFloat((el as HTMLElement).style.top))
+
+    expect(Math.abs(ghostTop - expectedTop)).toBeLessThanOrEqual(2)
+
+    await page.mouse.up()
   })
 })

--- a/tests/e2e/plugin-functionality.spec.ts
+++ b/tests/e2e/plugin-functionality.spec.ts
@@ -611,9 +611,13 @@ test.describe('Plugin Functionality E2E', () => {
       // Wait for any animations or visual feedback
       await page.waitForTimeout(100)
 
-      // Check that items are in the DOM (swap should maintain all items)
+      // Check that items are in the DOM (swap should maintain all items).
+      // PR2 #29 changed the default `fallbackOnBody` to false, so the
+      // pointer-driven ghost lives inside the zone during the drag and may
+      // linger briefly through its fade-out transition. Exclude ghost clones
+      // from the count.
       const finalCount = await page
-        .locator('#swap-container .sortable-item')
+        .locator('#swap-container .sortable-item:not(.sortable-ghost)')
         .count()
       expect(finalCount).toBe(4)
 

--- a/tests/e2e/showcase.spec.ts
+++ b/tests/e2e/showcase.spec.ts
@@ -17,7 +17,13 @@ test.describe('Showcase Page Functionality', () => {
     const smoothList = page.locator('#smooth-list')
     await expect(smoothList).toBeVisible()
 
-    const smoothItems = smoothList.locator('.sortable-item')
+    // Exclude the pointer-driven ghost clone from item enumeration. PR2 #29
+    // changed the default `fallbackOnBody` from implicit-true to false, so
+    // mid-drag the ghost lives inside the zone and would otherwise satisfy
+    // `.sortable-item` queries (it is a deep clone of a sortable item).
+    const smoothItems = smoothList.locator(
+      '.sortable-item:not(.sortable-ghost)'
+    )
     await expect(smoothItems).toHaveCount(4)
 
     // Verify items can be dragged
@@ -70,7 +76,9 @@ test.describe('Showcase Page Functionality', () => {
     const basicList = page.locator('#basic-list')
     await expect(basicList).toBeVisible()
 
-    const items = basicList.locator('.sortable-item')
+    // Filter out the in-zone ghost clone — see note in 'visual effects demos
+    // should be draggable' above for the PR2 #29 rationale.
+    const items = basicList.locator('.sortable-item:not(.sortable-ghost)')
     await expect(items).toHaveCount(4)
 
     // Test dragging

--- a/tests/unit/fallback-mode.spec.ts
+++ b/tests/unit/fallback-mode.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { DragManager } from '../../src/core/DragManager'
 import { DropZone } from '../../src/core/DropZone'
 import { EventSystem } from '../../src/core/EventSystem'
+import { GhostManager } from '../../src/core/GhostManager'
 import type { SortableEvents } from '../../src/types/index'
 
 /**
@@ -134,6 +135,110 @@ describe('forceFallback (#29 PR1)', () => {
       expect(removed).toContain('pointerdown')
 
       container.removeEventListener = originalRemove
+    })
+  })
+})
+
+/**
+ * Unit coverage for #29 PR2 — `fallbackOnBody`, `fallbackOffsetX`,
+ * `fallbackOffsetY`. Verifies the options bag is threaded from
+ * {@link GhostManager.createGhost} through to (a) where the ghost is appended
+ * and (b) the inline `left` / `top` set on each `updateGhostPosition` call.
+ */
+describe('fallback options (#29 PR2)', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  function makeTarget(): HTMLElement {
+    const el = document.createElement('div')
+    el.className = 'sortable-item'
+    el.style.position = 'absolute'
+    el.style.left = '0px'
+    el.style.top = '0px'
+    el.style.width = '100px'
+    el.style.height = '50px'
+    document.body.appendChild(el)
+    return el
+  }
+
+  function makePointerEvent(x: number, y: number): PointerEvent {
+    // jsdom supports the PointerEvent constructor in recent versions; if it
+    // doesn't, fall back to MouseEvent (the GhostManager only reads
+    // `clientX` / `clientY`).
+    try {
+      return new PointerEvent('pointerdown', { clientX: x, clientY: y })
+    } catch {
+      return new MouseEvent('pointerdown', {
+        clientX: x,
+        clientY: y,
+      }) as unknown as PointerEvent
+    }
+  }
+
+  describe('appendTo (fallbackOnBody)', () => {
+    it('defaults to document.body when no appendTo is supplied', () => {
+      const gm = new GhostManager()
+      const target = makeTarget()
+      const ghost = gm.createGhost(target, makePointerEvent(10, 10))
+      expect(ghost.parentElement).toBe(document.body)
+      gm.destroy(target)
+    })
+
+    it('appends to the supplied container when appendTo is provided', () => {
+      const gm = new GhostManager()
+      const zone = document.createElement('div')
+      zone.id = 'zone'
+      document.body.appendChild(zone)
+      const target = document.createElement('div')
+      target.className = 'sortable-item'
+      target.style.width = '100px'
+      target.style.height = '50px'
+      zone.appendChild(target)
+
+      const ghost = gm.createGhost(target, makePointerEvent(10, 10), {
+        appendTo: zone,
+      })
+      expect(ghost.parentElement).toBe(zone)
+      gm.destroy(target)
+    })
+  })
+
+  describe('offsetX / offsetY', () => {
+    it('passes through to updateGhostPosition (additive shift)', () => {
+      const gm = new GhostManager()
+      const target = makeTarget()
+      // Cursor starts at (50, 25) — element top-left is (0, 0), so the grab
+      // offset captured by createGhost is (50, 25). With fallback offsets of
+      // (+20, -10), the inline position at the same cursor should be
+      // (50 - 50 + 20, 25 - 25 - 10) = (20, -10).
+      const ghost = gm.createGhost(target, makePointerEvent(50, 25), {
+        offsetX: 20,
+        offsetY: -10,
+      })
+      expect(ghost.style.left).toBe('20px')
+      expect(ghost.style.top).toBe('-10px')
+
+      // Subsequent updates apply the same additive shift on top of the
+      // cursor-relative position.
+      gm.updateGhostPosition(150, 125)
+      expect(ghost.style.left).toBe('120px') // 150 - 50 + 20
+      expect(ghost.style.top).toBe('90px') // 125 - 25 + (-10) = 90
+      gm.destroy(target)
+    })
+
+    it('default offset of zero matches pre-PR2 behaviour', () => {
+      const gm = new GhostManager()
+      const target = makeTarget()
+      const ghost = gm.createGhost(target, makePointerEvent(50, 25))
+      // No offset → ghost top-left tracks the element top-left exactly.
+      expect(ghost.style.left).toBe('0px')
+      expect(ghost.style.top).toBe('0px')
+
+      gm.updateGhostPosition(100, 60)
+      expect(ghost.style.left).toBe('50px')
+      expect(ghost.style.top).toBe('35px')
+      gm.destroy(target)
     })
   })
 })


### PR DESCRIPTION
## Summary

PR 2 of #29 — finishes wiring three of the remaining fallback-system options into the existing pointer drag pipeline:

- **`fallbackOnBody`** (default `false`, legacy parity) — chooses the ghost element's parent. When `false`, the ghost is appended to the sortable zone's root element; when `true`, to `document.body` (the pre-PR2 behaviour).
- **`fallbackOffsetX` / `fallbackOffsetY`** (default `0`) — additive pixel shift applied to the ghost relative to the cursor. Positive values shift right / down, matching legacy `fallbackOffset.x` / `.y` direction (see `_onTouchMove` in `legacy-sortable/src/Sortable.js`).

Interface refactor: `GhostManager.createGhost` (and `createStackedGhost`) promoted from a positional `fallbackClass?: string` parameter to a `CreateGhostOptions` bag carrying `fallbackClass`, `appendTo`, `offsetX`, `offsetY`, and `dataIdAttr`. PR1 anticipated this — see PR #53 notes.

`Sortable.option('fallbackOnBody' | 'fallbackOffsetX' | 'fallbackOffsetY', value)` triggers a clean drag-manager rebuild in both the main and `group` re-create branches, matching the PR1 precedent.

## Acceptance criteria

- [x] `fallbackOnBody: true` keeps current behaviour (ghost appended to `document.body`).
- [x] `fallbackOnBody: false` (default) appends ghost to the sortable zone's root element.
- [x] `fallbackOffsetX`/`fallbackOffsetY` shift the ghost element by the configured pixels relative to the cursor.
- [x] `@ts-expect-error` directives removed from `_fallbackOnBody`, `_fallbackOffsetX`, `_fallbackOffsetY`.
- [x] `Sortable.option(...)` triggers a clean re-create for the 3 new options in both the main and `group` branches.
- [x] `GhostManager.destroyGhost` removes the ghost from wherever it was appended (unchanged — `el.remove()` is parent-agnostic).

## Deviations from the brief

1. **Identity-attribute stripping on the ghost clone (`GhostManager.createGhost`).** The new `fallbackOnBody: false` default exposed a latent regression: a deep-cloned ghost living inside the zone shares `id` and the configured `dataIdAttr` with the original element, breaking DOM queries like `[data-id="…"]` and yielding duplicate-id HTML. PR1 didn't surface this because the ghost lived in `document.body`. The clone now sheds `id`, `dataIdAttr`, `aria-grabbed`, `aria-selected`, `aria-posinset`, `aria-setsize`, and `tabindex` — semantic identity belongs to the real item, not a visual-only `pointer-events: none` clone. The brief framed "out of scope" as "any refactor beyond the createGhost signature" — this is arguably regression-fix rather than refactor, but flagging it explicitly.

2. **Surgical test fixes in 3 unrelated files** to filter the in-zone ghost out of `.sortable-item` enumerations:
   - `tests/e2e/showcase.spec.ts` (2 tests)
   - `tests/e2e/plugin-functionality.spec.ts` (1 test)
   - `tests/e2e/fallback-mode.spec.ts` (the PR1 tests — the existing `FALLBACK_LIST .sortable-item` count went from 4 → 5 mid-drag because the ghost is a `.sortable-item` clone)

   All use the same `:not(.sortable-ghost)` filter. Stripping `data-id` (deviation 1 above) doesn't help here because the ghost still carries the `.sortable-item` class — that class is the user's `draggable` selector and we can't strip it without breaking everything downstream. Legacy Sortable removes the configured `ghostClass` from the fallback ghost, but that's a more invasive divergence I'm deferring.

## What's NOT in this PR

- **`fallbackTolerance`** — PR3 (#29). Keeps its `@ts-expect-error` here. That option is a meatier change requiring a pre-commit sub-state in the pointer drag pipeline.
- **PR4** — final fallback cleanup pass.
- **Stripping the `sortable-ghost` / `sortable-item` class duality** — out of scope; would be a larger refactor of the ghost lifecycle alongside legacy's `ghostClass`-toggle approach. The `:not(.sortable-ghost)` test pattern is a reasonable bridge.

## Test plan

- [x] `npm run check` (lint + type-check) — passes with 0 errors (32 pre-existing warnings unchanged).
- [x] `npm run test:unit` — 203 passed / 2 skipped (was 199 / 2; +4 new fallback-mode unit tests).
- [x] `npx playwright test --project=chromium fallback-mode.spec.ts` — 6 passed (was 2; +4 new PR2 tests covering both axes of `fallbackOnBody` and `fallbackOffsetX` / `fallbackOffsetY`).
- [x] `CI=1 npx playwright test --project=chromium` — 126 passed / 46 skipped (was 122 / 46).
- [x] `npm run build && npm run size` — all targets under budget.

## Bundle delta vs PR1

| Bundle | After PR1 | After PR2 | Delta |
| --- | --- | --- | --- |
| ESM (gzip) | 19.11 kB | 19.34 kB | +0.23 kB |
| CJS (gzip) | 11.07 kB | 11.25 kB | +0.18 kB |
| UMD (gzip) | 11.15 kB | 11.33 kB | +0.18 kB |

ESM headroom against the 20 kB budget: 0.66 kB. Tight but holding. PR3 (`fallbackTolerance`) is the next thing to watch.

Refs #29, #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)