### PR TITLE
feat: controlled mode — framework-friendly DnD (no consumer-DOM mutation)

### DIFF
--- a/docs/plans/2026-07-09-controlled-mode-design.md
+++ b/docs/plans/2026-07-09-controlled-mode-design.md
@@ -1,0 +1,118 @@
+# Controlled Mode Design (framework-friendly DnD)
+
+**Date:** 2026-07-09
+**Status:** Draft
+**Blocks:** #44 (framework wrappers — React first)
+
+## Problem
+
+Resortable's drag pipeline mutates the consumer's DOM directly:
+
+- Same-zone pointer drag relocates the real item live (`DragManager.onPointerMove` → `DropZone.move`/`moveMultiple`).
+- Cross-zone drag inserts the real items (or clones) into the target zone mid-drag (`DragManager.ts` pointer path ~1247, HTML5 path ~608).
+- Keyboard grab-move relocates items per arrow press.
+- Final `end`/`add`/`remove` indices are derived from the resulting DOM.
+
+Declarative frameworks (React, Vue, Svelte) own that DOM. After a drop, the consumer updates state and the framework re-renders — but the library already moved the nodes, so reconciliation sees a DOM that doesn't match its virtual tree. Every SortableJS wrapper (react-sortablejs et al.) works around this by undoing the library's DOM changes before applying state, which is fragile (StrictMode breakage, key churn, duplicate nodes). We should not ship a React adapter on top of that hack.
+
+## Approach: `controlled: true` option
+
+One new boolean option. Default `false` — existing behavior untouched.
+
+**Invariant:** in controlled mode the library NEVER changes the structural position of consumer-owned nodes. Between `start` and `end` it may only:
+
+1. add/remove its own overlay artifacts (ghost — already `position: fixed` outside flow),
+2. insert/move **one placeholder element** it owns,
+3. toggle CSS classes / inline styles on dragged items (hide/show).
+
+At the moment `end` (and `add`/`remove`/`update`) fire, the consumer's DOM structure is **identical to pre-drag**. The events carry the full intent; the consumer commits it by updating state and re-rendering. Cancel (`Escape`, revert, spill) is trivial: remove placeholder, unhide items — nothing to restore.
+
+### Why placeholder, not transform-displacement
+
+dnd-kit/react-beautiful-dnd visualize the gap by transforming siblings. That avoids even the placeholder insertion, but requires a parallel layout engine (measure all siblings, compute offsets, handle grids/wrapping). The placeholder gets identical UX from natural reflow, works in flex/grid/wrapped layouts for free, and reuses `GhostManager.createPlaceholder` + the HTML5 pipeline's existing placeholder logic. A foreign node inside a framework-owned container is safe as long as it's removed before the commit re-render — which the invariant guarantees. (Known edge: an *external* re-render mid-drag may reflow around the placeholder; acceptable v1, transform mode can be a future opt-in if it bites.)
+
+## Mechanism
+
+### Drag state addition
+
+Track pending intent in `ActiveDrag` (GlobalDragState) instead of deriving from DOM:
+
+```ts
+pending?: {
+  zone: HTMLElement      // current placeholder container
+  index: number          // insertion index among draggables (see Index semantics)
+}
+```
+
+### Pointer pipeline (`DragManager`)
+
+- `commitPointerDrag`: after ghost creation, insert placeholder at the anchor item's position and hide all dragged items (`sortable-controlled-hidden` → `display: none`). Placeholder sized from the anchor (multi-drag: single placeholder; stacked ghost already conveys count).
+- `onPointerMove` same-zone branch: replace `targetZone.move/moveMultiple(...)` with a placeholder move to the computed index (FLIP-animate affected siblings via the existing `AnimationManager.animateReorder`). Update `pending`.
+- `onPointerMove` cross-zone branch: move the placeholder into the target zone instead of inserting real items. `onMove` dispatch, group checks, `setPutTarget` unchanged. Update `pending`.
+- `cleanupPointerDrag`: remove placeholder, unhide items, restore classes — **then** let `globalDragState.endDrag` emit events from `pending` (not from DOM). Revert path becomes: same cleanup, no `pending` commit.
+
+### HTML5 pipeline
+
+Already placeholder-driven during `dragover`. Changes: skip the real `zone.move()` in `onDrop`; record `pending` as the placeholder moves; suppress mid-drag `update`/`sort`/`change` DOM assumptions (see Events).
+
+### Keyboard pipeline (`KeyboardManager`)
+
+Grab: hide grabbed items, insert placeholder (same as pointer commit). Arrow move: move placeholder, update `pending`, announce target position from `pending.index`. Enter: cleanup then emit intent. Escape: cleanup, no events beyond `unchoose`/`end` with `newIndex === oldIndex`.
+
+Focus survives the consumer re-render via `dataIdAttr`: the adapter re-focuses `[data-id="<anchor>"]` after commit (adapter concern, but the contract is that identity lives in `dataIdAttr`, not node identity).
+
+### Clone mode
+
+Controlled mode never creates clone DOM nodes. `pullMode: 'clone'` is reported in the events; the consumer's state update inserts the copy (that's what "clone" means in data anyway). `GlobalDragState.setPutTarget` skips clone creation when controlled.
+
+### Events
+
+- All existing events keep firing with the same names/timing, but indices come from `pending`, and multi-item events gain arrays:
+
+```ts
+oldIndexes?: number[]   // per items[], indices in `from` at drag start
+newIndexes?: number[]   // per items[], indices in `to` after commit (contiguous block)
+```
+
+  (Deliberately `-Indexes`, not legacy MultiDrag's misspelled `oldIndicies` — migration doc gets a note.)
+- Mid-drag `sort`/`update`/`change` still fire as the placeholder moves (useful for live UIs), with `newIndex` = current `pending.index`.
+- Ordering guarantee (documented + asserted in tests): DOM restored **before** `remove`/`add`/`update`/`end` fire, so a synchronous `setState` inside a handler re-renders against clean DOM.
+
+### Index semantics
+
+`newIndex` / `newIndexes[i]` = index the item will occupy in the target list **after** the consumer applies the move — i.e. count of draggable siblings before the placeholder, excluding hidden dragged items and the placeholder itself. Placeholder must never match the `draggable` selector (it's a bare tag + ghost class today; add a defensive `data-resortable-placeholder` attribute and filter it in `DropZone.getItems`). Matches SortableJS semantics so `migration-from-sortable-v1.md` stays true.
+
+## Touch points
+
+| File | Change |
+|------|--------|
+| `src/types/index.ts` | `controlled` option; `oldIndexes`/`newIndexes` on `SortableEvent` |
+| `src/core/DragManager.ts` | gate the three mutation sites; placeholder-drive; cleanup ordering |
+| `src/core/GlobalDragState.ts` | `pending` on `ActiveDrag`; controlled `endDrag` emission; skip clone creation |
+| `src/core/KeyboardManager.ts` | placeholder-based grab/move/drop |
+| `src/core/GhostManager.ts` | placeholder marker attr; multi-drag placeholder sizing |
+| `src/core/DropZone.ts` | `getItems()` excludes placeholder; index helper for "count before placeholder" |
+
+`Sortable.sort()` / `toArray()` unchanged — imperative helpers stay uncontrolled-only (document that `sort()` throws or no-ops in controlled mode; the consumer owns order).
+
+## Testing strategy
+
+- Unit: controlled-mode suite asserting the invariant — snapshot `container.innerHTML` before drag and at each event emission; must be identical at `end`. Index math for same-zone, cross-zone, multi-drag, clone, keyboard.
+- E2E: duplicate a representative slice of the existing drag specs with `controlled: true` + a minimal "framework sim" (re-render list from data on `end`, keyed nodes recreated) — assert no duplicate/orphan nodes and correct visual order.
+- A11y: keyboard grab/move/drop announcements unchanged; axe gate already covers the rest.
+
+## Follow-on (separate designs)
+
+1. **`resortable/react`** — `useSortable(ref, { items, onSort, ...options })`; forces `controlled: true`; `onSort(intent)` where intent is `{ dataIds, from, to, oldIndexes, newIndexes, pullMode }`; focus restore; StrictMode-safe mount/destroy. Cross-list state coordination stays in userland (each list gets the `add`/`remove` pair; adapter dedupes into one `onSort` on the shared group).
+2. **Visibox adoption** — bind the adapter in DS container components (`SongWidget`/`ClipWidget` already stub `dragPreview`, `Grabber`, "binding lives in the container"); map `onSort` → existing `MOVE_SONGS` / `MOVE_CLIP(S)` IPC.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Option shape | single `controlled: boolean` | one mode switch, no matrix; default false = zero behavior change |
+| Gap visualization | placeholder + reflow | reuses HTML5-path machinery; grid/flex free; transform engine is over-engineering v1 |
+| Clone mode | no clone nodes; intent-only | consumer state insert IS the clone; avoids foreign node leaking into framework DOM |
+| Multi-drag indices | new `oldIndexes`/`newIndexes` | events must carry full intent; fixes legacy `Indicies` misspelling |
+| Keyboard | placeholder-based, commit on Enter | same invariant as pointer; per-arrow live commits would spam consumer re-renders |
+| `sort()`/`store` in controlled mode | no-op + doc | order is consumer state; silent DOM sort would violate the invariant |

--- a/docs/plans/2026-07-09-controlled-mode-design.md
+++ b/docs/plans/2026-07-09-controlled-mode-design.md
@@ -103,7 +103,7 @@ newIndexes?: number[]   // per items[], indices in `to` after commit (contiguous
 
 ## Follow-on (separate designs)
 
-1. **`resortable/react`** — `useSortable(ref, { items, onSort, ...options })`; forces `controlled: true`; `onSort(intent)` where intent is `{ dataIds, from, to, oldIndexes, newIndexes, pullMode }`; focus restore; StrictMode-safe mount/destroy. Cross-list state coordination stays in userland (each list gets the `add`/`remove` pair; adapter dedupes into one `onSort` on the shared group).
+1. **`resortable/react`** — `useSortable({ onSort, ...options })` returning a callback ref (see `2026-07-09-react-adapter-design.md` for the authoritative API); forces `controlled: true`; `onSort(intent)` where intent is `{ dataIds, from, to, oldIndexes, newIndexes, pullMode }`; focus restore; StrictMode-safe mount/destroy. Cross-list state coordination stays in userland (the intent is assembled from the source list's `end` event; `onAdd`/`onRemove` pass-throughs serve split-state consumers).
 2. **Visibox adoption** — bind the adapter in DS container components (`SongWidget`/`ClipWidget` already stub `dragPreview`, `Grabber`, "binding lives in the container"); map `onSort` → existing `MOVE_SONGS` / `MOVE_CLIP(S)` IPC.
 
 ## Decisions

--- a/docs/plans/2026-07-09-react-adapter-design.md
+++ b/docs/plans/2026-07-09-react-adapter-design.md
@@ -1,0 +1,190 @@
+# React Adapter Design (`resortable/react`)
+
+**Date:** 2026-07-09
+**Status:** Draft
+**Depends on:** [Controlled Mode](./2026-07-09-controlled-mode-design.md) (#44)
+
+## Problem
+
+Controlled mode makes Resortable safe under a declarative renderer, but raw usage from React is still all boilerplate: `useEffect` create/destroy (broken twice by StrictMode double-effects), translating `end`/`add`/`remove` into a state update, keeping option changes from remounting the instance, and restoring keyboard focus after the commit re-render. Every consumer would re-write the same ~100 fragile lines. Ship one adapter that owns them.
+
+## Approach: `useSortable` hook, subpath export
+
+A single hook is the whole v1 API. It creates a `Sortable` with `controlled: true` forced, translates the drag outcome into one **intent** object, and hands it to the consumer, who commits it by updating state. The adapter never touches consumer DOM (that invariant is the core's; the adapter just doesn't break it).
+
+```tsx
+import { useSortable } from 'resortable/react'
+
+function TrackList({ tracks, onReorder }: Props) {
+  const { ref } = useSortable({
+    group: 'playlist',
+    multiDrag: true,
+    animation: 150,
+    onSort: (intent) => onReorder(applyIntent(tracks, intent)),
+  })
+  return (
+    <ul ref={ref}>
+      {tracks.map((t) => (
+        <li key={t.id} data-id={t.id} className="sortable-item">{t.title}</li>
+      ))}
+    </ul>
+  )
+}
+```
+
+### Hook signature
+
+```ts
+function useSortable<T extends HTMLElement = HTMLElement>(
+  options: UseSortableOptions
+): {
+  ref: React.RefCallback<T>          // attach to the list container
+  sortable: React.RefObject<Sortable | null>  // escape hatch to the raw instance
+  getSelectedIds(): string[]
+  setSelectedIds(ids: string[]): void
+}
+
+type UseSortableOptions = Omit<
+  SortableOptions,
+  'controlled' | 'onSort' | 'onEnd' | 'store'
+> & {
+  onSort: (intent: SortIntent) => void
+  onSelectionChange?: (ids: string[]) => void
+  id?: string   // names this zone in cross-list intents (fromId/toId)
+}
+```
+
+- Hook **returns** the ref (callback ref) rather than taking one: the callback ref tells us exactly when the element attaches/detaches, which handles conditional rendering and avoids "ref not yet assigned" effect races.
+- Naming collision: core `SortableOptions.onSort` takes a `SortableEvent`; the adapter option shadows it with the intent signature and is stripped before options reach `new Sortable()`. `onEnd`/`store` are stripped too — the adapter owns the end event, and order persistence is consumer state in controlled mode.
+- All remaining `SortableOptions` pass through untouched (group, handle, filter, delay, multiDrag, direction, dataIdAttr, …).
+
+### Intent object
+
+```ts
+interface SortIntent {
+  dataIds: string[]      // per event.items[], read from dataIdAttr at emit time
+  from: HTMLElement
+  to: HTMLElement
+  fromId?: string        // hook `id` when the zone is adapter-managed
+  toId?: string
+  oldIndexes: number[]   // from event.oldIndexes (fallback [event.oldIndex])
+  newIndexes: number[]   // from event.newIndexes (fallback [event.newIndex])
+  pullMode?: boolean | 'clone' | 'move'
+}
+```
+
+Assembled **entirely from the source list's `end` event**. Controlled mode guarantees `end` fires exactly once per drag, after DOM restore, carrying `to`, `oldIndexes`/`newIndexes` (from `pending`), and `pullMode`. `dataIds` are read off `event.items` via the effective `dataIdAttr` (default `data-id`); an item without the attribute is a consumer bug — dev-mode `console.error`, index used as fallback.
+
+- **No-op drop** (`from === to` and `oldIndexes` deep-equals `newIndexes`, or Escape/revert): no `onSort`.
+- **Clone** (`pullMode: 'clone'`): consumer inserts copies into the target state; `dataIds` are the *source* ids — the consumer mints new ids for the copies. Documented, not adapter magic.
+
+### Cross-container dedupe
+
+For a cross-list drag, core fires `remove` on the source instance, `add` on the target, `end` on the source. Two hook instances therefore each see events — but the adapter fires **one `onSort` total, on the source hook**, built from `end`. No group-keyed event dedupe is needed because `end` is already unique per drag; deriving intent from `add`+`remove` pairs and de-duplicating them would rebuild information `end` already carries.
+
+A module-level registry still exists — `const zones = new WeakMap<HTMLElement, ZoneRecord>()` (element → `{ id, optionsRef }`), the adapter's analog of core's `GlobalDragState` singleton: every mounted hook registers its container on attach, unregisters on detach. Its jobs:
+
+1. Resolve `event.to` → `toId` so cross-list intents name the receiving zone without the consumer comparing DOM nodes.
+2. Detect "target is not adapter-managed" (plain `Sortable` on the other side) — intent still fires, `toId` undefined.
+
+Consumers with **split state** (source and target lists in unrelated components with no shared parent) don't get a target-side `onSort`; they use the pass-through `onAdd`/`onRemove` options, whose raw events already carry `oldIndexes`/`newIndexes` per the controlled-mode design. Shared-state consumers (the normal React case — a common ancestor owns both arrays) handle everything in one `onSort`.
+
+### Mount / destroy / StrictMode
+
+- Callback ref stores the element in `useState`; a `useEffect([element])` does `new Sortable(element, mapped)` / `sortable.destroy()`.
+- StrictMode's double effect produces create → destroy → create. `destroy()` is already clean (detach + `WeakMap` delete), so this Just Works; a test locks it (exactly one live instance, no duplicate listeners after double-mount).
+- React 18 and 19 both supported; no use of 19-only ref-cleanup semantics.
+
+### Option updates without remount
+
+- Every callback (`onSort`, `onSelectionChange`, pass-throughs, `onMove`) lives in a ref the adapter reads at call time — changing a callback identity never touches the `Sortable`.
+- A second effect shallow-diffs the remaining option values against the previous render and applies changes via `sortable.option(key, value)`. No remount. (`option()` internally rebuilds `DragManager` for group/handle/etc. — that's core's cost, invisible here.)
+- **Mid-drag guard:** if a diff lands while `Sortable.active` is set, queue it and flush on the next `end`/`unchoose` — `option()`'s DragManager teardown mid-drag would kill the drag.
+
+### Items changing mid-drag
+
+The adapter takes no `items` prop — the consumer renders children. Controlled mode tolerates an external re-render around the placeholder. Contract, documented: intent **indexes are a snapshot** of drag-start/drop-time positions; if the consumer's array may mutate mid-drag (live data), apply the intent by `dataIds` (splice by id lookup), not by index. Keys must stay stable during a drag; keyed reorder is fine.
+
+### Focus restoration (keyboard a11y)
+
+At `end`, if `document.activeElement` is one of `event.items` (true after a keyboard grab-drop, since core moves focus with the grab), record the anchor's data-id. After calling `onSort`, one `requestAnimationFrame` later (consumer commit has rendered), query `to` for `[<dataIdAttr>="<anchor>"]` and `.focus()` it. rAF avoids coupling to the consumer's render cycle; if the element isn't found (consumer rejected the intent), do nothing.
+
+### Multi-drag selection
+
+`SelectionManager` (exposed as `dragManager.selectionManager`) provides `select(el, additive)`, `deselect`, `clearSelection`, `getSelected()`, and emits `select` events with element arrays. That's enough for:
+
+- **v1: internal selection** — core owns the `Set<HTMLElement>`; adapter maps elements ⇄ data-ids at the boundary. `onSelectionChange(ids)` mirrors the `select` event out; `getSelectedIds()`/`setSelectedIds(ids)` (id → `querySelector([data-id=…])` → `select`) are the escape hatch for programmatic control.
+- **Deferred: controlled `selectedIds` prop.** True controlled selection needs SelectionManager to reconcile an external id list without emitting feedback loops, and to survive commit re-renders where React recreates nodes (element-identity Sets go stale). Add when a real consumer needs it.
+- **Core pre-req:** `SelectionManager` hardcodes `'.sortable-item'` in `isValidItem`/`getSortableItems` instead of honoring the `draggable` option. Fix in core alongside this work; otherwise adapter users must use that class.
+
+### `<Sortable>` component wrapper
+
+**Not shipping one.** The hook attaches to any element the consumer already renders; a wrapper component must choose a tag, forward refs, and either clone children or take a render prop — three API decisions for zero capability. A consumer who wants a component writes it in five lines over the hook. Revisit only on demonstrated demand.
+
+### SSR safety
+
+No module-scope `window`/`document` access in the adapter, and instantiation only happens inside effects/ref callbacks, which never run on the server. Core is already side-effect-clean at import (touch detection etc. runs in `attach()`, not import). Lock both with a node-environment (non-jsdom) vitest that imports `resortable/react` and asserts no throw.
+
+## Packaging: subpath export, not a workspace package
+
+The repo is a single package with one semantic-release pipeline and no workspace tooling; the Vite lib build already emits multiple formats from one entry. A workspace/monorepo adds versioning, release, and CI surface for one small file. **Recommendation: subpath export.**
+
+- New source: `src/react/index.ts` (the only new runtime file). It imports core via the self-referencing specifier `import { Sortable } from 'resortable'` — Node resolves a package's own name through its exports map, and the build marks it external. This guarantees the adapter shares the consumer's core module instance (bundling core into the react build would duplicate `GlobalDragState`/`PluginSystem` singletons — the one packaging failure mode that must not happen).
+- Second build config (`vite.config.react.ts`, `npm run build` chains it): entry `src/react/index.ts`, formats `es` + `cjs` (no UMD — script-tag users aren't writing React hooks), externals `react`, `resortable`; d.ts to `dist/react/`.
+- `package.json`:
+
+```json
+"exports": {
+  ".": { "…": "unchanged" },
+  "./react": {
+    "types": "./dist/react/index.d.ts",
+    "import": "./dist/react/index.esm.js",
+    "require": "./dist/react/index.cjs.js"
+  }
+},
+"peerDependencies": { "react": ">=18" },
+"peerDependenciesMeta": { "react": { "optional": true } }
+```
+
+  `optional: true` keeps core-only installs warning-free. **No `react-dom` anywhere in the runtime graph** — the hook uses only `react` APIs; `react-dom` + `@testing-library/react` are devDependencies for tests.
+- Add a `size-limit` entry for `dist/react/index.esm.js` (budget: 5 kB gzip — it's glue).
+- This also establishes the subpath pattern the docs already promise for `resortable/plugins`.
+
+## Touch points
+
+| File | Change |
+|------|--------|
+| `src/react/index.ts` | new — hook, intent assembly, zone registry, focus restore, selection bridge |
+| `package.json` | `./react` export, react peer dep (optional), test/build deps, size-limit entry |
+| `vite.config.react.ts` | new — es/cjs build for the adapter, externals `react` + `resortable` |
+| `vitest.config.ts` | include `tests/unit/react/**`; React tests use jsdom (already default) |
+| `src/core/SelectionManager.ts` | pre-req: honor `draggable` option instead of hardcoded `.sortable-item` |
+| `examples/` + `vite.config.examples.ts` | React demo app (doubles as the Playwright fixture) |
+
+## Testing strategy
+
+- **Unit (vitest + jsdom + React Testing Library):**
+  - StrictMode double-mount: render under `<StrictMode>`, assert one live instance and that a drag still emits exactly one `onSort`.
+  - Intent assembly: emit synthetic `end` events on the instance's `eventSystem` (same-list, cross-list, multi-drag, clone, no-op/cancel) and assert intent shape, single delivery, `fromId`/`toId` resolution.
+  - Option updates: change props, spy on `destroy` (never called) and `option()` (called per changed key); mid-drag diff deferred until `end`.
+  - Focus restore: keyboard-shaped end event → commit re-render with new nodes → active element is `[data-id=anchor]`.
+  - Selection bridge: `select` event → `onSelectionChange` ids; `setSelectedIds` round-trip.
+  - SSR: node-environment test imports the adapter without a DOM.
+- **E2E (Playwright):** real React app fixture in `examples/` (built via `vite.config.examples.ts`, served by the existing Playwright web server). Specs: pointer same-list reorder commits correct order with no duplicate/orphan nodes; cross-list drag between two hooks updates both lists from one `onSort`; keyboard grab-move-drop restores focus; StrictMode build of the same fixture passes the same specs.
+- **A11y:** run the existing axe gate against the React fixture.
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Packaging | subpath `resortable/react` | one package/release pipeline already; workspace is overhead for one file |
+| Core linkage | self-referencing `import 'resortable'`, externalized | guarantees single core instance; bundling core would fork GlobalDragState |
+| Hook ref | hook returns callback ref | knows attach/detach timing; survives conditional render; no effect races |
+| Intent source | source list's `end` event only | fires exactly once with full intent; add/remove dedupe would rebuild it |
+| `onSort` delivery | once, on the source hook | shared-state consumers hoist the handler; split state uses onAdd/onRemove pass-through |
+| Registry | module-level `WeakMap<element, zone>` | resolves `toId` across hook instances; WeakMap = no unmount leaks; mirrors GlobalDragState singleton scope |
+| Option changes | ref'd callbacks + `option()` diff, queued during drag | no remount; mid-drag DragManager rebuild would kill the drag |
+| Selection | internal v1 + id-based helpers | SelectionManager suffices today; controlled `selectedIds` waits for a real consumer |
+| Component wrapper | none | hook covers it; wrapper adds API decisions, zero capability |
+| Peer deps | `react >=18` optional; no react-dom | hook uses only `react`; optional keeps core-only installs clean |
+| React 19 features | none required | works on 18/19 with plain effects; no ref-cleanup dependency |

--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -7,7 +7,8 @@ import {
 } from '../types/index.js'
 import { DropZone } from './DropZone.js'
 import { type SortableEventSystem } from './EventSystem.js'
-import { globalDragState } from './GlobalDragState.js'
+import { globalDragState, type ActiveDrag } from './GlobalDragState.js'
+import { hideControlled, restoreControlledHidden } from '../utils/dom.js'
 import { SelectionManager } from './SelectionManager.js'
 import { KeyboardManager } from './KeyboardManager.js'
 import { GhostManager } from './GhostManager.js'
@@ -116,6 +117,14 @@ export class DragManager implements DragManagerInterface {
   ) => boolean | -1 | 1 | void
   private ghostManager: GhostManager
 
+  // Controlled mode (see the `controlled` option): consumer-owned nodes are
+  // never structurally moved — the placeholder is the only thing that
+  // travels, and events carry the intent for the consumer to commit.
+  private controlled: boolean
+  // Original inline `display` values of items hidden for a controlled
+  // pointer drag; null when nothing is hidden.
+  private hiddenDisplays: Map<HTMLElement, string> | null = null
+
   private groupManager: GroupManager
 
   private originalTouchActions = new Map<HTMLElement, string>()
@@ -170,6 +179,7 @@ export class DragManager implements DragManagerInterface {
         event: MoveEvent,
         originalEvent: Event
       ) => boolean | -1 | 1 | void
+      controlled?: boolean
     }
   ) {
     // Initialize group manager
@@ -224,6 +234,7 @@ export class DragManager implements DragManagerInterface {
     this._dataIdAttr = options?.dataIdAttr ?? 'data-id'
     this._setData = options?.setData
     this._onMove = options?.onMove
+    this.controlled = options?.controlled ?? false
 
     // Initialize ghost manager with classes
     this.ghostManager = new GhostManager(
@@ -253,6 +264,8 @@ export class DragManager implements DragManagerInterface {
       {
         deselectOnClickOutside: options?.deselectOnClickOutside,
         multiDrag: options?.multiSelect,
+        controlled: this.controlled,
+        ghostManager: this.ghostManager,
       }
     )
   }
@@ -373,7 +386,8 @@ export class DragManager implements DragManagerInterface {
       this,
       this.groupManager.getName(),
       this.startIndex,
-      this.events
+      this.events,
+      this.controlled
     )
 
     const evt: SortableEvent = {
@@ -472,6 +486,177 @@ export class DragManager implements DragManagerInterface {
     return this._onMove?.(moveEvent, originalEvent)
   }
 
+  /**
+   * Controlled-mode move handling, shared by both pipelines (HTML5 dragover
+   * and pointer move). Only the placeholder travels; consumer-owned nodes
+   * are never structurally moved. `onMove` cancellation/override semantics
+   * are preserved (dispatched on the SOURCE sortable's options, legacy
+   * parity). Per-pipeline differences:
+   *
+   * - `emitHtml5Events` — the HTML5 pipeline emits sort/update/change on
+   *   same-list reorders; the pointer pipeline only emits update (parity
+   *   with the uncontrolled paths).
+   * - `commitPending`  — the pointer pipeline commits pending live
+   *   (pointerup IS the drop); the HTML5 pipeline commits only in onDrop
+   *   so a cancelled drag (dragend without drop) reports a no-op.
+   */
+  private handleControlledMove(
+    e: Event,
+    over: HTMLElement | null,
+    targetManager: DragManager,
+    activeDrag: ActiveDrag,
+    opts: { emitHtml5Events: boolean; commitPending: boolean }
+  ): void {
+    const sourceManager = activeDrag.fromDragManager as DragManager
+    const placeholder = sourceManager.ghostManager.getPlaceholderElement()
+    if (!placeholder) return
+
+    const targetZone = targetManager.zone
+    const targetZoneElement = targetZone.element
+    if (targetZone.isAnimating) return
+
+    const items = activeDrag.items
+    const overIsValid =
+      over !== null && !items.includes(over) && over !== placeholder
+
+    if (placeholder.parentElement !== targetZoneElement) {
+      // ── Entering this zone (cross-zone, or returning to the source) ──
+      if (
+        targetZoneElement !== activeDrag.fromZone &&
+        !globalDragState.canAcceptDrop(
+          activeDrag.id,
+          targetManager.groupManager.getName()
+        )
+      ) {
+        return
+      }
+      globalDragState.setPutTarget(
+        activeDrag.id,
+        targetZoneElement,
+        targetManager,
+        targetManager.groupManager.getName()
+      )
+
+      const hasSibling = overIsValid && over.parentElement === targetZoneElement
+      const related: HTMLElement = hasSibling && over ? over : targetZoneElement
+      const visible = targetZone.getVisibleItems(items)
+      const newIndex =
+        hasSibling && over ? visible.indexOf(over) : visible.length
+      if (newIndex === -1) return
+
+      const moveEvent: MoveEvent = {
+        item: items[0],
+        items,
+        from: activeDrag.fromZone,
+        to: targetZoneElement,
+        oldIndex: activeDrag.startIndices[0],
+        newIndex,
+        related,
+        willInsertAfter: false,
+        draggedRect: placeholder.getBoundingClientRect(),
+        targetRect: related.getBoundingClientRect(),
+      }
+      const moveResult = sourceManager.dispatchMove(moveEvent, e)
+      if (moveResult === false) return
+
+      let insertRef: Node | null = hasSibling && over ? over : null
+      let index = newIndex
+      if (hasSibling && over && moveResult === 1) {
+        insertRef = over.nextSibling
+        index = newIndex + 1
+      }
+      targetZone.insertWithAnimation(placeholder, insertRef)
+      if (opts.commitPending) {
+        globalDragState.setPending(activeDrag.id, {
+          zone: targetZoneElement,
+          index,
+        })
+      }
+      return
+    }
+
+    // ── Reorder within the placeholder's current zone ──
+    if (!overIsValid || !over || over.parentElement !== targetZoneElement) {
+      return
+    }
+
+    const visible = targetZone.getVisibleItems(items)
+    const overIdx = visible.indexOf(over)
+    if (overIdx === -1) return
+    const oldIdx = targetZone.getControlledIndex(placeholder, items)
+
+    // Overlap gate: the ghost is the moving visual in controlled mode.
+    const movingRect = (
+      sourceManager.ghostManager.getGhostElement() ?? placeholder
+    ).getBoundingClientRect()
+    const overRect = over.getBoundingClientRect()
+    const naturalAfter = !!(
+      placeholder.compareDocumentPosition(over) &
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+    if (
+      !this.shouldSwap(
+        movingRect,
+        overRect,
+        naturalAfter ? 'forward' : 'backward'
+      )
+    ) {
+      return
+    }
+
+    const moveEvent: MoveEvent = {
+      item: items[0],
+      items,
+      from: targetZoneElement,
+      to: targetZoneElement,
+      oldIndex: oldIdx,
+      newIndex: overIdx + (naturalAfter ? 1 : 0),
+      related: over,
+      willInsertAfter: naturalAfter,
+      draggedRect: placeholder.getBoundingClientRect(),
+      targetRect: overRect,
+    }
+    const moveResult = sourceManager.dispatchMove(moveEvent, e)
+    if (moveResult === false) return
+
+    const insertAfter =
+      moveResult === 1 ? true : moveResult === -1 ? false : naturalAfter
+    const newIndex = overIdx + (insertAfter ? 1 : 0)
+    if (newIndex === oldIdx) return
+
+    targetZone.insertWithAnimation(
+      placeholder,
+      insertAfter ? over.nextSibling : over
+    )
+    if (opts.commitPending) {
+      globalDragState.setPending(activeDrag.id, {
+        zone: targetZoneElement,
+        index: newIndex,
+      })
+    }
+
+    const evt = {
+      item: items[0],
+      items,
+      from: targetZoneElement,
+      to: targetZoneElement,
+      oldIndex: oldIdx,
+      newIndex,
+    }
+    const isSourceList = activeDrag.fromZone === targetZoneElement
+    if (opts.emitHtml5Events) {
+      // HTML5-pipeline parity: sort always, update/change on the source list.
+      targetManager.events.emit('sort', evt)
+      if (isSourceList) {
+        targetManager.events.emit('update', evt)
+        targetManager.events.emit('change', evt)
+      }
+    } else if (isSourceList) {
+      // Pointer-pipeline parity: update only.
+      targetManager.events.emit('update', evt)
+    }
+  }
+
   private onDragOver = (e: DragEvent): void => {
     e.preventDefault()
     // Stop the event from bubbling to ancestor sortables unless the user
@@ -513,6 +698,17 @@ export class DragManager implements DragManagerInterface {
     const overEl = (e.target as HTMLElement).closest(this.draggable)
     const over: HTMLElement | null =
       overEl instanceof HTMLElement ? overEl : null
+
+    if (this.controlled) {
+      // Controlled mode: only the placeholder travels. Mid-drag events fire
+      // (HTML5 parity: sort/update/change) but pending is only committed in
+      // onDrop — a dragend without a drop must not commit intent.
+      this.handleControlledMove(e, over, this, activeDrag, {
+        emitHtml5Events: true,
+        commitPending: false,
+      })
+      return
+    }
 
     // Handle cross-zone dragging
     if (originalItem.parentElement !== this.zone.element) {
@@ -724,6 +920,20 @@ export class DragManager implements DragManagerInterface {
     const dragId = 'html5-drag'
     const activeDrag = globalDragState.getActiveDrag(dragId)
     if (!activeDrag) return
+
+    if (this.controlled) {
+      // Commit the intent: record the placeholder's final position. DOM
+      // cleanup + event emission happen in onDragEnd → endDrag.
+      const sourceManager = activeDrag.fromDragManager as DragManager
+      const placeholder = sourceManager.ghostManager.getPlaceholderElement()
+      if (placeholder && placeholder.parentElement === this.zone.element) {
+        globalDragState.setPending(dragId, {
+          zone: this.zone.element,
+          index: this.zone.getControlledIndex(placeholder, activeDrag.items),
+        })
+      }
+      return
+    }
 
     const originalItem = activeDrag.items[0]
     const placeholder = this.ghostManager.getPlaceholderElement()
@@ -1041,7 +1251,8 @@ export class DragManager implements DragManagerInterface {
       this,
       this.groupManager.getName(),
       this.draggedItems.map((item) => this.zone.getIndex(item)),
-      this.events
+      this.events,
+      this.controlled
     )
 
     const evt: SortableEvent = {
@@ -1079,7 +1290,15 @@ export class DragManager implements DragManagerInterface {
     } else {
       this.ghostManager.createGhost(target, e, ghostOptions)
     }
-    this.ghostManager.createPlaceholder(target)
+    const placeholder = this.ghostManager.createPlaceholder(target)
+
+    if (this.controlled) {
+      // The placeholder takes the anchor's spot and the real items are
+      // hidden in place (never structurally moved) — the ghost is the only
+      // visual that follows the pointer. Sized before hiding.
+      target.parentElement?.insertBefore(placeholder, target)
+      this.hiddenDisplays = hideControlled(this.draggedItems)
+    }
 
     // Then emit start event
     this.events.emit('start', evt)
@@ -1128,6 +1347,19 @@ export class DragManager implements DragManagerInterface {
       )
     }
     if (!targetZoneElement) return
+
+    if (this.controlled) {
+      const targetManager = this.findDragManagerForZone(targetZoneElement)
+      if (targetManager) {
+        // Pointer parity: only `update` fires mid-drag (gated on the source
+        // list); pending updates live because pointerup IS the commit.
+        this.handleControlledMove(e, over, targetManager, activeDrag, {
+          emitHtml5Events: false,
+          commitPending: true,
+        })
+      }
+      return
+    }
 
     // Find all Sortable instances and see which one manages this zone
     // We need to handle cross-zone movement by finding the right DragManager
@@ -1366,8 +1598,34 @@ export class DragManager implements DragManagerInterface {
     document.removeEventListener('pointerup', this.onPointerUp)
     document.removeEventListener('pointercancel', this.onPointerCancel)
 
+    // Controlled mode: restore the consumer's DOM BEFORE endDrag emits the
+    // intent events, so a synchronous state update in a handler re-renders
+    // against clean DOM. Capture the placeholder rect first — the ghost
+    // settles onto the drop position below.
+    let controlledSettleRect: DOMRect | null = null
+    if (this.controlled) {
+      const placeholder = this.ghostManager.getPlaceholderElement()
+      if (placeholder && !revert) {
+        controlledSettleRect = placeholder.getBoundingClientRect()
+      }
+      this.ghostManager.destroyPlaceholder()
+      if (this.hiddenDisplays) {
+        restoreControlledHidden(this.hiddenDisplays)
+        this.hiddenDisplays = null
+      }
+      if (revert && this.activePointerId !== null) {
+        // Cancelled — end reports newIndex = oldIndex.
+        globalDragState.clearPending(`pointer-${this.activePointerId}`)
+      }
+    }
+
     // If reverting (cancelled drag), restore original position
-    if (revert && this.dragElement && this.startIndex >= 0) {
+    if (
+      revert &&
+      !this.controlled &&
+      this.dragElement &&
+      this.startIndex >= 0
+    ) {
       const dragId =
         this.activePointerId !== null ? `pointer-${this.activePointerId}` : null
       const activeDrag = dragId ? globalDragState.getActiveDrag(dragId) : null
@@ -1417,7 +1675,10 @@ export class DragManager implements DragManagerInterface {
     const ghost = this.ghostManager.getGhostElement()
     const dragEl = this.dragElement
     if (ghost && dragEl && !revert) {
-      const finalRect = dragEl.getBoundingClientRect()
+      // Controlled mode: the item was restored to its original spot, so the
+      // ghost settles onto where the placeholder sat (the drop position the
+      // consumer is about to render) instead of the item's stale rect.
+      const finalRect = controlledSettleRect ?? dragEl.getBoundingClientRect()
       const ghostRect = ghost.getBoundingClientRect()
       const deltaX = finalRect.left - ghostRect.left
       const deltaY = finalRect.top - ghostRect.top

--- a/src/core/DropZone.ts
+++ b/src/core/DropZone.ts
@@ -40,9 +40,10 @@ export class DropZone {
    * items — the HTML5 pipeline leaves them visible in place).
    */
   public getVisibleItems(exclude: HTMLElement[] = []): HTMLElement[] {
+    const excluded = new Set(exclude)
     return this.getItems().filter(
       (el) =>
-        !exclude.includes(el) &&
+        !excluded.has(el) &&
         !el.classList.contains('sortable-controlled-hidden')
     )
   }
@@ -57,11 +58,11 @@ export class DropZone {
     placeholder: HTMLElement,
     exclude: HTMLElement[] = []
   ): number {
-    const visible = this.getVisibleItems(exclude)
+    const visible = new Set(this.getVisibleItems(exclude))
     let index = 0
     for (const child of Array.from(this.element.children)) {
       if (child === placeholder) return index
-      if (child instanceof HTMLElement && visible.includes(child)) {
+      if (child instanceof HTMLElement && visible.has(child)) {
         index++
       }
     }

--- a/src/core/DropZone.ts
+++ b/src/core/DropZone.ts
@@ -28,12 +28,62 @@ export class DropZone {
 
   /** Get sortable items (only elements matching the draggable selector) */
   public getItems(): HTMLElement[] {
-    return Array.from(this.element.querySelectorAll(this.draggableSelector))
+    return Array.from(
+      this.element.querySelectorAll<HTMLElement>(this.draggableSelector)
+    ).filter((el) => !el.hasAttribute('data-resortable-placeholder'))
+  }
+
+  /**
+   * Controlled-mode view of the list: draggable items excluding the
+   * placeholder (already filtered by getItems), items hidden for the active
+   * controlled drag, and any explicitly excluded elements (the dragged
+   * items — the HTML5 pipeline leaves them visible in place).
+   */
+  public getVisibleItems(exclude: HTMLElement[] = []): HTMLElement[] {
+    return this.getItems().filter(
+      (el) =>
+        !exclude.includes(el) &&
+        !el.classList.contains('sortable-controlled-hidden')
+    )
+  }
+
+  /**
+   * Controlled-mode drop index: the index the dragged item(s) will occupy
+   * in this list AFTER the consumer commits the move — i.e. the count of
+   * visible draggable siblings (see {@link getVisibleItems}) before
+   * `placeholder`.
+   */
+  public getControlledIndex(
+    placeholder: HTMLElement,
+    exclude: HTMLElement[] = []
+  ): number {
+    const visible = this.getVisibleItems(exclude)
+    let index = 0
+    for (const child of Array.from(this.element.children)) {
+      if (child === placeholder) return index
+      if (child instanceof HTMLElement && visible.includes(child)) {
+        index++
+      }
+    }
+    return index
   }
 
   /** Get index of an item within container */
   public getIndex(item: HTMLElement): number {
     return this.getItems().indexOf(item)
+  }
+
+  /**
+   * Insert `node` before `ref` (append when null), FLIP-animating the
+   * displaced items. Controlled mode uses this to move the placeholder.
+   */
+  public insertWithAnimation(node: HTMLElement, ref: Node | null): void {
+    const doInsert = () => this.element.insertBefore(node, ref)
+    if (this.animationManager) {
+      this.animationManager.animateReorder(this.getItems(), doInsert)
+    } else {
+      doInsert()
+    }
   }
 
   /** Move item to new index within container (among sortable items only) */

--- a/src/core/GhostManager.ts
+++ b/src/core/GhostManager.ts
@@ -273,6 +273,11 @@ export class GhostManager {
     // Create placeholder element
     this.placeholderElement = document.createElement(referenceElement.tagName)
 
+    // Mark the placeholder so index math and DropZone.getItems() can always
+    // exclude it, even if a consumer's `draggable` selector would otherwise
+    // match the bare tag (controlled mode relies on this).
+    this.placeholderElement.setAttribute('data-resortable-placeholder', '')
+
     // Copy dimensions
     const rect = referenceElement.getBoundingClientRect()
     this.placeholderElement.style.width = `${rect.width}px`

--- a/src/core/GlobalDragState.ts
+++ b/src/core/GlobalDragState.ts
@@ -21,6 +21,11 @@ interface ActiveDrag {
   eventSystem: SortableEventSystem
   clones?: HTMLElement[] // Cloned elements for clone operations
   pullMode?: 'move' | 'clone' // How these items were pulled
+  controlled?: boolean // Controlled mode: no consumer-DOM mutation, intent-only events
+  // Controlled mode: where the placeholder currently sits. Set/updated by the
+  // drag pipelines; endDrag() emits indices from here instead of the DOM.
+  // Cleared (left undefined) on cancel/revert so end reports newIndex = oldIndex.
+  pending?: { zone: HTMLElement; index: number }
 }
 
 interface PutTarget {
@@ -46,7 +51,8 @@ class GlobalDragStateManager {
     fromDragManager: DragManager,
     groupName: string,
     startIndex: number | number[],
-    eventSystem: SortableEventSystem
+    eventSystem: SortableEventSystem,
+    controlled = false
   ): void {
     const itemsArray = Array.isArray(items) ? items : [items]
     const indicesArray = Array.isArray(startIndex) ? startIndex : [startIndex]
@@ -58,9 +64,36 @@ class GlobalDragStateManager {
       groupName,
       startIndices: indicesArray,
       eventSystem,
+      controlled,
+      // Controlled drags start with the placeholder at the item's own spot.
+      pending: controlled
+        ? { zone: fromZone, index: indicesArray[0] }
+        : undefined,
     })
     // Clear any existing put target for this drag
     this.putTargets.delete(dragId)
+  }
+
+  /** Controlled mode: record where the placeholder currently sits */
+  public setPending(
+    dragId: string,
+    pending: { zone: HTMLElement; index: number }
+  ): void {
+    const activeDrag = this.activeDrags.get(dragId)
+    if (activeDrag) activeDrag.pending = pending
+  }
+
+  /** Controlled mode: read the current placeholder position */
+  public getPending(
+    dragId: string
+  ): { zone: HTMLElement; index: number } | undefined {
+    return this.activeDrags.get(dragId)?.pending
+  }
+
+  /** Controlled mode: cancel — end will report newIndex = oldIndex */
+  public clearPending(dragId: string): void {
+    const activeDrag = this.activeDrags.get(dragId)
+    if (activeDrag) activeDrag.pending = undefined
   }
 
   /** Set the current drop target for a specific drag */
@@ -83,7 +116,10 @@ class GlobalDragStateManager {
             const pullMode = sourceGroupManager.getPullMode(groupName)
             activeDrag.pullMode = pullMode
 
-            if (pullMode === 'clone') {
+            // Controlled mode never materializes clone nodes — `pullMode:
+            // 'clone'` is reported in the events and the consumer's state
+            // update inserts the copy.
+            if (pullMode === 'clone' && !activeDrag.controlled) {
               // Create clones of all dragged items
               const clones = activeDrag.items.map((item) => {
                 const clone = item.cloneNode(true) as HTMLElement
@@ -122,6 +158,13 @@ class GlobalDragStateManager {
   public endDrag(dragId: string): void {
     const activeDrag = this.activeDrags.get(dragId)
     if (!activeDrag) return
+
+    if (activeDrag.controlled) {
+      this.endControlledDrag(activeDrag)
+      this.activeDrags.delete(dragId)
+      this.putTargets.delete(dragId)
+      return
+    }
 
     const putTarget = this.putTargets.get(dragId)
     const isDifferentZone = putTarget && putTarget.zone !== activeDrag.fromZone
@@ -220,6 +263,65 @@ class GlobalDragStateManager {
 
     this.activeDrags.delete(dragId)
     this.putTargets.delete(dragId)
+  }
+
+  /**
+   * Controlled-mode drag end: the caller (drag pipeline) has already
+   * restored the DOM (placeholder removed, hidden items shown), so every
+   * index here comes from `pending`, never from the DOM. Events carry the
+   * full intent (`oldIndexes`/`newIndexes`); the consumer commits it by
+   * updating state. A cleared `pending` means cancelled — report
+   * newIndex = oldIndex so consumers can no-op.
+   */
+  private endControlledDrag(activeDrag: ActiveDrag): void {
+    const putTarget = this.putTargets.get(activeDrag.id)
+    const { pending } = activeDrag
+    const oldIndex = activeDrag.startIndices[0]
+    const oldIndexes = [...activeDrag.startIndices]
+    const toZone = pending?.zone ?? activeDrag.fromZone
+    const newIndex = pending?.index ?? oldIndex
+    const newIndexes = pending
+      ? activeDrag.items.map((_, i) => pending.index + i)
+      : oldIndexes
+    const isDifferentZone = toZone !== activeDrag.fromZone
+
+    const base = {
+      item: activeDrag.items[0],
+      items: activeDrag.items,
+      from: activeDrag.fromZone,
+      to: toZone,
+      oldIndex,
+      newIndex,
+      oldIndexes,
+      newIndexes,
+    }
+
+    if (isDifferentZone) {
+      const isClone = activeDrag.pullMode === 'clone'
+      const pullMode = isClone
+        ? ('clone' as const)
+        : activeDrag.pullMode || true
+      if (isClone) {
+        // No clone node exists in controlled mode — the event reports the
+        // intent and the consumer's state insert IS the clone.
+        activeDrag.eventSystem.emit('clone', { ...base, pullMode })
+      } else {
+        activeDrag.eventSystem.emit('remove', { ...base, pullMode })
+      }
+      // Fire add on the target's event system (skip if the placeholder
+      // ended somewhere we never registered — shouldn't happen, but don't
+      // emit into the wrong list's handlers).
+      const targetEvents =
+        putTarget && putTarget.zone === toZone
+          ? putTarget.dragManager.events
+          : null
+      if (targetEvents && targetEvents !== activeDrag.eventSystem) {
+        targetEvents.emit('add', { ...base, pullMode })
+      }
+    }
+
+    activeDrag.eventSystem.emit('unchoose', { ...base, newIndex: -1 })
+    activeDrag.eventSystem.emit('end', base)
   }
 
   /** Check if a specific drag can be accepted by a group */

--- a/src/core/KeyboardManager.ts
+++ b/src/core/KeyboardManager.ts
@@ -2,6 +2,8 @@ import { SelectionManager } from './SelectionManager.js'
 import { DropZone } from './DropZone.js'
 import { SortableEventSystem } from './EventSystem.js'
 import { globalDragState } from './GlobalDragState.js'
+import { GhostManager } from './GhostManager.js'
+import { hideControlled, restoreControlledHidden } from '../utils/dom.js'
 
 /**
  * Handles keyboard navigation and operations for sortable lists
@@ -18,16 +20,30 @@ export class KeyboardManager {
   private multiDrag: boolean
   private onDocumentClick: ((e: MouseEvent) => void) | null = null
 
+  // Controlled mode (see the `controlled` option): grabbed items are hidden
+  // in place and the placeholder is what arrow keys move; endDrag emits the
+  // intent from pending state.
+  private controlled: boolean
+  private ghostManager?: GhostManager
+  private hiddenDisplays: Map<HTMLElement, string> | null = null
+
   constructor(
     private container: HTMLElement,
     private zone: DropZone,
     private selectionManager: SelectionManager,
     private events: SortableEventSystem,
     private groupName: string,
-    options?: { deselectOnClickOutside?: boolean; multiDrag?: boolean }
+    options?: {
+      deselectOnClickOutside?: boolean
+      multiDrag?: boolean
+      controlled?: boolean
+      ghostManager?: GhostManager
+    }
   ) {
     this.deselectOnClickOutside = options?.deselectOnClickOutside ?? true
     this.multiDrag = options?.multiDrag ?? false
+    this.controlled = options?.controlled ?? false
+    this.ghostManager = options?.ghostManager
     this.setupAnnouncer()
   }
 
@@ -318,8 +334,19 @@ export class KeyboardManager {
       { zone: this.zone, events: this.events },
       this.groupName,
       this.originalIndices,
-      this.events
+      this.events,
+      this.controlled
     )
+
+    if (this.controlled && this.ghostManager) {
+      const anchor = selected[0]
+      const placeholder = this.ghostManager.createPlaceholder(anchor)
+      anchor.parentElement?.insertBefore(placeholder, anchor)
+      this.hiddenDisplays = hideControlled(selected)
+      // display:none drops focus from the grabbed item — park focus on the
+      // container so arrow keys keep reaching our keydown listener.
+      this.container.focus()
+    }
 
     // Emit start event
     this.events.emit('start', {
@@ -348,6 +375,31 @@ export class KeyboardManager {
       item.classList.remove('sortable-grabbing')
       item.setAttribute('aria-grabbed', 'false')
     })
+
+    if (this.controlled) {
+      const anchor = this.grabbedItems[0]
+      const count = this.grabbedItems.length
+      const pending = globalDragState.getPending('keyboard-drag')
+      // Restore the consumer's DOM BEFORE endDrag emits the intent events.
+      this.ghostManager?.destroyPlaceholder()
+      if (this.hiddenDisplays) {
+        restoreControlledHidden(this.hiddenDisplays)
+        this.hiddenDisplays = null
+      }
+      // endDrag emits unchoose + end from pending (intent-only).
+      globalDragState.endDrag('keyboard-drag')
+      // Best-effort refocus; a framework adapter re-focuses by data-id
+      // after its re-render replaces the node.
+      anchor?.focus()
+      this.announce(
+        `Dropped ${count} item${count > 1 ? 's' : ''} at position ${(pending?.index ?? 0) + 1}`
+      )
+      this.isGrabbing = false
+      this.grabbedItems = []
+      this.originalIndices = []
+      this.updateItemAttributes()
+      return
+    }
 
     // Get final position before cleanup
     const newIndex = this.zone.getIndex(this.grabbedItems[0])
@@ -396,6 +448,29 @@ export class KeyboardManager {
   private cancelGrab(): void {
     if (!this.isGrabbing) return
 
+    if (this.controlled) {
+      const anchor = this.grabbedItems[0]
+      this.grabbedItems.forEach((item) => {
+        item.classList.remove('sortable-grabbing')
+        item.setAttribute('aria-grabbed', 'false')
+      })
+      this.ghostManager?.destroyPlaceholder()
+      if (this.hiddenDisplays) {
+        restoreControlledHidden(this.hiddenDisplays)
+        this.hiddenDisplays = null
+      }
+      // Cleared pending → end reports newIndex = oldIndex (a no-op commit).
+      globalDragState.clearPending('keyboard-drag')
+      globalDragState.endDrag('keyboard-drag')
+      anchor?.focus()
+      this.announce('Move cancelled')
+      this.isGrabbing = false
+      this.grabbedItems = []
+      this.originalIndices = []
+      this.updateItemAttributes()
+      return
+    }
+
     // Restore original positions
     this.grabbedItems.forEach((item, i) => {
       const currentIndex = this.zone.getIndex(item)
@@ -424,10 +499,43 @@ export class KeyboardManager {
   }
 
   /**
+   * Controlled mode: arrow keys move the placeholder one visible position;
+   * grabbed items stay hidden in place. Pending records the intent.
+   */
+  private moveGrabbedControlled(delta: -1 | 1): void {
+    const placeholder = this.ghostManager?.getPlaceholderElement()
+    if (!placeholder || placeholder.parentElement !== this.container) return
+
+    const visible = this.zone.getVisibleItems(this.grabbedItems)
+    const current = this.zone.getControlledIndex(placeholder, this.grabbedItems)
+
+    if (delta === 1) {
+      if (current >= visible.length) return
+      this.container.insertBefore(placeholder, visible[current].nextSibling)
+    } else {
+      if (current <= 0) return
+      this.container.insertBefore(placeholder, visible[current - 1])
+    }
+
+    const index = current + delta
+    globalDragState.setPending('keyboard-drag', {
+      zone: this.container,
+      index,
+    })
+    this.announce(`Moved to position ${index + 1}`)
+    this.updateItemAttributes()
+  }
+
+  /**
    * Move grabbed items up
    */
   private moveGrabbedUp(): void {
     if (!this.isGrabbing || this.grabbedItems.length === 0) return
+
+    if (this.controlled) {
+      this.moveGrabbedControlled(-1)
+      return
+    }
 
     const firstItem = this.grabbedItems[0]
     const currentIndex = this.zone.getIndex(firstItem)
@@ -457,6 +565,11 @@ export class KeyboardManager {
    */
   private moveGrabbedDown(): void {
     if (!this.isGrabbing || this.grabbedItems.length === 0) return
+
+    if (this.controlled) {
+      this.moveGrabbedControlled(1)
+      return
+    }
 
     const lastItem = this.grabbedItems[this.grabbedItems.length - 1]
     const currentIndex = this.zone.getIndex(lastItem)

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export {
 export { SelectionManager } from './core/SelectionManager.js'
 export { KeyboardManager } from './core/KeyboardManager.js'
 export { GroupManager } from './core/GroupManager.js'
+export { GhostManager, type CreateGhostOptions } from './core/GhostManager.js'
 export { AnimationManager } from './animation/AnimationManager.js'
 
 // WeakMap to track Sortable instances by their elements
@@ -307,48 +308,7 @@ export class Sortable {
       this.dropZone,
       this.eventSystem,
       this.options.group,
-      {
-        enableAccessibility: this.options.enableAccessibility,
-        multiSelect: this.options.multiDrag,
-        selectedClass: this.options.selectedClass,
-        focusClass: this.options.focusClass,
-        handle: this.options.handle,
-        filter: this.options.filter,
-        onFilter: this.options.onFilter,
-        ignore: this.options.ignore,
-        draggable: this.options.draggable,
-        delay: this.options.delay,
-        delayOnTouchOnly: this.options.delayOnTouchOnly,
-        touchStartThreshold: this.options.touchStartThreshold,
-        swapThreshold: this.options.swapThreshold,
-        invertSwap: this.options.invertSwap,
-        invertedSwapThreshold: this.options.invertedSwapThreshold,
-        direction: this.options.direction,
-        forceFallback: this.options.forceFallback,
-        fallbackClass: this.options.fallbackClass,
-        fallbackOnBody: this.options.fallbackOnBody,
-        fallbackTolerance: this.options.fallbackTolerance,
-        fallbackOffsetX: this.options.fallbackOffsetX,
-        fallbackOffsetY: this.options.fallbackOffsetY,
-        dragoverBubble: this.options.dragoverBubble,
-        dropBubble: this.options.dropBubble,
-        removeCloneOnHide: this.options.removeCloneOnHide,
-        emptyInsertThreshold: this.options.emptyInsertThreshold,
-        preventOnFilter: this.options.preventOnFilter,
-        dataIdAttr: this.options.dataIdAttr,
-        ghostClass: this.options.ghostClass,
-        chosenClass: this.options.chosenClass,
-        dragClass: this.options.dragClass,
-        deselectOnClickOutside: this.options.deselectOnClickOutside,
-        setData: this.options.setData,
-        // `onMove` is threaded directly into DragManager — unlike the other
-        // option callbacks which subscribe to the `EventSystem`, `onMove`
-        // controls cancellation / insert-side override via its return value
-        // (`false` / `-1` / `1`). The event-system can only propagate, not
-        // collect a return, so we wire it through the option bag instead.
-        // See #33.
-        onMove: this.options.onMove,
-      }
+      this.buildDragManagerOptions()
     )
     this.dragManager.attach()
 
@@ -420,12 +380,69 @@ export class Sortable {
       })
     }
 
-    // Restore order from store on initialization
-    if (this.options.store?.get) {
+    // Restore order from store on initialization (controlled mode: order is
+    // consumer state — sort() would warn-and-no-op, so skip entirely)
+    if (this.options.store?.get && !this.options.controlled) {
       const order = this.options.store.get(this)
       if (order && order.length > 0) {
         this.sort(order, false)
       }
+    }
+  }
+
+  /**
+   * The single source of truth for the DragManager option bag. Used by the
+   * constructor and both runtime-rebuild paths in `option()` — previously
+   * three hand-maintained copies that had drifted (the rebuilds silently
+   * dropped `setData`, `onMove`, `dataIdAttr`, `preventOnFilter`,
+   * `emptyInsertThreshold`, `dragoverBubble`, `dropBubble`,
+   * `removeCloneOnHide`).
+   */
+  private buildDragManagerOptions(): ConstructorParameters<
+    typeof DragManager
+  >[3] {
+    return {
+      enableAccessibility: this.options.enableAccessibility,
+      multiSelect: this.options.multiDrag,
+      selectedClass: this.options.selectedClass,
+      focusClass: this.options.focusClass,
+      handle: this.options.handle,
+      filter: this.options.filter,
+      onFilter: this.options.onFilter,
+      ignore: this.options.ignore,
+      draggable: this.options.draggable,
+      delay: this.options.delay,
+      delayOnTouchOnly: this.options.delayOnTouchOnly,
+      touchStartThreshold: this.options.touchStartThreshold,
+      swapThreshold: this.options.swapThreshold,
+      invertSwap: this.options.invertSwap,
+      invertedSwapThreshold: this.options.invertedSwapThreshold,
+      direction: this.options.direction,
+      forceFallback: this.options.forceFallback,
+      fallbackClass: this.options.fallbackClass,
+      fallbackOnBody: this.options.fallbackOnBody,
+      fallbackTolerance: this.options.fallbackTolerance,
+      fallbackOffsetX: this.options.fallbackOffsetX,
+      fallbackOffsetY: this.options.fallbackOffsetY,
+      dragoverBubble: this.options.dragoverBubble,
+      dropBubble: this.options.dropBubble,
+      removeCloneOnHide: this.options.removeCloneOnHide,
+      emptyInsertThreshold: this.options.emptyInsertThreshold,
+      preventOnFilter: this.options.preventOnFilter,
+      dataIdAttr: this.options.dataIdAttr,
+      ghostClass: this.options.ghostClass,
+      chosenClass: this.options.chosenClass,
+      dragClass: this.options.dragClass,
+      deselectOnClickOutside: this.options.deselectOnClickOutside,
+      setData: this.options.setData,
+      // `onMove` is threaded directly into DragManager — unlike the other
+      // option callbacks which subscribe to the `EventSystem`, `onMove`
+      // controls cancellation / insert-side override via its return value
+      // (`false` / `-1` / `1`). The event-system can only propagate, not
+      // collect a return, so we wire it through the option bag instead.
+      // See #33.
+      onMove: this.options.onMove,
+      controlled: this.options.controlled,
     }
   }
 
@@ -574,6 +591,13 @@ export class Sortable {
    * @public
    */
   public sort(order: string[], useAnimation = true): void {
+    if (this.options.controlled) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[resortable] sort() is a no-op in controlled mode — order is consumer state'
+      )
+      return
+    }
     const dataIdAttr = this.options.dataIdAttr ?? 'data-id'
     const items = Array.from(this.element.children) as HTMLElement[]
 
@@ -720,34 +744,7 @@ export class Sortable {
           this.dropZone,
           this.eventSystem,
           this.options.group,
-          {
-            enableAccessibility: this.options.enableAccessibility,
-            multiSelect: this.options.multiDrag,
-            selectedClass: this.options.selectedClass,
-            focusClass: this.options.focusClass,
-            handle: this.options.handle,
-            filter: this.options.filter,
-            onFilter: this.options.onFilter,
-            ignore: this.options.ignore,
-            draggable: this.options.draggable,
-            delay: this.options.delay,
-            delayOnTouchOnly: this.options.delayOnTouchOnly,
-            touchStartThreshold: this.options.touchStartThreshold,
-            swapThreshold: this.options.swapThreshold,
-            invertSwap: this.options.invertSwap,
-            invertedSwapThreshold: this.options.invertedSwapThreshold,
-            direction: this.options.direction,
-            forceFallback: this.options.forceFallback,
-            fallbackClass: this.options.fallbackClass,
-            fallbackOnBody: this.options.fallbackOnBody,
-            fallbackTolerance: this.options.fallbackTolerance,
-            fallbackOffsetX: this.options.fallbackOffsetX,
-            fallbackOffsetY: this.options.fallbackOffsetY,
-            ghostClass: this.options.ghostClass,
-            chosenClass: this.options.chosenClass,
-            dragClass: this.options.dragClass,
-            deselectOnClickOutside: this.options.deselectOnClickOutside,
-          }
+          this.buildDragManagerOptions()
         )
         this.dragManager.attach()
         break
@@ -755,39 +752,13 @@ export class Sortable {
 
       case 'group':
         // Re-create drag manager with new group configuration
+        // (`this.options.group` was already updated above the switch).
         this.dragManager.detach()
         this.dragManager = new DragManager(
           this.dropZone,
           this.eventSystem,
-          value as SortableOptions['group'],
-          {
-            enableAccessibility: this.options.enableAccessibility,
-            multiSelect: this.options.multiDrag,
-            selectedClass: this.options.selectedClass,
-            focusClass: this.options.focusClass,
-            handle: this.options.handle,
-            filter: this.options.filter,
-            onFilter: this.options.onFilter,
-            ignore: this.options.ignore,
-            draggable: this.options.draggable,
-            delay: this.options.delay,
-            delayOnTouchOnly: this.options.delayOnTouchOnly,
-            touchStartThreshold: this.options.touchStartThreshold,
-            swapThreshold: this.options.swapThreshold,
-            invertSwap: this.options.invertSwap,
-            invertedSwapThreshold: this.options.invertedSwapThreshold,
-            direction: this.options.direction,
-            forceFallback: this.options.forceFallback,
-            fallbackClass: this.options.fallbackClass,
-            fallbackOnBody: this.options.fallbackOnBody,
-            fallbackTolerance: this.options.fallbackTolerance,
-            fallbackOffsetX: this.options.fallbackOffsetX,
-            fallbackOffsetY: this.options.fallbackOffsetY,
-            ghostClass: this.options.ghostClass,
-            chosenClass: this.options.chosenClass,
-            dragClass: this.options.dragClass,
-            deselectOnClickOutside: this.options.deselectOnClickOutside,
-          }
+          this.options.group,
+          this.buildDragManagerOptions()
         )
         this.dragManager.attach()
         break
@@ -840,6 +811,7 @@ const defaultOptions: SortableOptions = {
   group: 'default',
   sort: true,
   disabled: false,
+  controlled: false,
   multiDrag: false,
   enableAccessibility: true,
   selectedClass: 'sortable-selected',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -120,6 +120,28 @@ export interface SortableOptions {
   sort?: boolean
 
   /**
+   * Controlled (framework-friendly) mode
+   *
+   * @remarks
+   * When `true`, the library NEVER changes the structural position of
+   * consumer-owned nodes. During a drag it only manages its own overlay
+   * ghost, a single placeholder element, and hide/show styling on the
+   * dragged items. When `end` (and `add`/`remove`/`update`) fire, the DOM
+   * structure is identical to pre-drag; the events carry the full intent
+   * (including {@link SortableEvent.oldIndexes} / {@link SortableEvent.newIndexes})
+   * and the consumer commits it by updating state and re-rendering.
+   *
+   * Designed for declarative frameworks (React, Vue, Svelte) that own the
+   * list DOM. See `docs/plans/2026-07-09-controlled-mode-design.md`.
+   *
+   * Note: `sort()` and `store` are no-ops in controlled mode — order is
+   * consumer state.
+   *
+   * @defaultValue false
+   */
+  controlled?: boolean
+
+  /**
    * Whether the sortable is disabled
    * @defaultValue false
    */
@@ -663,6 +685,25 @@ export interface SortableEvent {
    * Array of selected elements (multi-drag mode)
    */
   items: HTMLElement[]
+
+  /**
+   * Per-item indices in `from` at drag start, parallel to `items`
+   *
+   * @remarks
+   * Only populated in controlled mode (see the `controlled` option).
+   * Named `-Indexes` deliberately — NOT legacy MultiDrag's misspelled
+   * `oldIndicies`.
+   */
+  oldIndexes?: number[]
+
+  /**
+   * Per-item indices in `to` after the consumer commits the move,
+   * parallel to `items` (contiguous block starting at the drop index)
+   *
+   * @remarks
+   * Only populated in controlled mode (see the `controlled` option).
+   */
+  newIndexes?: number[]
 }
 
 /**

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -104,3 +104,33 @@ export function toArray(parent: HTMLElement, dataIdAttr = 'data-id'): string[] {
     return el.dataset[attrName] ?? el.getAttribute(dataIdAttr) ?? String(i)
   })
 }
+
+/**
+ * CSS class marking items hidden for an active controlled-mode drag.
+ * Index math (DropZone.getControlledIndex) excludes items carrying it.
+ */
+export const CONTROLLED_HIDDEN_CLASS = 'sortable-controlled-hidden'
+
+/**
+ * Hide elements for a controlled-mode drag (visual removal without touching
+ * their structural position). Returns the original inline `display` values
+ * so {@link restoreControlledHidden} can put them back exactly.
+ */
+export function hideControlled(items: HTMLElement[]): Map<HTMLElement, string> {
+  const saved = new Map<HTMLElement, string>()
+  for (const item of items) {
+    saved.set(item, item.style.display)
+    item.classList.add(CONTROLLED_HIDDEN_CLASS)
+    item.style.display = 'none'
+  }
+  return saved
+}
+
+/** Restore elements hidden by {@link hideControlled}. */
+export function restoreControlledHidden(saved: Map<HTMLElement, string>): void {
+  saved.forEach((display, item) => {
+    item.classList.remove(CONTROLLED_HIDDEN_CLASS)
+    item.style.display = display
+  })
+  saved.clear()
+}

--- a/tests/unit/controlled-mode.spec.ts
+++ b/tests/unit/controlled-mode.spec.ts
@@ -1,0 +1,406 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { Sortable } from '../../src/index'
+import type { SortableEvent } from '../../src/types/index'
+
+/**
+ * Controlled mode (`controlled: true`) — the library never structurally
+ * moves consumer-owned nodes. See docs/plans/2026-07-09-controlled-mode-design.md.
+ *
+ * THE invariant asserted throughout: when `end` / `add` / `remove` fire, the
+ * container's DOM is byte-identical to its pre-drag state; the events carry
+ * the intent (`oldIndex(es)` / `newIndex(es)`) instead.
+ *
+ * We drive the HTML5 pipeline (jsdom dispatches drag events synchronously)
+ * and the keyboard pipeline. The pointer pipeline shares
+ * `handleControlledMove` with HTML5 and gets geometry-real coverage in e2e.
+ */
+
+function createContainer(id: string, count = 4): HTMLElement {
+  const container = document.createElement('div')
+  container.id = id
+  for (let i = 1; i <= count; i++) {
+    const el = document.createElement('div')
+    el.className = 'sortable-item'
+    el.dataset.id = `${id}-${i}`
+    el.textContent = `Item ${i}`
+    container.appendChild(el)
+  }
+  document.body.appendChild(container)
+  return container
+}
+
+function makeDragEvent(type: string, init: DragEventInit = {}): DragEvent {
+  try {
+    return new DragEvent(type, { bubbles: true, cancelable: true, ...init })
+  } catch {
+    return new Event(type, { bubbles: true, cancelable: true }) as DragEvent
+  }
+}
+
+function ids(container: HTMLElement): string[] {
+  return Array.from(container.querySelectorAll('.sortable-item')).map(
+    (el) => (el as HTMLElement).dataset.id ?? ''
+  )
+}
+
+/** Full same-zone HTML5 drag: item → dragover target → drop → dragend */
+function html5Drag(item: HTMLElement, overTarget: HTMLElement): void {
+  item.dispatchEvent(makeDragEvent('dragstart'))
+  overTarget.dispatchEvent(makeDragEvent('dragover'))
+  overTarget.dispatchEvent(makeDragEvent('drop'))
+  item.dispatchEvent(makeDragEvent('dragend'))
+}
+
+describe('controlled mode', () => {
+  let container: HTMLElement
+  let sortable: Sortable
+  let others: Sortable[]
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    container = createContainer('list')
+    others = []
+  })
+
+  afterEach(() => {
+    sortable?.destroy()
+    others.forEach((s) => s.destroy())
+  })
+
+  describe('HTML5 pipeline, same list', () => {
+    it('never mutates consumer DOM: order identical at end-event time and after the drag', () => {
+      const domAtEnd: string[][] = []
+      sortable = new Sortable(container, {
+        animation: 0,
+        controlled: true,
+        onEnd: () => domAtEnd.push(ids(container)),
+      })
+      const before = ids(container)
+
+      const item1 = container.children[0] as HTMLElement
+      const item3 = container.children[3] as HTMLElement
+      html5Drag(item1, item3)
+
+      expect(domAtEnd).toEqual([before])
+      expect(ids(container)).toEqual(before)
+      // No placeholder or hidden-item residue
+      expect(
+        container.querySelector('[data-resortable-placeholder]')
+      ).toBeNull()
+      expect(container.querySelector('.sortable-controlled-hidden')).toBeNull()
+    })
+
+    it('end carries the intent: oldIndex/newIndex + oldIndexes/newIndexes', () => {
+      const onEnd = vi.fn<(evt: SortableEvent) => void>()
+      sortable = new Sortable(container, {
+        animation: 0,
+        controlled: true,
+        onEnd,
+      })
+
+      const item1 = container.children[0] as HTMLElement
+      const item3 = container.children[3] as HTMLElement // data-id list-4? index 3 → 'list-4'... children[3] is item 4
+      html5Drag(item1, item3)
+
+      expect(onEnd).toHaveBeenCalledTimes(1)
+      const evt = onEnd.mock.calls[0][0]
+      expect(evt.oldIndex).toBe(0)
+      // Placeholder ends after children[3] hmm — inserted before/after by drag direction
+      expect(evt.newIndex).toBeGreaterThan(0)
+      expect(evt.oldIndexes).toEqual([0])
+      expect(evt.newIndexes).toEqual([evt.newIndex])
+      expect(evt.from).toBe(container)
+      expect(evt.to).toBe(container)
+    })
+
+    it('mid-drag placeholder is marked and gone by dragend', () => {
+      sortable = new Sortable(container, { animation: 0, controlled: true })
+      const item1 = container.children[0] as HTMLElement
+      const item3 = container.children[2] as HTMLElement
+
+      item1.dispatchEvent(makeDragEvent('dragstart'))
+      expect(
+        container.querySelector('[data-resortable-placeholder]')
+      ).not.toBeNull()
+
+      item3.dispatchEvent(makeDragEvent('dragover'))
+      item3.dispatchEvent(makeDragEvent('drop'))
+      item1.dispatchEvent(makeDragEvent('dragend'))
+      expect(document.querySelector('[data-resortable-placeholder]')).toBeNull()
+    })
+
+    it('dragend without drop = cancel: newIndex equals oldIndex', () => {
+      const onEnd = vi.fn<(evt: SortableEvent) => void>()
+      sortable = new Sortable(container, {
+        animation: 0,
+        controlled: true,
+        onEnd,
+      })
+      const item1 = container.children[0] as HTMLElement
+      const item3 = container.children[2] as HTMLElement
+
+      item1.dispatchEvent(makeDragEvent('dragstart'))
+      item3.dispatchEvent(makeDragEvent('dragover'))
+      // No drop — e.g. Escape / released outside
+      item1.dispatchEvent(makeDragEvent('dragend'))
+
+      const evt = onEnd.mock.calls[0][0]
+      expect(evt.newIndex).toBe(evt.oldIndex)
+      expect(ids(container)).toEqual(['list-1', 'list-2', 'list-3', 'list-4'])
+    })
+
+    it('onMove returning false cancels the placeholder move', () => {
+      const onEnd = vi.fn<(evt: SortableEvent) => void>()
+      const onUpdate = vi.fn()
+      sortable = new Sortable(container, {
+        animation: 0,
+        controlled: true,
+        onMove: () => false,
+        onUpdate,
+        onEnd,
+      })
+      const item1 = container.children[0] as HTMLElement
+      const item3 = container.children[2] as HTMLElement
+      html5Drag(item1, item3)
+
+      expect(onUpdate).not.toHaveBeenCalled()
+      const evt = onEnd.mock.calls[0][0]
+      expect(evt.newIndex).toBe(evt.oldIndex)
+    })
+
+    it('emits mid-drag update/sort/change with pending indices (HTML5 parity)', () => {
+      const onUpdate = vi.fn<(evt: SortableEvent) => void>()
+      const onSort = vi.fn()
+      const onChange = vi.fn()
+      sortable = new Sortable(container, {
+        animation: 0,
+        controlled: true,
+        onUpdate,
+        onSort,
+        onChange,
+      })
+      const item1 = container.children[0] as HTMLElement
+      const item3 = container.children[2] as HTMLElement
+
+      item1.dispatchEvent(makeDragEvent('dragstart'))
+      item3.dispatchEvent(makeDragEvent('dragover'))
+
+      expect(onSort).toHaveBeenCalled()
+      expect(onUpdate).toHaveBeenCalled()
+      expect(onChange).toHaveBeenCalled()
+      const evt = onUpdate.mock.calls[0][0]
+      expect(evt.oldIndex).toBe(0)
+      expect(evt.newIndex).toBe(2) // placeholder lands after item-3 (index 2 excl. dragged)
+      // Cleanup
+      item1.dispatchEvent(makeDragEvent('dragend'))
+    })
+  })
+
+  describe('HTML5 pipeline, cross-list', () => {
+    let target: HTMLElement
+    let targetSortable: Sortable
+
+    beforeEach(() => {
+      target = createContainer('other', 3)
+    })
+
+    type EventMock = ReturnType<typeof vi.fn<(evt: SortableEvent) => void>>
+
+    function makePair(
+      sourceGroup: unknown = 'shared',
+      targetGroup: unknown = 'shared'
+    ): {
+      onAdd: EventMock
+      onRemove: EventMock
+      onEnd: EventMock
+      onClone: EventMock
+    } {
+      const onAdd = vi.fn<(evt: SortableEvent) => void>()
+      const onRemove = vi.fn<(evt: SortableEvent) => void>()
+      const onEnd = vi.fn<(evt: SortableEvent) => void>()
+      const onClone = vi.fn<(evt: SortableEvent) => void>()
+      sortable = new Sortable(container, {
+        animation: 0,
+        controlled: true,
+        group: sourceGroup as never,
+        onRemove,
+        onEnd,
+        onClone,
+      })
+      targetSortable = new Sortable(target, {
+        animation: 0,
+        controlled: true,
+        group: targetGroup as never,
+        onAdd,
+      })
+      others.push(targetSortable)
+      return { onAdd, onRemove, onEnd, onClone }
+    }
+
+    it('move between lists: remove/add/end carry intent, both DOMs untouched', () => {
+      const { onAdd, onRemove, onEnd } = makePair()
+      const sourceBefore = ids(container)
+      const targetBefore = ids(target)
+
+      const item2 = container.children[1] as HTMLElement
+      const targetItem2 = target.children[1] as HTMLElement
+
+      item2.dispatchEvent(makeDragEvent('dragstart'))
+      targetItem2.dispatchEvent(makeDragEvent('dragover'))
+      targetItem2.dispatchEvent(makeDragEvent('drop'))
+      item2.dispatchEvent(makeDragEvent('dragend'))
+
+      // DOM invariant on both sides
+      expect(ids(container)).toEqual(sourceBefore)
+      expect(ids(target)).toEqual(targetBefore)
+
+      expect(onRemove).toHaveBeenCalledTimes(1)
+      expect(onAdd).toHaveBeenCalledTimes(1)
+      const removeEvt = onRemove.mock.calls[0][0]
+      expect(removeEvt.from).toBe(container)
+      expect(removeEvt.to).toBe(target)
+      expect(removeEvt.oldIndex).toBe(1)
+      expect(removeEvt.newIndex).toBe(1) // placeholder inserted before target item 2
+      expect(removeEvt.oldIndexes).toEqual([1])
+      expect(removeEvt.newIndexes).toEqual([1])
+
+      const addEvt = onAdd.mock.calls[0][0]
+      expect(addEvt.to).toBe(target)
+      expect(addEvt.newIndex).toBe(1)
+
+      const endEvt = onEnd.mock.calls[0][0]
+      expect(endEvt.to).toBe(target)
+      expect(endEvt.newIndex).toBe(1)
+    })
+
+    it('clone mode creates no clone node; clone + add report pullMode clone', () => {
+      const { onAdd, onRemove, onClone } = makePair(
+        { name: 'shared', pull: 'clone' },
+        'shared'
+      )
+
+      const item1 = container.children[0] as HTMLElement
+      const targetItem1 = target.children[0] as HTMLElement
+
+      item1.dispatchEvent(makeDragEvent('dragstart'))
+      targetItem1.dispatchEvent(makeDragEvent('dragover'))
+      targetItem1.dispatchEvent(makeDragEvent('drop'))
+      item1.dispatchEvent(makeDragEvent('dragend'))
+
+      // No clone node materialized anywhere
+      expect(ids(container)).toEqual(['list-1', 'list-2', 'list-3', 'list-4'])
+      expect(ids(target)).toEqual(['other-1', 'other-2', 'other-3'])
+
+      expect(onClone).toHaveBeenCalledTimes(1)
+      expect(onClone.mock.calls[0][0].pullMode).toBe('clone')
+      expect(onRemove).not.toHaveBeenCalled()
+      expect(onAdd).toHaveBeenCalledTimes(1)
+      expect(onAdd.mock.calls[0][0].pullMode).toBe('clone')
+    })
+  })
+
+  describe('keyboard pipeline', () => {
+    function press(el: HTMLElement, key: string): void {
+      el.dispatchEvent(
+        new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+      )
+    }
+
+    it('grab → ArrowDown → Enter emits intent; DOM untouched', () => {
+      const onEnd = vi.fn<(evt: SortableEvent) => void>()
+      const domAtEnd: string[][] = []
+      sortable = new Sortable(container, {
+        animation: 0,
+        controlled: true,
+        onEnd: (evt) => {
+          onEnd(evt)
+          domAtEnd.push(ids(container))
+        },
+      })
+      const before = ids(container)
+      const item2 = container.children[1] as HTMLElement
+
+      item2.dispatchEvent(new MouseEvent('click', { bubbles: true })) // select + focus
+      press(item2, 'Enter') // grab
+      press(container, 'ArrowDown')
+      press(container, 'Enter') // drop
+
+      expect(onEnd).toHaveBeenCalledTimes(1)
+      const evt = onEnd.mock.calls[0][0]
+      expect(evt.oldIndex).toBe(1)
+      expect(evt.newIndex).toBe(2)
+      expect(evt.oldIndexes).toEqual([1])
+      expect(evt.newIndexes).toEqual([2])
+      expect(domAtEnd).toEqual([before])
+      expect(ids(container)).toEqual(before)
+      expect(
+        container.querySelector('[data-resortable-placeholder]')
+      ).toBeNull()
+      expect(container.querySelector('.sortable-controlled-hidden')).toBeNull()
+    })
+
+    it('Escape cancels: newIndex equals oldIndex, DOM untouched', () => {
+      const onEnd = vi.fn<(evt: SortableEvent) => void>()
+      sortable = new Sortable(container, {
+        animation: 0,
+        controlled: true,
+        onEnd,
+      })
+      const before = ids(container)
+      const item2 = container.children[1] as HTMLElement
+
+      item2.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      press(item2, 'Enter')
+      press(container, 'ArrowDown')
+      press(container, 'Escape')
+
+      const evt = onEnd.mock.calls[0][0]
+      expect(evt.newIndex).toBe(evt.oldIndex)
+      expect(ids(container)).toEqual(before)
+      expect(container.querySelector('.sortable-controlled-hidden')).toBeNull()
+    })
+
+    it('multi-drag: contiguous newIndexes for multiple grabbed items', () => {
+      const onEnd = vi.fn<(evt: SortableEvent) => void>()
+      sortable = new Sortable(container, {
+        animation: 0,
+        controlled: true,
+        multiDrag: true,
+        onEnd,
+      })
+      const item1 = container.children[0] as HTMLElement
+      const item2 = container.children[1] as HTMLElement
+
+      // multiDrag plain click toggles additively
+      item1.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      item2.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      press(item2, 'Enter') // grab both
+      press(container, 'ArrowDown')
+      press(container, 'Enter')
+
+      const evt = onEnd.mock.calls[0][0]
+      expect(evt.items).toHaveLength(2)
+      expect(evt.oldIndexes).toEqual([0, 1])
+      const newIndex = evt.newIndex ?? -1
+      expect(newIndex).toBeGreaterThanOrEqual(0)
+      expect(evt.newIndexes).toEqual([newIndex, newIndex + 1])
+      expect(ids(container)).toEqual(['list-1', 'list-2', 'list-3', 'list-4'])
+    })
+  })
+
+  describe('imperative API guards', () => {
+    it('sort() is a warned no-op in controlled mode', () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      sortable = new Sortable(container, { animation: 0, controlled: true })
+      const before = ids(container)
+
+      sortable.sort(['list-4', 'list-3', 'list-2', 'list-1'])
+
+      expect(ids(container)).toEqual(before)
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('controlled mode')
+      )
+      warn.mockRestore()
+    })
+  })
+})

--- a/tests/unit/controlled-mode.spec.ts
+++ b/tests/unit/controlled-mode.spec.ts
@@ -99,14 +99,15 @@ describe('controlled mode', () => {
       })
 
       const item1 = container.children[0] as HTMLElement
-      const item3 = container.children[3] as HTMLElement // data-id list-4? index 3 → 'list-4'... children[3] is item 4
-      html5Drag(item1, item3)
+      const item4 = container.children[3] as HTMLElement // data-id 'list-4'
+      html5Drag(item1, item4)
 
       expect(onEnd).toHaveBeenCalledTimes(1)
       const evt = onEnd.mock.calls[0][0]
       expect(evt.oldIndex).toBe(0)
-      // Placeholder ends after children[3] hmm — inserted before/after by drag direction
-      expect(evt.newIndex).toBeGreaterThan(0)
+      // Dragging down: placeholder lands after item4 — index 3 among the
+      // remaining draggables (list-2, list-3, list-4).
+      expect(evt.newIndex).toBe(3)
       expect(evt.oldIndexes).toEqual([0])
       expect(evt.newIndexes).toEqual([evt.newIndex])
       expect(evt.from).toBe(container)


### PR DESCRIPTION
## Summary

Implements the controlled-mode design (#104): with `controlled: true`, the library never structurally moves consumer-owned nodes. Only the placeholder travels during a drag; dragged items are hidden in place; `end`/`add`/`remove`/`clone` carry the full intent (new `oldIndexes`/`newIndexes` arrays) computed from pending state, and the consumer commits by re-rendering. This is the foundation for the React adapter (#44) — adapter design doc included as a follow-on plan.

## How it works

- **Shared `handleControlledMove`** drives both pipelines. HTML5 commits pending only in `onDrop` (dragend without drop = cancel, reports `newIndex === oldIndex`); pointer commits live since pointerup IS the drop.
- **DOM restored before events fire** — a synchronous `setState` in an `end` handler re-renders against clean DOM. Asserted in tests via innerHTML-order checks at emission time.
- **Keyboard** grab/arrow/drop is placeholder-based; focus parks on the container while items are `display:none` (hiding a focused element drops focus).
- **Clone mode** never materializes clone nodes — `pullMode: 'clone'` reports the intent.
- **`onMove` cancellation/override** (`false`/`-1`/`1`) preserved, dispatched on the source sortable (legacy parity).
- `sort()`/`store` are warned no-ops in controlled mode.

## Also in this PR

- Extracted `buildDragManagerOptions()` in `Sortable` — the constructor and both runtime-rebuild paths had drifted; rebuilds silently dropped `setData`, `onMove`, `dataIdAttr`, `preventOnFilter`, `emptyInsertThreshold`, `dragoverBubble`, `dropBubble`, `removeCloneOnHide`.
- `docs/plans/2026-07-09-react-adapter-design.md` — `resortable/react` follow-on design.

## Known follow-ups (not this PR)

- `SelectionManager`/`KeyboardManager` hardcode `.sortable-item` instead of honoring the `draggable` option — pre-existing, blocks custom selectors for keyboard/selection; needed before real-world adoption.
- Controlled-mode e2e specs with real geometry (pointer pipeline currently covered by shared-code unit tests + existing uncontrolled e2e).
- OnSpill semantics in controlled mode are consumer-side by design; revisit if plugin parity is wanted.

## Testing

- 12 new unit tests (`tests/unit/controlled-mode.spec.ts`): DOM-invariant at event time, intent indices, cancel paths, cross-list move, clone-as-intent, keyboard incl. multi-drag arrays, `sort()` guard.
- Full suite: 253 passed, 0 regressions. Lint/type-check clean. Size budget unchanged (13.6 kB gzip vs 50 kB limit).

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdYhCz2wBSCMuJTUZ14igj

<!-- claude-session:ed99445c-8f69-4987-98c1-d922ed1fa6db -->
🔖 **Claude agent:** missioncontrol-f9  
session id: `ed99445c-8f69-4987-98c1-d922ed1fa6db`