### PR TITLE
chore: raise bundle-size budgets to smoke-test ranges

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,21 +53,21 @@
     {
       "name": "ESM (gzip)",
       "path": "dist/sortable.es.js",
-      "limit": "20 kB",
+      "limit": "50 kB",
       "gzip": true,
       "brotli": false
     },
     {
       "name": "CJS (gzip)",
       "path": "dist/sortable.cjs.js",
-      "limit": "12 kB",
+      "limit": "30 kB",
       "gzip": true,
       "brotli": false
     },
     {
       "name": "UMD (gzip)",
       "path": "dist/sortable.umd.js",
-      "limit": "12 kB",
+      "limit": "30 kB",
       "gzip": true,
       "brotli": false
     }


### PR DESCRIPTION
## Summary

Raise the \`size-limit\` budgets from tight (~5% headroom) to generous (~60-80% headroom) so they act as a catastrophic-regression smoke test rather than a per-feature gatekeeper.

| Format | Old | New | Current usage |
|---|---|---|---|
| ESM (gzip) | 20 kB | **50 kB** | 19.95 kB (40%) |
| CJS (gzip) | 12 kB | **30 kB** | 11.47 kB (38%) |
| UMD (gzip) | 12 kB | **30 kB** | 11.54 kB (38%) |

## Why

#39 introduced the budget at the size at-the-time, which was great as a regression-detection signal but proved tight in practice — PR 3 of #29 landed with 0.05 kB ESM headroom. Bundle size isn't a near-term release goal; better to remove the per-feature friction and tighten later when there's an explicit budget target.

## Test plan

- [ ] \`bundle-size\` CI job passes (now with generous headroom)
- [ ] All other CI jobs unaffected

Refs #39
Refs #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)