### PR TITLE
feat: wire fallbackTolerance pre-commit threshold (#29)

### DIFF
--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -23,6 +23,10 @@ export class DragManager implements DragManagerInterface {
   private startIndex = -1
   private isPointerDragging = false
   private activePointerId: number | null = null
+  // Pre-commit capture phase target — non-null while pointer is captured but
+  // the drag has NOT yet committed (gated by `fallbackTolerance`). Distinct
+  // from `dragElement`, which only becomes non-null at commit. PR3 #29.
+  private pointerCaptureTarget: HTMLElement | null = null
   private dragElement: HTMLElement | null = null
   private draggedItems: HTMLElement[] = []
   private _selectionManager: SelectionManager
@@ -58,8 +62,16 @@ export class DragManager implements DragManagerInterface {
   // `true` → `document.body` (legacy `fallbackOnBody: true`); `false`
   // (default) → the sortable zone's root element. See PR2 #29.
   private _fallbackOnBody: boolean
-  // @ts-expect-error - Will be implemented in fallback system
-
+  // `_fallbackTolerance` is the minimum Chebyshev pixel distance the pointer
+  // must move from pointerdown before the drag actually *commits* — a ghost
+  // is created, `choose` / `start` events fire, and `globalDragState`
+  // registers an active drag. Below the threshold the pointer is *captured*
+  // but no drag side-effects occur (cf. legacy `Sortable.js:826-831`).
+  // Default `0` — drag commits immediately, identical to pre-PR3 behaviour.
+  // Distinct from `touchStartThreshold`, which *cancels* a delayed-drag if
+  // the pointer moves before the hold timer fires (drag-prevention guard).
+  // Ordering with `delay`: pointerdown → delay timer → capture phase →
+  // (distance reached) → commit phase. See PR3 #29.
   private _fallbackTolerance: number
   // `_fallbackOffsetX` / `_fallbackOffsetY` shift the ghost by a fixed pixel
   // offset relative to the cursor. Positive values move it right / down;
@@ -271,6 +283,8 @@ export class DragManager implements DragManagerInterface {
     // Cancel any pending drag delay
     this.cancelDragDelay()
     document.removeEventListener('pointermove', this.onPointerMoveBeforeDrag)
+    // Tear down any in-flight fallback-tolerance capture phase (PR3 #29)
+    if (this.pointerCaptureTarget) this.teardownCapturePhase()
 
     // Detach accessibility features
     if (this.enableAccessibility) {
@@ -790,11 +804,85 @@ export class DragManager implements DragManagerInterface {
     }
   }
 
+  /**
+   * Entry point after pointerdown (and after any `delay` timer). When
+   * `fallbackTolerance > 0` the drag enters a *capture* phase first: the
+   * pointer is captured, but no ghost / events / global state — the drag
+   * only *commits* once the pointer travels at least `fallbackTolerance`
+   * pixels (Chebyshev) from the pointerdown position (legacy
+   * `Sortable.js:826-831`). With tolerance `0` (default) commit is
+   * immediate — behaviour unchanged from pre-PR3.
+   */
   private startPointerDrag(e: PointerEvent, target: HTMLElement): void {
-    // Clear any delay timer
+    // Clear any delay timer / pre-drag listener — we're past that window.
     this.cancelDragDelay()
     document.removeEventListener('pointermove', this.onPointerMoveBeforeDrag)
 
+    if (this._fallbackTolerance <= 0) {
+      this.commitPointerDrag(e, target)
+      return
+    }
+    // Capture phase: pointer held, drag NOT yet committed. setPointerCapture
+    // pins subsequent events to `target` and suppresses default touch panning
+    // on iOS during the tolerance gap. Firefox throws on synthetic events.
+    this.pointerCaptureTarget = target
+    this.activePointerId = e.pointerId
+    this.dragStartPosition = { x: e.clientX, y: e.clientY }
+    try {
+      target.setPointerCapture(e.pointerId)
+    } catch {
+      /* synthetic events in Firefox */
+    }
+    document.addEventListener('pointermove', this.onPointerMoveCapture)
+    document.addEventListener('pointerup', this.onPointerUpCapture)
+    document.addEventListener('pointercancel', this.onPointerUpCapture)
+  }
+
+  private onPointerMoveCapture = (e: PointerEvent): void => {
+    const origin = this.dragStartPosition
+    const target = this.pointerCaptureTarget
+    if (!origin || !target || e.pointerId !== this.activePointerId) return
+    // Chebyshev distance — matches legacy `Math.max(|dx|, |dy|) < tolerance`
+    // at Sortable.js:827.
+    if (
+      Math.max(Math.abs(e.clientX - origin.x), Math.abs(e.clientY - origin.y)) <
+      this._fallbackTolerance
+    )
+      return
+    this.teardownCapturePhase()
+    this.commitPointerDrag(e, target)
+  }
+
+  // Pointer released (or cancelled) BEFORE the tolerance threshold — treat
+  // as a click, not a drag. No `choose` / `start` / `end` events fired;
+  // no DOM changes; just tear the capture state down.
+  private onPointerUpCapture = (e: PointerEvent): void => {
+    if (e.pointerId === this.activePointerId) this.teardownCapturePhase()
+  }
+
+  private teardownCapturePhase(): void {
+    const t = this.pointerCaptureTarget
+    if (t && this.activePointerId !== null) {
+      try {
+        t.releasePointerCapture(this.activePointerId)
+      } catch {
+        /* already released */
+      }
+    }
+    document.removeEventListener('pointermove', this.onPointerMoveCapture)
+    document.removeEventListener('pointerup', this.onPointerUpCapture)
+    document.removeEventListener('pointercancel', this.onPointerUpCapture)
+    this.pointerCaptureTarget = null
+    this.activePointerId = null
+    this.dragStartPosition = undefined
+  }
+
+  /**
+   * Commit phase — the actual drag start. Creates the ghost, fires events,
+   * registers with `globalDragState`. Reachable directly (tolerance 0) or
+   * via {@link onPointerMoveCapture} after the tolerance threshold is met.
+   */
+  private commitPointerDrag(e: PointerEvent, target: HTMLElement): void {
     // Prevent text selection during drag (especially needed on iOS Safari)
     window.getSelection()?.removeAllRanges()
     this.savedBodyUserSelect = document.body.style.userSelect

--- a/src/index.ts
+++ b/src/index.ts
@@ -657,6 +657,7 @@ export class Sortable {
       case 'forceFallback':
       case 'fallbackClass':
       case 'fallbackOnBody':
+      case 'fallbackTolerance':
       case 'fallbackOffsetX':
       case 'fallbackOffsetY': {
         // Re-create drag manager with new options. `forceFallback` changes
@@ -689,6 +690,7 @@ export class Sortable {
             forceFallback: this.options.forceFallback,
             fallbackClass: this.options.fallbackClass,
             fallbackOnBody: this.options.fallbackOnBody,
+            fallbackTolerance: this.options.fallbackTolerance,
             fallbackOffsetX: this.options.fallbackOffsetX,
             fallbackOffsetY: this.options.fallbackOffsetY,
             ghostClass: this.options.ghostClass,
@@ -727,6 +729,7 @@ export class Sortable {
             forceFallback: this.options.forceFallback,
             fallbackClass: this.options.fallbackClass,
             fallbackOnBody: this.options.fallbackOnBody,
+            fallbackTolerance: this.options.fallbackTolerance,
             fallbackOffsetX: this.options.fallbackOffsetX,
             fallbackOffsetY: this.options.fallbackOffsetY,
             ghostClass: this.options.ghostClass,

--- a/tests/e2e/fallback-mode.spec.ts
+++ b/tests/e2e/fallback-mode.spec.ts
@@ -318,3 +318,167 @@ test.describe('fallback positioning (#29 PR2)', () => {
     await page.mouse.up()
   })
 })
+
+/**
+ * Coverage for #29 (PR3) — `fallbackTolerance`. The pointer must travel at
+ * least N pixels (Chebyshev distance, matching legacy semantics) from
+ * pointerdown before the drag commits. Below the threshold no ghost is
+ * created, no `choose`/`start` event fires, no DOM order changes. Above the
+ * threshold the drag commits and behaves identically to the no-tolerance
+ * path.
+ *
+ * As with PR2, fixtures are built on the fly via `page.evaluate` so this
+ * file stays self-contained and the demo `index.html` is not perturbed.
+ */
+test.describe('fallbackTolerance (#29 PR3)', () => {
+  const PR3_LIST = '#pr3-fallback-list'
+  const PR3_ITEM = (id: string): string => `${PR3_LIST} [data-id="${id}"]`
+  const PR3_ITEMS = `${PR3_LIST} .sortable-item:not(.sortable-ghost)`
+
+  async function buildList(
+    page: Page,
+    opts: { fallbackTolerance?: number } = {}
+  ): Promise<void> {
+    await page.evaluate((opts) => {
+      document.getElementById('pr3-fallback-list')?.remove()
+      const container = document.createElement('div')
+      container.id = 'pr3-fallback-list'
+      container.style.position = 'absolute'
+      container.style.top = '50px'
+      container.style.left = '50px'
+      container.style.width = '300px'
+      container.style.background = '#efe'
+      container.innerHTML = `
+        <div class="sortable-item" data-id="pr3-1"
+             style="width:200px;height:40px;background:#cdc;">Item 1</div>
+        <div class="sortable-item" data-id="pr3-2"
+             style="width:200px;height:40px;background:#dcd;">Item 2</div>
+        <div class="sortable-item" data-id="pr3-3"
+             style="width:200px;height:40px;background:#cdc;">Item 3</div>
+        <div class="sortable-item" data-id="pr3-4"
+             style="width:200px;height:40px;background:#dcd;">Item 4</div>
+      `
+      document.body.appendChild(container)
+
+      // Instrument: capture any drag-lifecycle event so tests can assert
+      // that no commit-phase side-effects occurred during a sub-tolerance
+      // press-and-release.
+      interface WindowWithEvents extends Window {
+        __pr3Events?: string[]
+        Sortable?: typeof import('../../src/index.js').Sortable
+      }
+      const win = window as WindowWithEvents
+      win.__pr3Events = []
+      const push = (name: string) => (): void => {
+        win.__pr3Events?.push(name)
+      }
+      const Sortable = win.Sortable
+      if (!Sortable) throw new Error('Sortable not loaded on window')
+      new Sortable(container, {
+        animation: 0,
+        forceFallback: true,
+        fallbackClass: 'sortable-fallback',
+        fallbackTolerance: opts.fallbackTolerance,
+        onChoose: push('choose'),
+        onStart: push('start'),
+        onEnd: push('end'),
+      })
+    }, opts)
+  }
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+    await page.waitForFunction(() => window.resortableLoaded === true)
+  })
+
+  test('small pointer move does not start drag', async ({ page }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    await buildList(page, { fallbackTolerance: 10 })
+
+    const initial = await page
+      .locator(PR3_ITEMS)
+      .evaluateAll((els) => els.map((el) => el.getAttribute('data-id')))
+
+    const from = await center(page, PR3_ITEM('pr3-1'))
+    // Move 3px — well below 10px tolerance. The drag must NOT commit.
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(from.x + 3, from.y, { steps: 3 })
+
+    // No ghost, no class, no order change while still under threshold.
+    await expect(page.locator('.sortable-ghost')).toHaveCount(0)
+    await expect(page.locator('.sortable-fallback')).toHaveCount(0)
+    const stillOrder = await page
+      .locator(PR3_ITEMS)
+      .evaluateAll((els) => els.map((el) => el.getAttribute('data-id')))
+    expect(stillOrder).toEqual(initial)
+
+    await page.mouse.up()
+  })
+
+  test('movement past threshold starts drag normally', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    await buildList(page, { fallbackTolerance: 10 })
+
+    const from = await center(page, PR3_ITEM('pr3-1'))
+    const to = await center(page, PR3_ITEM('pr3-4'))
+
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    // First an intermediate move that crosses the 10px threshold (15px).
+    await page.mouse.move(from.x + 15, from.y, { steps: 4 })
+
+    // Drag committed: ghost present, fallback class on it.
+    const ghost = page.locator('.sortable-ghost.sortable-fallback')
+    await expect(ghost).toHaveCount(1)
+
+    // Complete the drag — reorder should succeed normally.
+    await page.mouse.move(to.x, to.y, { steps: 10 })
+    await page.mouse.up()
+
+    const finalOrder = await page
+      .locator(PR3_ITEMS)
+      .evaluateAll((els) => els.map((el) => el.getAttribute('data-id')))
+    expect(finalOrder[0]).not.toBe('pr3-1')
+    expect(finalOrder).toContain('pr3-1')
+    expect(finalOrder).toHaveLength(4)
+  })
+
+  test('pointerup during capture phase fires no drag events', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    await buildList(page, { fallbackTolerance: 10 })
+
+    const from = await center(page, PR3_ITEM('pr3-1'))
+
+    // Press, nudge 2px (below threshold), release — a click, not a drag.
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(from.x + 2, from.y, { steps: 2 })
+    await page.mouse.up()
+
+    // No drag-lifecycle event should have fired.
+    const events = await page.evaluate(() =>
+      (window as unknown as { __pr3Events: string[] }).__pr3Events.slice()
+    )
+    expect(events).toEqual([])
+
+    // And no ghost lingers.
+    await expect(page.locator('.sortable-ghost')).toHaveCount(0)
+  })
+})

--- a/tests/unit/fallback-mode.spec.ts
+++ b/tests/unit/fallback-mode.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { DragManager } from '../../src/core/DragManager'
 import { DropZone } from '../../src/core/DropZone'
 import { EventSystem } from '../../src/core/EventSystem'
@@ -240,5 +240,181 @@ describe('fallback options (#29 PR2)', () => {
       expect(ghost.style.top).toBe('35px')
       gm.destroy(target)
     })
+  })
+})
+
+/**
+ * Unit coverage for #29 PR3 — `fallbackTolerance`. Verifies the
+ * capture-phase / commit-phase state-machine boundary:
+ *
+ *   pointerdown → (delay timer) → CAPTURE PHASE
+ *      ├─ pointermove < tolerance → stay in capture (no events, no ghost)
+ *      ├─ pointermove ≥ tolerance → COMMIT (choose, start, ghost, ...)
+ *      └─ pointerup before threshold → click; tear down, no events.
+ *
+ * With tolerance `0` (default) the capture phase is skipped entirely and
+ * pointerdown commits immediately — observable from `DragManager.isDragging`.
+ */
+describe('fallbackTolerance state machine (#29 PR3)', () => {
+  function makeContainer(): HTMLElement {
+    document.body.innerHTML = ''
+    const container = document.createElement('div')
+    for (let i = 1; i <= 3; i++) {
+      const el = document.createElement('div')
+      el.className = 'sortable-item'
+      el.dataset.id = `${i}`
+      // Lay items out so getBoundingClientRect returns non-zero rects in jsdom.
+      el.style.width = '100px'
+      el.style.height = '40px'
+      container.appendChild(el)
+    }
+    document.body.appendChild(container)
+    return container
+  }
+
+  function makePointer(
+    type: 'pointerdown' | 'pointermove' | 'pointerup',
+    x: number,
+    y: number,
+    pointerId = 1
+  ): PointerEvent {
+    try {
+      return new PointerEvent(type, {
+        clientX: x,
+        clientY: y,
+        pointerId,
+        button: 0,
+        isPrimary: true,
+        bubbles: true,
+        cancelable: true,
+      })
+    } catch {
+      const ev = new MouseEvent(type, {
+        clientX: x,
+        clientY: y,
+        button: 0,
+        bubbles: true,
+        cancelable: true,
+      }) as unknown as PointerEvent & { pointerId: number; isPrimary: boolean }
+      ;(ev as unknown as { pointerId: number }).pointerId = pointerId
+      ;(ev as unknown as { isPrimary: boolean }).isPrimary = true
+      return ev
+    }
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('tolerance 0: drag commits immediately on pointerdown', () => {
+    const container = makeContainer()
+    const target = container.firstElementChild as HTMLElement
+    const zone = new DropZone(container)
+    const events = new EventSystem<SortableEvents>()
+    const dm = new DragManager(zone, events, undefined, {
+      delayOnTouchOnly: 0,
+      fallbackTolerance: 0,
+    })
+    dm.attach()
+
+    const chooseSpy = vi.fn()
+    events.on('choose', chooseSpy)
+
+    target.dispatchEvent(makePointer('pointerdown', 50, 20))
+
+    expect(dm.isDragging).toBe(true)
+    expect(chooseSpy).toHaveBeenCalledTimes(1)
+
+    // Release so dm.detach() doesn't dangle global listeners across tests.
+    document.dispatchEvent(makePointer('pointerup', 50, 20))
+    dm.detach()
+  })
+
+  it('tolerance > 0: pointermove below threshold does not commit', () => {
+    const container = makeContainer()
+    const target = container.firstElementChild as HTMLElement
+    const zone = new DropZone(container)
+    const events = new EventSystem<SortableEvents>()
+    const dm = new DragManager(zone, events, undefined, {
+      delayOnTouchOnly: 0,
+      fallbackTolerance: 10,
+    })
+    dm.attach()
+
+    const chooseSpy = vi.fn()
+    const startSpy = vi.fn()
+    events.on('choose', chooseSpy)
+    events.on('start', startSpy)
+
+    target.dispatchEvent(makePointer('pointerdown', 50, 20))
+    // 4px move — below 10px Chebyshev threshold.
+    document.dispatchEvent(makePointer('pointermove', 54, 20))
+    document.dispatchEvent(makePointer('pointermove', 50, 24))
+
+    expect(dm.isDragging).toBe(false)
+    expect(chooseSpy).not.toHaveBeenCalled()
+    expect(startSpy).not.toHaveBeenCalled()
+
+    document.dispatchEvent(makePointer('pointerup', 50, 24))
+    dm.detach()
+  })
+
+  it('tolerance > 0: pointermove crossing threshold commits drag', () => {
+    const container = makeContainer()
+    const target = container.firstElementChild as HTMLElement
+    const zone = new DropZone(container)
+    const events = new EventSystem<SortableEvents>()
+    const dm = new DragManager(zone, events, undefined, {
+      delayOnTouchOnly: 0,
+      fallbackTolerance: 10,
+    })
+    dm.attach()
+
+    const chooseSpy = vi.fn()
+    const startSpy = vi.fn()
+    events.on('choose', chooseSpy)
+    events.on('start', startSpy)
+
+    target.dispatchEvent(makePointer('pointerdown', 50, 20))
+    // Still below threshold — no commit yet.
+    document.dispatchEvent(makePointer('pointermove', 55, 20))
+    expect(dm.isDragging).toBe(false)
+    // Crosses 10px — commits.
+    document.dispatchEvent(makePointer('pointermove', 62, 20))
+    expect(dm.isDragging).toBe(true)
+    expect(chooseSpy).toHaveBeenCalledTimes(1)
+    expect(startSpy).toHaveBeenCalledTimes(1)
+
+    document.dispatchEvent(makePointer('pointerup', 62, 20))
+    dm.detach()
+  })
+
+  it('tolerance > 0: pointerup before threshold fires no drag events', () => {
+    const container = makeContainer()
+    const target = container.firstElementChild as HTMLElement
+    const zone = new DropZone(container)
+    const events = new EventSystem<SortableEvents>()
+    const dm = new DragManager(zone, events, undefined, {
+      delayOnTouchOnly: 0,
+      fallbackTolerance: 10,
+    })
+    dm.attach()
+
+    const chooseSpy = vi.fn()
+    const startSpy = vi.fn()
+    const endSpy = vi.fn()
+    events.on('choose', chooseSpy)
+    events.on('start', startSpy)
+    events.on('end', endSpy)
+
+    target.dispatchEvent(makePointer('pointerdown', 50, 20))
+    document.dispatchEvent(makePointer('pointermove', 53, 21))
+    document.dispatchEvent(makePointer('pointerup', 53, 21))
+
+    expect(dm.isDragging).toBe(false)
+    expect(chooseSpy).not.toHaveBeenCalled()
+    expect(startSpy).not.toHaveBeenCalled()
+    expect(endSpy).not.toHaveBeenCalled()
+    dm.detach()
   })
 })


### PR DESCRIPTION
## Summary

PR 3 of #29 — wires `fallbackTolerance`, the pointer-movement gate that decides whether a press becomes a drag. Below the threshold the pointer is captured but no ghost, no events, no `globalDragState` registration; above it the drag commits identically to the no-tolerance path. Default `0` preserves current behaviour exactly.

Implementation splits the pointer pipeline into **capture** and **commit** phases (matches legacy `Sortable.js:826-831`):

- `startPointerDrag` decides: tolerance 0 → call `commitPointerDrag` directly (no behaviour change); tolerance > 0 → enter capture phase (record origin, `setPointerCapture`, install scoped move/up listeners).
- `onPointerMoveCapture` runs Chebyshev distance check (`Math.max(|dx|, |dy|) >= tolerance`) and escalates to commit.
- `onPointerUpCapture` cleanly tears down the capture state when the pointer releases below threshold — a click, not a drag.
- `setPointerCapture` during the tolerance gap also suppresses iOS pan-scroll, preserving the touch path.

Ordering chain unchanged elsewhere: `pointerdown → (delay timer) → capture phase → (distance reached) → commit phase`. `touchStartThreshold` still cancels delayed drags before the tolerance window opens.

## What's NOT in this PR

PR 4 (final cleanup of remaining `@ts-expect-error` stubs — `_dataIdAttr` and `_removeCloneOnHide`, both out-of-scope for the fallback system). This PR removes the last fallback-system `@ts-expect-error`.

## Bundle strategy

**Strategy A (trim while implementing).** Net growth landed inside existing budgets:

| | Baseline (pre-PR3) | This PR | Limit | Headroom |
|---|---|---|---|---|
| ESM (gzip) | 19.51 kB | **19.95 kB** | 20 kB | 0.05 kB |
| CJS (gzip) | 11.33 kB | **11.47 kB** | 12 kB | 0.53 kB |
| UMD (gzip) | 11.40 kB | **11.54 kB** | 12 kB | 0.46 kB |

ESM net growth ~0.44 kB. No budget raise needed; budgets remain at 20/12/12 kB. Headroom for PR 4 + post-2.0 plugins is tight on ESM (~50 bytes); if PR 4 needs significant new code we may need to revisit, but it's described as cleanup-only.

## Acceptance criteria

- [x] `fallbackTolerance: 10` — a 5px (and 3px) pointer move does NOT create a ghost, fire `start`, or modify the DOM.
- [x] `fallbackTolerance: 10` — an 11px (15px tested) pointer move commits the drag normally.
- [x] `fallbackTolerance: 0` (default) — drag commits immediately, no observable behaviour change.
- [x] Pointerup during capture-but-not-committed phase fires no drag events and leaves DOM clean.
- [x] `touchStartThreshold` and `delay` continue to function with tolerance enabled; ordering is correct.
- [x] `@ts-expect-error` removed from `_fallbackTolerance` (final fallback-system stub gone).
- [x] `Sortable.option('fallbackTolerance', value)` re-creates the DragManager — added to both rebuild branches in `src/index.ts`.
- [x] Bundle strategy stated above; no budget raise needed.

## Test plan

- [x] `npm run check` — 0 errors (32 warnings, all pre-existing).
- [x] `npm run test:unit` — **207 passing** (was 203, +4 new state-machine boundary tests).
- [x] `npx playwright test --project=chromium fallback-mode.spec.ts` — **9/9 passing** (3 new PR3 e2e).
- [x] `CI=1 npx playwright test --project=chromium` — **127 passing**, 46 skipped. Two flaky tests (`ghost-elements.spec.ts:153` and `independent-groups.spec.ts:27`) pre-date this PR and both pass on retry; neither touches the fallback path.
- [x] `npm run build && npm run size` — all three artifacts under budget (see table above).

New tests, e2e (`tests/e2e/fallback-mode.spec.ts`):
- `fallbackTolerance: small pointer move does not start drag`
- `fallbackTolerance: movement past threshold starts drag normally`
- `fallbackTolerance: pointerup during capture phase fires no drag events` (instruments `__pr3Events` to assert no `choose`/`start`/`end` fired).

New tests, unit (`tests/unit/fallback-mode.spec.ts`):
- `tolerance 0: drag commits immediately on pointerdown`
- `tolerance > 0: pointermove below threshold does not commit`
- `tolerance > 0: pointermove crossing threshold commits drag`
- `tolerance > 0: pointerup before threshold fires no drag events`

Refs #29, #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)