### PR TITLE
fix: deselect prior item in single-select mode (#46)

### DIFF
--- a/src/core/KeyboardManager.ts
+++ b/src/core/KeyboardManager.ts
@@ -175,8 +175,13 @@ export class KeyboardManager {
                 this.selectionManager.selectRange(lastSelected, focused)
               }
             } else {
-              // Toggle selection (add/remove from selection)
-              this.selectionManager.toggle(focused)
+              // Toggle selection. In multi-select mode (multiDrag), the
+              // toggle is additive so prior selections stay. In single-
+              // select mode (default), pass additive=false so selecting a
+              // new item replaces the prior selection — both
+              // `aria-selected` and the selected class are cleared on the
+              // previously-selected items.
+              this.selectionManager.toggle(focused, this.multiDrag)
             }
           }
         }
@@ -259,12 +264,14 @@ export class KeyboardManager {
         this.selectionManager.selectRange(lastSelected, target)
       }
     } else if (e.ctrlKey || e.metaKey) {
-      // Toggle selection (modifier key always toggles)
+      // Ctrl/Cmd+Click is the canonical "extend selection" modifier;
+      // toggle additively so existing selections stay.
       e.preventDefault()
-      this.selectionManager.toggle(target)
+      this.selectionManager.toggle(target, true)
     } else if (this.multiDrag) {
       // When multiDrag is enabled, plain click toggles selection
-      this.selectionManager.toggle(target)
+      // additively.
+      this.selectionManager.toggle(target, true)
     } else {
       // Single selection (unless clicking on already selected item)
       if (!this.selectionManager.isSelected(target)) {

--- a/src/core/SelectionManager.ts
+++ b/src/core/SelectionManager.ts
@@ -19,13 +19,14 @@ export class SelectionManager implements SelectionManagerInterface {
     options?: {
       selectedClass?: string
       focusClass?: string
-      multiSelect?: boolean // TODO: Use in Phase 2.4 for multi-select logic
+      // multiSelect mode is enforced by call sites via the `additive`
+      // argument on select()/toggle(), so SelectionManager does not need
+      // to retain the flag itself.
+      multiSelect?: boolean
     }
   ) {
     this.selectedClass = options?.selectedClass || 'sortable-selected'
     this.focusClass = options?.focusClass || 'sortable-focused'
-    // TODO: Implement multiSelect logic in Phase 2.4
-    // this.multiSelect = options?.multiSelect || false
   }
 
   /**
@@ -55,14 +56,19 @@ export class SelectionManager implements SelectionManagerInterface {
 
   /**
    * Toggle selection of an item
+   *
+   * If the item is selected, it is deselected. Otherwise the item is
+   * selected; pass `additive = true` to keep the existing selection
+   * (multi-select behaviour) or leave it `false` to replace any current
+   * selection with just this item (single-select behaviour).
    */
-  public toggle(item: HTMLElement): void {
+  public toggle(item: HTMLElement, additive = false): void {
     if (!this.isValidItem(item)) return
 
     if (this.selectedItems.has(item)) {
       this.deselect(item)
     } else {
-      this.select(item, true)
+      this.select(item, additive)
     }
   }
 

--- a/tests/e2e/keyboard-navigation.spec.ts
+++ b/tests/e2e/keyboard-navigation.spec.ts
@@ -65,8 +65,7 @@ test.describe('Keyboard Navigation', () => {
     await expect(firstItem).toBeFocused()
   })
 
-  // Skipped pending #46 — single-select mode does not deselect prior item.
-  test.skip('selects items with Space key', async ({ page }) => {
+  test('selects items with Space key', async ({ page }) => {
     const container = page.locator('#basic-list')
     const firstItem = page.locator('#basic-list [data-id="basic-1"]')
     const secondItem = page.locator('#basic-list [data-id="basic-2"]')

--- a/tests/unit/selection-manager.test.ts
+++ b/tests/unit/selection-manager.test.ts
@@ -61,6 +61,34 @@ describe('SelectionManager', () => {
       expect(selectionManager.getSelected()).toHaveLength(0)
       expect(items[0].getAttribute('aria-selected')).toBe('false')
     })
+
+    it('should deselect prior item when toggling a new item in single-select mode', () => {
+      // Simulates the keyboard Space-key flow: toggle item 0, then toggle item 1.
+      // In single-select mode (default), only the most recent should remain selected.
+      selectionManager.toggle(items[0])
+      expect(selectionManager.isSelected(items[0])).toBe(true)
+      expect(items[0].getAttribute('aria-selected')).toBe('true')
+      expect(items[0].classList.contains('sortable-selected')).toBe(true)
+
+      selectionManager.toggle(items[1])
+
+      expect(selectionManager.getSelected()).toHaveLength(1)
+      expect(selectionManager.isSelected(items[1])).toBe(true)
+      expect(selectionManager.isSelected(items[0])).toBe(false)
+      expect(items[0].getAttribute('aria-selected')).toBe('false')
+      expect(items[0].classList.contains('sortable-selected')).toBe(false)
+      expect(items[1].getAttribute('aria-selected')).toBe('true')
+      expect(items[1].classList.contains('sortable-selected')).toBe(true)
+    })
+
+    it('should deselect currently-selected item when toggled again in single-select mode', () => {
+      selectionManager.toggle(items[0])
+      selectionManager.toggle(items[0])
+
+      expect(selectionManager.getSelected()).toHaveLength(0)
+      expect(items[0].getAttribute('aria-selected')).toBe('false')
+      expect(items[0].classList.contains('sortable-selected')).toBe(false)
+    })
   })
 
   describe('Multi-Selection', () => {
@@ -86,6 +114,17 @@ describe('SelectionManager', () => {
 
       selectionManager.toggle(items[0])
       expect(selectionManager.getSelected()).not.toContain(items[0])
+    })
+
+    it('should keep prior selection when toggling additively in multi-select mode', () => {
+      // Multi-select call sites (Ctrl/Cmd+Click, Space when multiDrag is on)
+      // pass additive=true so prior selections survive.
+      selectionManager.toggle(items[0], true)
+      selectionManager.toggle(items[2], true)
+
+      expect(selectionManager.getSelected()).toContain(items[0])
+      expect(selectionManager.getSelected()).toContain(items[2])
+      expect(selectionManager.getSelected()).toHaveLength(2)
     })
 
     it('should select range of items', () => {


### PR DESCRIPTION
## Summary

Selecting an item with the Space key in single-select mode left the previously-selected item showing `aria-selected="true"` and the `sortable-selected` class. This fix routes the Space-key toggle through an additive-aware path so single-select mode atomically clears the prior selection while multi-select mode keeps the existing additive behaviour.

## Root cause

`KeyboardManager`'s Space handler called `SelectionManager.toggle(item)`, and `toggle()` always delegated to `select(item, /* additive */ true)` for newly-selected items. That bypassed `select()`'s existing single-select clear path. The fix adds an `additive` parameter to `toggle()` so the Space handler can pass `this.multiDrag` (defaults to `false`), routing single-select toggles through the non-additive `select()` branch — which already clears prior selections and resets ARIA + class state atomically.

## Acceptance criteria

- [x] In single-select mode (default), selecting any item via Space, click, or arrow+space deselects all others atomically (`aria-selected="true"` and `sortable-selected` class on only the newly-selected item; both removed from previously-selected items).
- [x] In multi-select mode (`multiDrag: true`), behaviour unchanged — multiple items can be selected simultaneously.
- [x] `tests/e2e/keyboard-navigation.spec.ts:68` (`selects items with Space key`) un-skipped and passing.
- [x] New unit tests in `tests/unit/selection-manager.test.ts` cover the deselect-on-toggle transition (single-select) and the additive-toggle behaviour (multi-select).
- [x] No regressions: full chromium E2E suite still green, full unit suite still green.

## Approach

1. `SelectionManager.toggle(item, additive = false)` — when the item is not currently selected, the new `additive` flag controls whether `select()` is called additively. Default of `false` matches the canonical single-select-mode semantics.
2. `KeyboardManager` call sites are now explicit about intent:
   - Space handler: `toggle(focused, this.multiDrag)` — additive only when multiDrag is on.
   - Ctrl/Cmd+Click: `toggle(target, true)` — Ctrl/Cmd is the canonical "extend" modifier and always additive.
   - multiDrag plain-click branch: `toggle(target, true)`.

## Test counts

| Suite | Before | After |
| --- | --- | --- |
| Unit | 207 passing, 2 skipped | 210 passing, 2 skipped |
| E2E (chromium) | 131 passing, 46 skipped | 132 passing, 45 skipped |

Bundle sizes unchanged (within 50/30/30 kB budgets).

## Test plan

- [x] `npm run check` — 0 errors.
- [x] `npm run test:unit` — 210 pass (+3 new).
- [x] `CI=1 npx playwright test --project=chromium keyboard-navigation.spec.ts` — all 7 pass including the un-skipped Space test.
- [x] `CI=1 npx playwright test --project=chromium` — 132 pass / 45 skipped.
- [x] `npm run build && npm run size` — within budgets.

Closes #46
Refs #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)