### PR TITLE
fix(showcase): tune touch long-press so mobile drags don't trigger page scroll

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,10 +722,21 @@
       window.sortables = [];
       window.resortableLoaded = true;
 
+      // Touch tuning shared by every demo below.
+      // The library default is delayOnTouchOnly: 200ms / touchStartThreshold: 5px.
+      // That 5px cancel-threshold is so tight that a natural drag motion (press +
+      // immediately move) blows past it before the 200ms hold elapses, so the
+      // pending drag is cancelled and the gesture falls through to a PAGE SCROLL.
+      // Snappier hold (150ms) + a forgiving 15px tolerance means a deliberate
+      // press-and-drag reliably starts a drag, while a fast swipe — which covers
+      // far more than 15px well under 150ms — still scrolls the page.
+      const TOUCH = { delayOnTouchOnly: 150, touchStartThreshold: 15 };
+
       // Smooth Transitions
       const smoothList = document.getElementById('smooth-list');
       if (smoothList) {
         window.sortables.push(new Sortable(smoothList, {
+          ...TOUCH,
           animation: 300,
           draggable: '.sortable-item',
           easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
@@ -742,6 +753,7 @@
       const multiSelectList = document.getElementById('multi-select-list');
       if (multiSelectList) {
         window.sortables.push(new Sortable(multiSelectList, {
+          ...TOUCH,
           animation: 200,
           draggable: '.sortable-item',
           multiDrag: true,
@@ -754,6 +766,7 @@
       const keyboardList = document.getElementById('keyboard-list');
       if (keyboardList) {
         window.sortables.push(new Sortable(keyboardList, {
+          ...TOUCH,
           animation: 200,
           draggable: '.sortable-item',
           multiDrag: true,
@@ -768,6 +781,7 @@
       const marqueeList = document.getElementById('marquee-list');
       if (marqueeList) {
         const marqueeSortable = new Sortable(marqueeList, {
+          ...TOUCH,
           animation: 200,
           draggable: '.sortable-item',
           multiDrag: true,
@@ -780,6 +794,7 @@
 
       // Kanban
       const kanbanOptions = {
+        ...TOUCH,
         group: 'kanban',
         animation: 200,
         draggable: '.kanban-card',
@@ -794,6 +809,7 @@
       const imageGallery = document.getElementById('image-gallery');
       if (imageGallery) {
         window.sortables.push(new Sortable(imageGallery, {
+          ...TOUCH,
           animation: 300,
           draggable: '.gallery-item',
           ghostClass: 'sortable-ghost',
@@ -806,6 +822,7 @@
       const nestedList = document.getElementById('nested-list');
       if (nestedList) {
         window.sortables.push(new Sortable(nestedList, {
+          ...TOUCH,
           animation: 200,
           draggable: '.folder',
           handle: '.folder-header',
@@ -814,6 +831,7 @@
         }));
       }
       const folderOptions = {
+        ...TOUCH,
         group: 'files',
         animation: 150,
         draggable: '.file',


### PR DESCRIPTION
## Problem

Reported while testing the live demo (`/demo/`) on an iPhone: **the page often scrolls when trying to drag an item.**

## Root cause

On touch, the library already gates drag start behind a long-press: `delayOnTouchOnly` defaults to **200ms** and `touchStartThreshold` defaults to **5px** (`DragManager.ts:198-199`). While that hold timer is pending, `touch-action` is set to `manipulation` (scroll allowed), and `onPointerMoveBeforeDrag` **cancels** the pending drag the instant the finger moves more than 5px (`DragManager.ts:909`).

So the natural "press and immediately move to drag" motion blows past 5px well before the 200ms elapses → the pending drag is cancelled → the gesture falls through to a **page scroll**. Note that `preventDefault()` on pointer events cannot suppress scrolling; only `touch-action` / non-passive `touchmove` can — so the cancel path scrolls unavoidably.

## Fix

Apply a shared `TOUCH` config to every showcase demo:

```js
const TOUCH = { delayOnTouchOnly: 150, touchStartThreshold: 15 };
```

- **Snappier arm (150ms)** — the drag commits before the user has moved much.
- **Forgiving tolerance (15px)** — a deliberate drag-start's finger drift no longer cancels into a scroll.
- A fast **scroll flick** still covers far more than 15px in well under 150ms, so it cancels-to-scroll exactly as before. Quick swipe = scroll; press-and-hold = drag (native iOS reorder feel).

**Demo-config only — no library code changed**, so no impact on the e2e suite or library consumers.

## Verification

- `npm run check` — 0 errors.
- `vite build --config vite.config.examples.ts` — demo builds clean (validates the inline module JS).
- iOS Safari's gesture/`touch-action` timing can't be faithfully emulated headlessly, so final feel should be confirmed on a real device.

## Follow-up worth considering

The library *default* of `delayOnTouchOnly: 200` / `touchStartThreshold: 5` is the same trap for any consumer who doesn't override it. Worth revisiting the default (and/or adding a non-passive `touchmove` guard for immediate-drag mode) in a separate library-level change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)