### PR TITLE
fix: SortableJS-parity fixes for controlled mode from first downstream integration

### DIFF
--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -29,6 +29,10 @@ export class DragManager implements DragManagerInterface {
   // the drag has NOT yet committed (gated by `fallbackTolerance`). Distinct
   // from `dragElement`, which only becomes non-null at commit. PR3 #29.
   private pointerCaptureTarget: HTMLElement | null = null
+  // True when `choose` was already emitted during the capture phase (legacy
+  // parity: choose fires at tap start). commitPointerDrag must then not
+  // re-emit it, and a tolerance-abandoned tap must emit `unchoose`.
+  private capturePhaseChose = false
   private dragElement: HTMLElement | null = null
   private draggedItems: HTMLElement[] = []
   private _selectionManager: SelectionManager
@@ -144,6 +148,7 @@ export class DragManager implements DragManagerInterface {
     options?: {
       enableAccessibility?: boolean
       multiSelect?: boolean
+      multiDragKey?: 'ctrl' | 'meta' | 'shift' | 'alt' | null
       selectedClass?: string
       focusClass?: string
       handle?: string
@@ -219,6 +224,13 @@ export class DragManager implements DragManagerInterface {
     this._forceFallback = options?.forceFallback ?? false
     this._fallbackClass = options?.fallbackClass
     this._fallbackOnBody = options?.fallbackOnBody ?? false
+    // Default 0 = commit on pointerdown (SortableJS parity). Apps where a
+    // plain click has its own meaning should pass a few px so clicks don't
+    // churn a full drag start/teardown (ghost, placeholder, hidden items) —
+    // native HTML5 drags only ever start after real movement. The default
+    // stays 0 because Firefox under synthesized input (Playwright) delivers
+    // pointermove with coordinates frozen at the pointerdown position, so a
+    // nonzero default would make drags impossible to automate there.
     this._fallbackTolerance = options?.fallbackTolerance ?? 0
     this._fallbackOffsetX = options?.fallbackOffsetX ?? 0
     this._fallbackOffsetY = options?.fallbackOffsetY ?? 0
@@ -265,9 +277,11 @@ export class DragManager implements DragManagerInterface {
       {
         deselectOnClickOutside: options?.deselectOnClickOutside,
         multiDrag: options?.multiSelect,
+        multiDragKey: options?.multiDragKey,
         controlled: this.controlled,
         ghostManager: this.ghostManager,
         draggable: this.draggable,
+        dataIdAttr: this._dataIdAttr,
       }
     )
   }
@@ -405,7 +419,9 @@ export class DragManager implements DragManagerInterface {
 
     // Create ghost element (but for HTML5 drag, we'll use it as a placeholder)
     // The actual dragging visual is handled by the browser
-    const placeholder = this.ghostManager.createPlaceholder(target)
+    const placeholder = this.ghostManager.createPlaceholder(target, {
+      dataIdAttr: this._dataIdAttr,
+    })
     // Insert placeholder where the item was
     target.parentElement?.insertBefore(placeholder, target)
 
@@ -502,6 +518,62 @@ export class DragManager implements DragManagerInterface {
    *   (pointerup IS the drop); the HTML5 pipeline commits only in onDrop
    *   so a cancelled drag (dragend without drop) reports a no-op.
    */
+  /**
+   * Insert-after decision for controlled placement. Real pointer
+   * coordinates beat DOM order: the placeholder goes after `over` when the
+   * cursor is past `over`'s midpoint along the layout axis. This is stable
+   * under repeated events (same cursor → same answer), which the previous
+   * DOM-order heuristic wasn't — placeholder and `over` swap relative DOM
+   * order after each move, so hovering one item oscillated. It also makes
+   * wrapping grids work: the hovered item's row decides, per axis.
+   *
+   * Falls back to DOM order when the event has no usable coordinates or
+   * rects are zero-size (jsdom, synthetic events): moving toward a later
+   * sibling inserts after it.
+   */
+  private controlledInsertAfter(
+    e: Event,
+    over: HTMLElement,
+    placeholder: HTMLElement,
+    visible: HTMLElement[]
+  ): boolean {
+    const pt = e as MouseEvent
+    const hasCoords =
+      typeof pt.clientX === 'number' && (pt.clientX !== 0 || pt.clientY !== 0)
+    if (hasCoords) {
+      const rect = over.getBoundingClientRect()
+      if (rect.width > 0 || rect.height > 0) {
+        return this.detectHorizontalLayout(visible)
+          ? pt.clientX > rect.left + rect.width / 2
+          : pt.clientY > rect.top + rect.height / 2
+      }
+    }
+    // DOM-order fallback is only meaningful when the placeholder already
+    // lives in `over`'s list; across lists (zone enter) default to "before".
+    if (placeholder.parentElement !== over.parentElement) return false
+    return !!(
+      placeholder.compareDocumentPosition(over) &
+      Node.DOCUMENT_POSITION_FOLLOWING
+    )
+  }
+
+  /**
+   * Layout-axis detection from the first two visible items: tops within
+   * half an item height of each other → items flow in a row (horizontal or
+   * wrapping grid). Falls back to the `direction` option when there aren't
+   * two measurable items.
+   */
+  private detectHorizontalLayout(visible: HTMLElement[]): boolean {
+    if (visible.length >= 2) {
+      const a = visible[0].getBoundingClientRect()
+      const b = visible[1].getBoundingClientRect()
+      if (a.height > 0 || a.width > 0) {
+        return Math.abs(a.top - b.top) < Math.max(a.height, b.height) / 2
+      }
+    }
+    return this.direction === 'horizontal'
+  }
+
   private handleControlledMove(
     e: Event,
     over: HTMLElement | null,
@@ -542,9 +614,16 @@ export class DragManager implements DragManagerInterface {
       const hasSibling = overIsValid && over.parentElement === targetZoneElement
       const related: HTMLElement = hasSibling && over ? over : targetZoneElement
       const visible = targetZone.getVisibleItems(items)
-      const newIndex =
+      // Which side of the hovered sibling the cursor is on decides the
+      // insert side; hovering empty container space appends at the end.
+      const enterAfter =
+        hasSibling && over
+          ? this.controlledInsertAfter(e, over, placeholder, visible)
+          : false
+      const overIdx =
         hasSibling && over ? visible.indexOf(over) : visible.length
-      if (newIndex === -1) return
+      if (overIdx === -1) return
+      const newIndex = overIdx + (enterAfter ? 1 : 0)
 
       const moveEvent: MoveEvent = {
         item: items[0],
@@ -554,18 +633,22 @@ export class DragManager implements DragManagerInterface {
         oldIndex: activeDrag.startIndices[0],
         newIndex,
         related,
-        willInsertAfter: false,
+        willInsertAfter: enterAfter,
         draggedRect: placeholder.getBoundingClientRect(),
         targetRect: related.getBoundingClientRect(),
       }
       const moveResult = sourceManager.dispatchMove(moveEvent, e)
       if (moveResult === false) return
 
-      let insertRef: Node | null = hasSibling && over ? over : null
-      let index = newIndex
-      if (hasSibling && over && moveResult === 1) {
-        insertRef = over.nextSibling
-        index = newIndex + 1
+      // `onMove` return value overrides the cursor-derived side (legacy
+      // contract: 1 forces after, -1 forces before).
+      const insertAfter =
+        moveResult === 1 ? true : moveResult === -1 ? false : enterAfter
+      let insertRef: Node | null = null
+      let index = visible.length
+      if (hasSibling && over) {
+        insertRef = insertAfter ? over.nextSibling : over
+        index = visible.indexOf(over) + (insertAfter ? 1 : 0)
       }
       targetZone.insertWithAnimation(placeholder, insertRef)
       if (opts.commitPending) {
@@ -592,9 +675,11 @@ export class DragManager implements DragManagerInterface {
       sourceManager.ghostManager.getGhostElement() ?? placeholder
     ).getBoundingClientRect()
     const overRect = over.getBoundingClientRect()
-    const naturalAfter = !!(
-      placeholder.compareDocumentPosition(over) &
-      Node.DOCUMENT_POSITION_FOLLOWING
+    const naturalAfter = this.controlledInsertAfter(
+      e,
+      over,
+      placeholder,
+      visible
     )
     if (
       !this.shouldSwap(
@@ -1143,17 +1228,29 @@ export class DragManager implements DragManagerInterface {
       this.commitPointerDrag(e, target)
       return
     }
-    // Capture phase: pointer held, drag NOT yet committed. setPointerCapture
-    // pins subsequent events to `target` and suppresses default touch panning
-    // on iOS during the tolerance gap. Firefox throws on synthetic events.
+    // Capture phase: pointer held, drag NOT yet committed. Listeners live on
+    // `document`, so NO setPointerCapture here — Firefox freezes pointermove
+    // coordinates at the pointerdown position while an element holds pointer
+    // capture (observed with synthesized input; the tolerance distance then
+    // never accrues and the drag never commits). Capture is taken at commit
+    // time in commitPointerDrag, as it always was.
     this.pointerCaptureTarget = target
     this.activePointerId = e.pointerId
     this.dragStartPosition = { x: e.clientX, y: e.clientY }
-    try {
-      target.setPointerCapture(e.pointerId)
-    } catch {
-      /* synthetic events in Firefox */
-    }
+    // SortableJS parity: `choose` (and chosenClass) fire at tap start,
+    // BEFORE any movement. The rest of the drag (ghost, placeholder, start
+    // event, global state) waits for the tolerance threshold.
+    const idx = this.zone.getIndex(target)
+    target.classList.add(this.ghostManager.getChosenClass())
+    this.capturePhaseChose = true
+    this.events.emit('choose', {
+      item: target,
+      items: [target],
+      from: this.zone.element,
+      to: this.zone.element,
+      oldIndex: idx,
+      newIndex: idx,
+    })
     document.addEventListener('pointermove', this.onPointerMoveCapture)
     document.addEventListener('pointerup', this.onPointerUpCapture)
     document.addEventListener('pointercancel', this.onPointerUpCapture)
@@ -1170,15 +1267,38 @@ export class DragManager implements DragManagerInterface {
       this._fallbackTolerance
     )
       return
+    // Anchor the ghost's grab-point to the ORIGINAL pointerdown position —
+    // the pointer has already traveled up to the tolerance (or the full
+    // first automation step) by commit time.
     this.teardownCapturePhase()
-    this.commitPointerDrag(e, target)
+    this.commitPointerDrag(e, target, origin)
+    // The event that crossed the threshold is also the first real drag
+    // move — process it, or a single-move drag (automation, fast flick)
+    // commits at its final position without ever handling a move and the
+    // drop becomes a no-op.
+    this.onPointerMove(e)
   }
 
   // Pointer released (or cancelled) BEFORE the tolerance threshold — treat
-  // as a click, not a drag. No `choose` / `start` / `end` events fired;
-  // no DOM changes; just tear the capture state down.
+  // as a click, not a drag. `choose` already fired at tap start (legacy
+  // parity), so balance it with `unchoose`; no start/end, no DOM changes.
   private onPointerUpCapture = (e: PointerEvent): void => {
-    if (e.pointerId === this.activePointerId) this.teardownCapturePhase()
+    if (e.pointerId !== this.activePointerId) return
+    const target = this.pointerCaptureTarget
+    if (target && this.capturePhaseChose) {
+      target.classList.remove(this.ghostManager.getChosenClass())
+      this.capturePhaseChose = false
+      const idx = this.zone.getIndex(target)
+      this.events.emit('unchoose', {
+        item: target,
+        items: [target],
+        from: this.zone.element,
+        to: this.zone.element,
+        oldIndex: idx,
+        newIndex: idx,
+      })
+    }
+    this.teardownCapturePhase()
   }
 
   private teardownCapturePhase(): void {
@@ -1203,21 +1323,24 @@ export class DragManager implements DragManagerInterface {
    * registers with `globalDragState`. Reachable directly (tolerance 0) or
    * via {@link onPointerMoveCapture} after the tolerance threshold is met.
    */
-  private commitPointerDrag(e: PointerEvent, target: HTMLElement): void {
+  private commitPointerDrag(
+    e: PointerEvent,
+    target: HTMLElement,
+    cursorOrigin?: { x: number; y: number }
+  ): void {
     // Prevent text selection during drag (especially needed on iOS Safari)
     window.getSelection()?.removeAllRanges()
     this.savedBodyUserSelect = document.body.style.userSelect
     document.body.style.userSelect = 'none'
     document.body.style.setProperty('-webkit-user-select', 'none')
 
-    // Get selected items if multiSelect is enabled
+    // Multi-drag: dragging an already-selected item moves the whole
+    // selection. Dragging an UNselected item moves just that item and does
+    // NOT touch the selection — selecting is an explicit user gesture
+    // (click / modifier+click), not a side effect of dragging.
     this.draggedItems = [target]
     if (this._selectionManager.isSelected(target)) {
-      // If the target is already selected, drag all selected items
       this.draggedItems = this._selectionManager.getSelected()
-    } else {
-      // If target is not selected, select only it
-      this._selectionManager.select(target)
     }
 
     // Dim non-anchor selected items
@@ -1265,8 +1388,13 @@ export class DragManager implements DragManagerInterface {
       oldIndex: this.startIndex,
       newIndex: this.startIndex,
     }
-    // Emit choose event first
-    this.events.emit('choose', evt)
+    // Emit choose first — unless the capture phase already did (legacy
+    // parity: choose fires at tap start when fallbackTolerance > 0).
+    if (this.capturePhaseChose) {
+      this.capturePhaseChose = false
+    } else {
+      this.events.emit('choose', evt)
+    }
 
     // Create ghost element for visual feedback. `fallbackClass` is applied
     // alongside `ghostClass` so fallback-mode styles can target a stable hook
@@ -1281,6 +1409,7 @@ export class DragManager implements DragManagerInterface {
       offsetX: this._fallbackOffsetX,
       offsetY: this._fallbackOffsetY,
       dataIdAttr: this._dataIdAttr,
+      cursorOrigin,
     }
     if (this.draggedItems.length > 1) {
       this.ghostManager.createStackedGhost(
@@ -1292,7 +1421,9 @@ export class DragManager implements DragManagerInterface {
     } else {
       this.ghostManager.createGhost(target, e, ghostOptions)
     }
-    const placeholder = this.ghostManager.createPlaceholder(target)
+    const placeholder = this.ghostManager.createPlaceholder(target, {
+      dataIdAttr: this._dataIdAttr,
+    })
 
     if (this.controlled) {
       // The placeholder takes the anchor's spot and the real items are
@@ -1326,8 +1457,11 @@ export class DragManager implements DragManagerInterface {
     const activeDrag = globalDragState.getActiveDrag(dragId)
     if (!activeDrag) return
 
-    // Find the element under the mouse cursor
-    const elementUnderMouse = document.elementFromPoint(e.clientX, e.clientY)
+    // Find the element under the mouse cursor. Optional call: older jsdom
+    // builds (CI) don't implement elementFromPoint, and this path is now
+    // reachable from unit tests via the capture-phase commit's first-move
+    // processing.
+    const elementUnderMouse = document.elementFromPoint?.(e.clientX, e.clientY)
     const over = elementUnderMouse?.closest(
       this.draggable
     ) as HTMLElement | null

--- a/src/core/DropZone.ts
+++ b/src/core/DropZone.ts
@@ -26,11 +26,21 @@ export class DropZone {
     return this.animationManager?.isAnimating ?? false
   }
 
-  /** Get sortable items (only elements matching the draggable selector) */
+  /**
+   * Get sortable items (only elements matching the draggable selector).
+   * The placeholder and the ghost are clones of a real item, so they match
+   * the selector — both are marked with data attributes and excluded here,
+   * otherwise index math counts phantom items (the ghost lives inside the
+   * zone element when `fallbackOnBody` is false).
+   */
   public getItems(): HTMLElement[] {
     return Array.from(
       this.element.querySelectorAll<HTMLElement>(this.draggableSelector)
-    ).filter((el) => !el.hasAttribute('data-resortable-placeholder'))
+    ).filter(
+      (el) =>
+        !el.hasAttribute('data-resortable-placeholder') &&
+        !el.hasAttribute('data-resortable-ghost')
+    )
   }
 
   /**

--- a/src/core/GhostManager.ts
+++ b/src/core/GhostManager.ts
@@ -46,6 +46,37 @@ export interface CreateGhostOptions {
    * ghost clone so identity queries continue to address only the real item.
    */
   dataIdAttr?: string
+  /**
+   * Cursor position to anchor the grab-point offset to, when it differs
+   * from the triggering event's position. With `fallbackTolerance > 0` the
+   * drag commits only after the pointer has already traveled several
+   * pixels — anchoring to the commit event would shift the ghost by that
+   * traveled distance. Pass the pointerdown position instead.
+   */
+  cursorOrigin?: { x: number; y: number }
+}
+
+/**
+ * Strip identity attributes from a clone of a sortable item. Any attribute
+ * that uniquely identifies the original would otherwise produce duplicate
+ * matches in DOM queries (notably `[data-id="..."]` lookups in tests and
+ * consumer code). Duplicate `id` is invalid HTML in any case; the ARIA /
+ * tabindex state describes the *real* element's user-facing semantics and
+ * has no meaning on a visual-only clone.
+ */
+function stripIdentity(clone: HTMLElement, dataIdAttr: string): HTMLElement {
+  clone.removeAttribute('id')
+  clone.removeAttribute(dataIdAttr)
+  clone.removeAttribute('aria-grabbed')
+  clone.removeAttribute('aria-selected')
+  clone.removeAttribute('aria-posinset')
+  clone.removeAttribute('aria-setsize')
+  clone.removeAttribute('tabindex')
+  // Descendant `id`s would also be duplicated; clear them too.
+  clone
+    .querySelectorAll<HTMLElement>('[id]')
+    .forEach((el) => el.removeAttribute('id'))
+  return clone
 }
 
 /**
@@ -103,27 +134,16 @@ export class GhostManager {
     this.destroyGhost()
 
     // Clone the dragged element
-    this.ghostElement = draggedElement.cloneNode(true) as HTMLElement
-
-    // Strip identity attributes from the clone. With `fallbackOnBody: false`
-    // (PR2 default — legacy parity), the ghost lives inside the sortable
-    // zone, so any attribute that uniquely identifies the original would
-    // otherwise produce duplicate matches in DOM queries (notably
-    // `[data-id="..."]` lookups in tests and consumer code). Duplicate `id`
-    // is invalid HTML in any case; the ARIA / tabindex state describes the
-    // *real* element's user-facing semantics and has no meaning on a
-    // visual-only ghost clone (which is also `pointer-events: none`).
-    this.ghostElement.removeAttribute('id')
-    this.ghostElement.removeAttribute(dataIdAttr)
-    this.ghostElement.removeAttribute('aria-grabbed')
-    this.ghostElement.removeAttribute('aria-selected')
-    this.ghostElement.removeAttribute('aria-posinset')
-    this.ghostElement.removeAttribute('aria-setsize')
-    this.ghostElement.removeAttribute('tabindex')
-    // Descendant `id`s would also be duplicated; clear them too.
-    this.ghostElement
-      .querySelectorAll<HTMLElement>('[id]')
-      .forEach((el) => el.removeAttribute('id'))
+    this.ghostElement = stripIdentity(
+      draggedElement.cloneNode(true) as HTMLElement,
+      dataIdAttr
+    )
+    // The clone keeps the original's classes for its looks, so it can match
+    // the consumer's `draggable` selector. Mark it so DropZone.getItems()
+    // (and index math built on it) always excludes it — with
+    // `fallbackOnBody: false` the ghost lives INSIDE the zone element and
+    // would otherwise be counted as a real item.
+    this.ghostElement.setAttribute('data-resortable-ghost', '')
 
     // Get computed styles from the original element
     const computedStyle = window.getComputedStyle(draggedElement)
@@ -191,9 +211,12 @@ export class GhostManager {
     this.ghostElement.style.transform = 'none' // Reset any transforms
     this.ghostElement.style.transition = 'none' // Disable transitions during drag
 
-    // Calculate offset from cursor to element top-left
-    this.cursorOffsetX = event.clientX - rect.left
-    this.cursorOffsetY = event.clientY - rect.top
+    // Calculate offset from cursor to element top-left. Anchor to the
+    // original grab point when provided (see CreateGhostOptions.cursorOrigin).
+    const anchorX = options?.cursorOrigin?.x ?? event.clientX
+    const anchorY = options?.cursorOrigin?.y ?? event.clientY
+    this.cursorOffsetX = anchorX - rect.left
+    this.cursorOffsetY = anchorY - rect.top
 
     // Set initial position
     this.updateGhostPosition(event.clientX, event.clientY)
@@ -262,33 +285,44 @@ export class GhostManager {
   }
 
   /**
-   * Creates a placeholder element to show where the item will be dropped
+   * Creates a placeholder element to show where the item will be dropped.
+   *
+   * The placeholder is a semi-transparent CLONE of the dragged element —
+   * legacy-SortableJS parity, where the in-list drop indicator is the item
+   * itself wearing `ghostClass`. A bare gray box (the previous behaviour)
+   * reads as a rendering glitch next to rich item content like thumbnails.
+   *
    * @param referenceElement - Element to base the placeholder on
+   * @param options - `dataIdAttr` names the identity attribute to strip
    * @returns The created placeholder element
    */
-  createPlaceholder(referenceElement: HTMLElement): HTMLElement {
+  createPlaceholder(
+    referenceElement: HTMLElement,
+    options?: { dataIdAttr?: string }
+  ): HTMLElement {
     // Clean up any existing placeholder
     this.destroyPlaceholder()
 
-    // Create placeholder element
-    this.placeholderElement = document.createElement(referenceElement.tagName)
+    this.placeholderElement = stripIdentity(
+      referenceElement.cloneNode(true) as HTMLElement,
+      options?.dataIdAttr ?? 'data-id'
+    )
 
-    // Mark the placeholder so index math and DropZone.getItems() can always
-    // exclude it, even if a consumer's `draggable` selector would otherwise
-    // match the bare tag (controlled mode relies on this).
+    // Mark the placeholder so index math and DropZone.getItems() always
+    // exclude it — the clone keeps the original's classes, so it matches
+    // the consumer's `draggable` selector (controlled mode relies on this).
     this.placeholderElement.setAttribute('data-resortable-placeholder', '')
 
-    // Copy dimensions
+    // Fix dimensions so it holds the original's exact footprint
     const rect = referenceElement.getBoundingClientRect()
     this.placeholderElement.style.width = `${rect.width}px`
     this.placeholderElement.style.height = `${rect.height}px`
 
-    // Apply ghost class for styling
+    // Apply ghost class for styling, dim it, and keep it hit-transparent so
+    // elementFromPoint / dragover resolve items and containers beneath it.
     this.placeholderElement.classList.add(this.ghostClass)
-
-    // Make it semi-transparent
     this.placeholderElement.style.opacity = '0.4'
-    this.placeholderElement.style.background = '#e0e0e0'
+    this.placeholderElement.style.pointerEvents = 'none'
 
     return this.placeholderElement
   }

--- a/src/core/KeyboardManager.ts
+++ b/src/core/KeyboardManager.ts
@@ -5,6 +5,23 @@ import { globalDragState } from './GlobalDragState.js'
 import { GhostManager } from './GhostManager.js'
 import { hideControlled, restoreControlledHidden } from '../utils/dom.js'
 
+/** Whether the configured multi-drag modifier is held on this event. */
+function isModifierHeld(
+  e: MouseEvent,
+  key: 'ctrl' | 'meta' | 'shift' | 'alt'
+): boolean {
+  switch (key) {
+    case 'ctrl':
+      return e.ctrlKey
+    case 'meta':
+      return e.metaKey
+    case 'shift':
+      return e.shiftKey
+    case 'alt':
+      return e.altKey
+  }
+}
+
 /**
  * Handles keyboard navigation and operations for sortable lists
  * @internal
@@ -18,6 +35,10 @@ export class KeyboardManager {
 
   private deselectOnClickOutside: boolean
   private multiDrag: boolean
+  // When set, click-to-select requires this modifier key; plain clicks pass
+  // through to the app untouched (see the `multiDragKey` option).
+  private multiDragKey: 'ctrl' | 'meta' | 'shift' | 'alt' | null
+  private dataIdAttr: string
   private onDocumentClick: ((e: MouseEvent) => void) | null = null
 
   // Controlled mode (see the `controlled` option): grabbed items are hidden
@@ -37,16 +58,20 @@ export class KeyboardManager {
     options?: {
       deselectOnClickOutside?: boolean
       multiDrag?: boolean
+      multiDragKey?: 'ctrl' | 'meta' | 'shift' | 'alt' | null
       controlled?: boolean
       ghostManager?: GhostManager
       draggable?: string
+      dataIdAttr?: string
     }
   ) {
     this.deselectOnClickOutside = options?.deselectOnClickOutside ?? true
     this.multiDrag = options?.multiDrag ?? false
+    this.multiDragKey = options?.multiDragKey ?? null
     this.controlled = options?.controlled ?? false
     this.ghostManager = options?.ghostManager
     this.draggableSelector = options?.draggable ?? '.sortable-item'
+    this.dataIdAttr = options?.dataIdAttr ?? 'data-id'
     this.setupAnnouncer()
   }
 
@@ -275,6 +300,22 @@ export class KeyboardManager {
     ) as HTMLElement
     if (!target) return
 
+    // With `multiDragKey` configured, selection is an explicit gesture:
+    // modifier+click toggles, shift+click extends a range, and a PLAIN click
+    // does nothing here — no selection, no focus steal — so the app keeps
+    // its own plain-click semantics (e.g. activating/triggering the item).
+    if (this.multiDragKey) {
+      if (e.shiftKey && this.selectionManager.getLastSelected()) {
+        e.preventDefault()
+        const last = this.selectionManager.getLastSelected()
+        if (last) this.selectionManager.selectRange(last, target)
+      } else if (isModifierHeld(e, this.multiDragKey)) {
+        e.preventDefault()
+        this.selectionManager.toggle(target, true)
+      }
+      return
+    }
+
     if (e.shiftKey && this.selectionManager.getLastSelected()) {
       // Range selection
       e.preventDefault()
@@ -343,7 +384,9 @@ export class KeyboardManager {
 
     if (this.controlled && this.ghostManager) {
       const anchor = selected[0]
-      const placeholder = this.ghostManager.createPlaceholder(anchor)
+      const placeholder = this.ghostManager.createPlaceholder(anchor, {
+        dataIdAttr: this.dataIdAttr,
+      })
       anchor.parentElement?.insertBefore(placeholder, anchor)
       this.hiddenDisplays = hideControlled(selected)
       // display:none drops focus from the grabbed item — park focus on the

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import { DragManager } from './core/DragManager.js'
 import { DropZone } from './core/DropZone.js'
 import { EventSystem } from './core/EventSystem.js'
 import { PluginSystem } from './core/PluginSystem.js'
+import { AutoScrollPlugin } from './plugins/AutoScrollPlugin.js'
 import {
   SortableOptions,
   type SortablePlugin,
@@ -259,6 +260,8 @@ export class Sortable {
   public dragManager: DragManager // Made non-readonly to allow replacement
   public readonly eventSystem: EventSystem<SortableEvents>
   private animationManager: AnimationManager
+  // Instance-owned auto-scroll plugin, created when `scroll: true`.
+  private autoScrollPlugin?: AutoScrollPlugin
 
   /**
    * Creates a new Sortable instance
@@ -311,6 +314,18 @@ export class Sortable {
       this.buildDragManagerOptions()
     )
     this.dragManager.attach()
+
+    // `scroll: true` — edge auto-scroll during drags (SortableJS Scroll
+    // parity). Instance-owned plugin instance (NOT the global PluginSystem
+    // registry) so per-instance sensitivity/speed never clash across
+    // sortables.
+    if (this.options.scroll) {
+      this.autoScrollPlugin = AutoScrollPlugin.create({
+        sensitivity: this.options.scrollSensitivity,
+        speed: this.options.scrollSpeed,
+      })
+      this.autoScrollPlugin.install(this)
+    }
 
     // Set up internal handlers for static properties
     this.eventSystem.on('start', (event) => {
@@ -443,6 +458,7 @@ export class Sortable {
       // See #33.
       onMove: this.options.onMove,
       controlled: this.options.controlled,
+      multiDragKey: this.options.multiDragKey,
     }
   }
 
@@ -465,6 +481,13 @@ export class Sortable {
   public destroy(): void {
     // Uninstall all plugins
     PluginSystem.uninstallAll(this)
+
+    // Instance-owned auto-scroll (scroll: true) bypasses the registry, so
+    // uninstall it explicitly.
+    if (this.autoScrollPlugin) {
+      this.autoScrollPlugin.uninstall(this)
+      this.autoScrollPlugin = undefined
+    }
 
     this.dragManager.detach()
     // Remove from instance tracking
@@ -813,6 +836,8 @@ const defaultOptions: SortableOptions = {
   disabled: false,
   controlled: false,
   multiDrag: false,
+  multiDragKey: null,
+  scroll: false,
   enableAccessibility: true,
   selectedClass: 'sortable-selected',
   focusClass: 'sortable-focused',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -154,10 +154,50 @@ export interface SortableOptions {
   multiDrag?: boolean
 
   /**
+   * Modifier key required for click-to-select in multi-drag mode.
+   *
+   * @remarks
+   * When set, selection becomes an explicit gesture: `<key>`+click toggles
+   * an item in/out of the selection and Shift+click extends a range, while
+   * a PLAIN click does nothing — no selection, no focus steal — leaving
+   * plain-click semantics (activating / triggering the item) to the app.
+   *
+   * When `null` (default), plain clicks toggle selection additively —
+   * appropriate for lists where clicking has no other meaning.
+   *
+   * Keyboard selection (Space) and dragging an existing selection are
+   * unaffected. Legacy parity: SortableJS MultiDrag's `multiDragKey`.
+   *
+   * @defaultValue null
+   */
+  multiDragKey?: 'ctrl' | 'meta' | 'shift' | 'alt' | null
+
+  /**
    * CSS class for selected items in multi-drag mode
    * @defaultValue 'sortable-selected'
    */
   selectedClass?: string
+
+  /**
+   * Auto-scroll scrollable ancestors (and the window) when dragging near
+   * their edges. Legacy parity: SortableJS Scroll plugin's `scroll: true`.
+   * Internally installs an instance-owned `AutoScrollPlugin`.
+   * @defaultValue false
+   */
+  scroll?: boolean
+
+  /**
+   * Distance in px from a scrollable edge at which auto-scroll kicks in.
+   * Only meaningful with `scroll: true`.
+   * @defaultValue 100
+   */
+  scrollSensitivity?: number
+
+  /**
+   * Auto-scroll speed in px per frame. Only meaningful with `scroll: true`.
+   * @defaultValue 10
+   */
+  scrollSpeed?: number
 
   /**
    * Clear selection when clicking outside the sortable container
@@ -405,7 +445,12 @@ export interface SortableOptions {
   fallbackOnBody?: boolean
 
   /**
-   * Fallback tolerance in pixels
+   * Pixels the pointer must travel from pointerdown before the pointer
+   * pipeline commits the drag (ghost, placeholder, start event). `0`
+   * commits immediately on pointerdown. `choose` fires at pointerdown
+   * either way. Recommended for apps where plain click has its own
+   * meaning (e.g. triggering the item): a few px keeps clicks from
+   * churning a full drag start/teardown.
    * @defaultValue 0
    */
   fallbackTolerance?: number

--- a/tests/e2e/fallback-mode.spec.ts
+++ b/tests/e2e/fallback-mode.spec.ts
@@ -472,11 +472,13 @@ test.describe('fallbackTolerance (#29 PR3)', () => {
     await page.mouse.move(from.x + 2, from.y, { steps: 2 })
     await page.mouse.up()
 
-    // No drag-lifecycle event should have fired.
+    // Legacy parity: `choose` fires at tap start and the abandoned tap
+    // balances it with nothing here (onUnchoose isn't instrumented) — but
+    // no drag COMMIT event (start/end) may fire.
     const events = await page.evaluate(() =>
       (window as unknown as { __pr3Events: string[] }).__pr3Events.slice()
     )
-    expect(events).toEqual([])
+    expect(events).toEqual(['choose'])
 
     // And no ghost lingers.
     await expect(page.locator('.sortable-ghost')).toHaveCount(0)
@@ -672,12 +674,14 @@ test.describe('fallback cross-option sweep (#29 PR4)', () => {
     await page.mouse.down()
 
     // 2) capture phase — 3px move is under the 8px tolerance, no commit.
+    //    `choose` fires at tap start (legacy parity), but no ghost and no
+    //    start event until the tolerance is crossed.
     await page.mouse.move(from.x + 3, from.y, { steps: 2 })
     await expect(page.locator('.sortable-ghost')).toHaveCount(0)
     const capturedEvents = await page.evaluate(() =>
       (window as unknown as { __pr4Events: string[] }).__pr4Events.slice()
     )
-    expect(capturedEvents).toEqual([])
+    expect(capturedEvents).toEqual(['choose'])
 
     // 3) commit phase — cross the tolerance, ghost should appear inside the
     //    zone (fallbackOnBody:false) with the fallback class.

--- a/tests/e2e/fixtures/delay-test.html
+++ b/tests/e2e/fixtures/delay-test.html
@@ -1,51 +1,45 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Delay Test</title>
-  <style>
-    .sortable-item {
-      padding: 10px;
-      margin: 5px;
-      background: #f0f0f0;
-      border: 1px solid #ccc;
-      cursor: move;
-    }
-    .sortable-ghost {
-      opacity: 0.5;
-    }
-    .sortable-chosen {
-      background: #d0d0d0;
-    }
-  </style>
-</head>
-<body>
-  <h1>Delay Test (300ms delay)</h1>
-  
-  <div id="delay-test">
-    <div class="sortable-item" data-id="item-1">
-      Item 1
-    </div>
-    <div class="sortable-item" data-id="item-2">
-      Item 2
-    </div>
-    <div class="sortable-item" data-id="item-3">
-      Item 3
-    </div>
-  </div>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Delay Test</title>
+    <style>
+      .sortable-item {
+        padding: 10px;
+        margin: 5px;
+        background: #f0f0f0;
+        border: 1px solid #ccc;
+        cursor: move;
+      }
+      .sortable-ghost {
+        opacity: 0.5;
+      }
+      .sortable-chosen {
+        background: #d0d0d0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Delay Test (300ms delay)</h1>
 
-  <script type="module">
-    import { Sortable } from '/src/index.js';
-    
-    const sortable = new Sortable(document.getElementById('delay-test'), {
-      delay: 300, // 300ms delay before drag starts
-      animation: 150,
-      onStart: (e) => console.log('Start drag after delay', e),
-      onEnd: (e) => console.log('End drag', e),
-    });
-    
-    window.sortable = sortable;
-  </script>
-</body>
+    <div id="delay-test">
+      <div class="sortable-item" data-id="item-1">Item 1</div>
+      <div class="sortable-item" data-id="item-2">Item 2</div>
+      <div class="sortable-item" data-id="item-3">Item 3</div>
+    </div>
+
+    <script type="module">
+      import { Sortable } from '/src/index.js'
+
+      const sortable = new Sortable(document.getElementById('delay-test'), {
+        delay: 300, // 300ms delay before drag starts
+        animation: 150,
+        onStart: (e) => console.log('Start drag after delay', e),
+        onEnd: (e) => console.log('End drag', e),
+      })
+
+      window.sortable = sortable
+    </script>
+  </body>
 </html>

--- a/tests/e2e/fixtures/delay-threshold.html
+++ b/tests/e2e/fixtures/delay-threshold.html
@@ -1,53 +1,50 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Delay with Touch Start Threshold Test</title>
-  <style>
-    .sortable-item {
-      padding: 10px;
-      margin: 5px;
-      background: #f0f0f0;
-      border: 1px solid #ccc;
-      cursor: move;
-    }
-    .sortable-ghost {
-      opacity: 0.5;
-    }
-    .sortable-chosen {
-      background: #d0d0d0;
-    }
-  </style>
-</head>
-<body>
-  <h1>Delay with Touch Start Threshold Test</h1>
-  <p>300ms delay | 10px movement threshold (cancels drag)</p>
-  
-  <div id="delay-threshold-test">
-    <div class="sortable-item" data-id="item-1">
-      Item 1
-    </div>
-    <div class="sortable-item" data-id="item-2">
-      Item 2
-    </div>
-    <div class="sortable-item" data-id="item-3">
-      Item 3
-    </div>
-  </div>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Delay with Touch Start Threshold Test</title>
+    <style>
+      .sortable-item {
+        padding: 10px;
+        margin: 5px;
+        background: #f0f0f0;
+        border: 1px solid #ccc;
+        cursor: move;
+      }
+      .sortable-ghost {
+        opacity: 0.5;
+      }
+      .sortable-chosen {
+        background: #d0d0d0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Delay with Touch Start Threshold Test</h1>
+    <p>300ms delay | 10px movement threshold (cancels drag)</p>
 
-  <script type="module">
-    import { Sortable } from '/src/index.js';
-    
-    const sortable = new Sortable(document.getElementById('delay-threshold-test'), {
-      delay: 300, // 300ms delay
-      touchStartThreshold: 10, // Cancel drag if moved more than 10px during delay
-      animation: 150,
-      onStart: (e) => console.log('Start drag', e),
-      onEnd: (e) => console.log('End drag', e),
-    });
-    
-    window.sortable = sortable;
-  </script>
-</body>
+    <div id="delay-threshold-test">
+      <div class="sortable-item" data-id="item-1">Item 1</div>
+      <div class="sortable-item" data-id="item-2">Item 2</div>
+      <div class="sortable-item" data-id="item-3">Item 3</div>
+    </div>
+
+    <script type="module">
+      import { Sortable } from '/src/index.js'
+
+      const sortable = new Sortable(
+        document.getElementById('delay-threshold-test'),
+        {
+          delay: 300, // 300ms delay
+          touchStartThreshold: 10, // Cancel drag if moved more than 10px during delay
+          animation: 150,
+          onStart: (e) => console.log('Start drag', e),
+          onEnd: (e) => console.log('End drag', e),
+        }
+      )
+
+      window.sortable = sortable
+    </script>
+  </body>
 </html>

--- a/tests/e2e/fixtures/delay-touch-only.html
+++ b/tests/e2e/fixtures/delay-touch-only.html
@@ -1,53 +1,50 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Delay Touch Only Test</title>
-  <style>
-    .sortable-item {
-      padding: 10px;
-      margin: 5px;
-      background: #f0f0f0;
-      border: 1px solid #ccc;
-      cursor: move;
-    }
-    .sortable-ghost {
-      opacity: 0.5;
-    }
-    .sortable-chosen {
-      background: #d0d0d0;
-    }
-  </style>
-</head>
-<body>
-  <h1>Delay Touch Only Test</h1>
-  <p>Mouse: instant drag | Touch: 400ms delay</p>
-  
-  <div id="delay-touch-test">
-    <div class="sortable-item" data-id="item-1">
-      Item 1
-    </div>
-    <div class="sortable-item" data-id="item-2">
-      Item 2
-    </div>
-    <div class="sortable-item" data-id="item-3">
-      Item 3
-    </div>
-  </div>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Delay Touch Only Test</title>
+    <style>
+      .sortable-item {
+        padding: 10px;
+        margin: 5px;
+        background: #f0f0f0;
+        border: 1px solid #ccc;
+        cursor: move;
+      }
+      .sortable-ghost {
+        opacity: 0.5;
+      }
+      .sortable-chosen {
+        background: #d0d0d0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Delay Touch Only Test</h1>
+    <p>Mouse: instant drag | Touch: 400ms delay</p>
 
-  <script type="module">
-    import { Sortable } from '/src/index.js';
-    
-    const sortable = new Sortable(document.getElementById('delay-touch-test'), {
-      delay: 0, // No delay for mouse
-      delayOnTouchOnly: 400, // 400ms delay for touch only
-      animation: 150,
-      onStart: (e) => console.log('Start drag', e),
-      onEnd: (e) => console.log('End drag', e),
-    });
-    
-    window.sortable = sortable;
-  </script>
-</body>
+    <div id="delay-touch-test">
+      <div class="sortable-item" data-id="item-1">Item 1</div>
+      <div class="sortable-item" data-id="item-2">Item 2</div>
+      <div class="sortable-item" data-id="item-3">Item 3</div>
+    </div>
+
+    <script type="module">
+      import { Sortable } from '/src/index.js'
+
+      const sortable = new Sortable(
+        document.getElementById('delay-touch-test'),
+        {
+          delay: 0, // No delay for mouse
+          delayOnTouchOnly: 400, // 400ms delay for touch only
+          animation: 150,
+          onStart: (e) => console.log('Start drag', e),
+          onEnd: (e) => console.log('End drag', e),
+        }
+      )
+
+      window.sortable = sortable
+    </script>
+  </body>
 </html>

--- a/tests/e2e/fixtures/draggable-selector-complex.html
+++ b/tests/e2e/fixtures/draggable-selector-complex.html
@@ -1,65 +1,81 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Draggable Selector Complex Test</title>
-  <style>
-    .sortable-item {
-      padding: 10px;
-      margin: 5px;
-      background: #f0f0f0;
-      border: 1px solid #ccc;
-    }
-    .active {
-      background: #e0f0e0;
-      cursor: move;
-    }
-    .inactive {
-      background: #f0e0e0;
-      cursor: not-allowed;
-      opacity: 0.6;
-    }
-    .premium {
-      background: #f0f0e0;
-      border: 2px solid gold;
-      cursor: move;
-    }
-    .sortable-ghost {
-      opacity: 0.5;
-    }
-    .sortable-chosen {
-      background: #d0d0d0;
-    }
-  </style>
-</head>
-<body>
-  <h1>Draggable Selector Complex Test</h1>
-  
-  <div id="draggable-complex-test">
-    <div class="sortable-item active" data-status="active" data-id="item-active">
-      Active Item (Draggable)
-    </div>
-    <div class="sortable-item inactive" data-status="inactive" data-id="item-inactive">
-      Inactive Item (Not Draggable)
-    </div>
-    <div class="sortable-item premium" data-status="premium" data-id="item-premium">
-      Premium Item (Draggable)
-    </div>
-  </div>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Draggable Selector Complex Test</title>
+    <style>
+      .sortable-item {
+        padding: 10px;
+        margin: 5px;
+        background: #f0f0f0;
+        border: 1px solid #ccc;
+      }
+      .active {
+        background: #e0f0e0;
+        cursor: move;
+      }
+      .inactive {
+        background: #f0e0e0;
+        cursor: not-allowed;
+        opacity: 0.6;
+      }
+      .premium {
+        background: #f0f0e0;
+        border: 2px solid gold;
+        cursor: move;
+      }
+      .sortable-ghost {
+        opacity: 0.5;
+      }
+      .sortable-chosen {
+        background: #d0d0d0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Draggable Selector Complex Test</h1>
 
-  <script type="module">
-    import { Sortable } from '/src/index.js';
-    
-    const sortable = new Sortable(document.getElementById('draggable-complex-test'), {
-      // Complex selector: only active items or items with premium status
-      draggable: '.sortable-item.active, .sortable-item[data-status="premium"]',
-      animation: 150,
-      onStart: (e) => console.log('Start drag', e),
-      onEnd: (e) => console.log('End drag', e),
-    });
-    
-    window.sortable = sortable;
-  </script>
-</body>
+    <div id="draggable-complex-test">
+      <div
+        class="sortable-item active"
+        data-status="active"
+        data-id="item-active"
+      >
+        Active Item (Draggable)
+      </div>
+      <div
+        class="sortable-item inactive"
+        data-status="inactive"
+        data-id="item-inactive"
+      >
+        Inactive Item (Not Draggable)
+      </div>
+      <div
+        class="sortable-item premium"
+        data-status="premium"
+        data-id="item-premium"
+      >
+        Premium Item (Draggable)
+      </div>
+    </div>
+
+    <script type="module">
+      import { Sortable } from '/src/index.js'
+
+      const sortable = new Sortable(
+        document.getElementById('draggable-complex-test'),
+        {
+          // Complex selector: only active items or items with premium status
+          draggable:
+            '.sortable-item.active, .sortable-item[data-status="premium"]',
+          animation: 150,
+          onStart: (e) => console.log('Start drag', e),
+          onEnd: (e) => console.log('End drag', e),
+        }
+      )
+
+      window.sortable = sortable
+    </script>
+  </body>
 </html>

--- a/tests/e2e/fixtures/draggable-selector.html
+++ b/tests/e2e/fixtures/draggable-selector.html
@@ -1,58 +1,58 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Draggable Selector Test</title>
-  <style>
-    .sortable-item {
-      padding: 10px;
-      margin: 5px;
-      background: #f0f0f0;
-      border: 1px solid #ccc;
-    }
-    .draggable-item {
-      background: #e0f0e0;
-      cursor: move;
-    }
-    .non-draggable {
-      background: #f0e0e0;
-      cursor: not-allowed;
-    }
-    .sortable-ghost {
-      opacity: 0.5;
-    }
-    .sortable-chosen {
-      background: #d0d0d0;
-    }
-  </style>
-</head>
-<body>
-  <h1>Draggable Selector Test</h1>
-  
-  <div id="draggable-test">
-    <div class="sortable-item draggable-item" data-id="item-1">
-      Item 1 (Draggable)
-    </div>
-    <div class="sortable-item non-draggable" data-id="item-2">
-      Item 2 (Non-Draggable)
-    </div>
-    <div class="sortable-item draggable-item" data-id="item-3">
-      Item 3 (Draggable)
-    </div>
-  </div>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Draggable Selector Test</title>
+    <style>
+      .sortable-item {
+        padding: 10px;
+        margin: 5px;
+        background: #f0f0f0;
+        border: 1px solid #ccc;
+      }
+      .draggable-item {
+        background: #e0f0e0;
+        cursor: move;
+      }
+      .non-draggable {
+        background: #f0e0e0;
+        cursor: not-allowed;
+      }
+      .sortable-ghost {
+        opacity: 0.5;
+      }
+      .sortable-chosen {
+        background: #d0d0d0;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Draggable Selector Test</h1>
 
-  <script type="module">
-    import { Sortable } from '/src/index.js';
-    
-    const sortable = new Sortable(document.getElementById('draggable-test'), {
-      draggable: '.draggable-item',
-      animation: 150,
-      onStart: (e) => console.log('Start drag', e),
-      onEnd: (e) => console.log('End drag', e),
-    });
-    
-    window.sortable = sortable;
-  </script>
-</body>
+    <div id="draggable-test">
+      <div class="sortable-item draggable-item" data-id="item-1">
+        Item 1 (Draggable)
+      </div>
+      <div class="sortable-item non-draggable" data-id="item-2">
+        Item 2 (Non-Draggable)
+      </div>
+      <div class="sortable-item draggable-item" data-id="item-3">
+        Item 3 (Draggable)
+      </div>
+    </div>
+
+    <script type="module">
+      import { Sortable } from '/src/index.js'
+
+      const sortable = new Sortable(document.getElementById('draggable-test'), {
+        draggable: '.draggable-item',
+        animation: 150,
+        onStart: (e) => console.log('Start drag', e),
+        onEnd: (e) => console.log('End drag', e),
+      })
+
+      window.sortable = sortable
+    </script>
+  </body>
 </html>

--- a/tests/e2e/fixtures/ignore-option.html
+++ b/tests/e2e/fixtures/ignore-option.html
@@ -1,94 +1,115 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Ignore Option Test</title>
-  <style>
-    body { font-family: sans-serif; padding: 16px; }
-    #ignore-test { width: 320px; }
-    .sortable-item {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      padding: 10px;
-      margin: 6px 0;
-      background: #f0f0f0;
-      border: 1px solid #ccc;
-      height: 36px;
-    }
-    .sortable-item .link { color: #06c; text-decoration: underline; }
-    .sortable-item .img {
-      width: 24px;
-      height: 24px;
-      background: #888;
-      display: inline-block;
-    }
-    .sortable-item .body {
-      flex: 1;
-      cursor: move;
-    }
-    .sortable-item .btn {
-      padding: 2px 8px;
-    }
-  </style>
-</head>
-<body>
-  <h1>Ignore Option Test</h1>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Ignore Option Test</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        padding: 16px;
+      }
+      #ignore-test {
+        width: 320px;
+      }
+      .sortable-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 10px;
+        margin: 6px 0;
+        background: #f0f0f0;
+        border: 1px solid #ccc;
+        height: 36px;
+      }
+      .sortable-item .link {
+        color: #06c;
+        text-decoration: underline;
+      }
+      .sortable-item .img {
+        width: 24px;
+        height: 24px;
+        background: #888;
+        display: inline-block;
+      }
+      .sortable-item .body {
+        flex: 1;
+        cursor: move;
+      }
+      .sortable-item .btn {
+        padding: 2px 8px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Ignore Option Test</h1>
 
-  <!-- List 1: default ignore = 'a, img' -->
-  <div id="ignore-test">
-    <div class="sortable-item" data-id="item-1">
-      <a href="javascript:void(0)" class="link" data-link>link</a>
-      <img class="img" alt="x"
-           src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs="
-           data-img>
-      <span class="body">Item 1</span>
-      <button type="button" class="btn">btn</button>
+    <!-- List 1: default ignore = 'a, img' -->
+    <div id="ignore-test">
+      <div class="sortable-item" data-id="item-1">
+        <a href="javascript:void(0)" class="link" data-link>link</a>
+        <img
+          class="img"
+          alt="x"
+          src="data:image/gif;base64,R0lGODlhAQABAIAAAP///wAAACwAAAAAAQABAAACAkQBADs="
+          data-img
+        />
+        <span class="body">Item 1</span>
+        <button type="button" class="btn">btn</button>
+      </div>
+      <div class="sortable-item" data-id="item-2">
+        <span class="body">Item 2</span>
+      </div>
+      <div class="sortable-item" data-id="item-3">
+        <span class="body">Item 3</span>
+      </div>
     </div>
-    <div class="sortable-item" data-id="item-2">
-      <span class="body">Item 2</span>
-    </div>
-    <div class="sortable-item" data-id="item-3">
-      <span class="body">Item 3</span>
-    </div>
-  </div>
 
-  <!-- List 2: custom ignore = 'input, button' (a should be draggable) -->
-  <div id="ignore-custom" style="margin-top: 24px;">
-    <div class="sortable-item" data-id="cust-1">
-      <a href="javascript:void(0)" class="link" data-link>link-cust</a>
-      <button type="button" class="btn" data-btn>btn-cust</button>
-      <span class="body">Custom 1</span>
+    <!-- List 2: custom ignore = 'input, button' (a should be draggable) -->
+    <div id="ignore-custom" style="margin-top: 24px">
+      <div class="sortable-item" data-id="cust-1">
+        <a href="javascript:void(0)" class="link" data-link>link-cust</a>
+        <button type="button" class="btn" data-btn>btn-cust</button>
+        <span class="body">Custom 1</span>
+      </div>
+      <div class="sortable-item" data-id="cust-2">
+        <span class="body">Custom 2</span>
+      </div>
+      <div class="sortable-item" data-id="cust-3">
+        <span class="body">Custom 3</span>
+      </div>
     </div>
-    <div class="sortable-item" data-id="cust-2">
-      <span class="body">Custom 2</span>
-    </div>
-    <div class="sortable-item" data-id="cust-3">
-      <span class="body">Custom 3</span>
-    </div>
-  </div>
 
-  <script type="module">
-    import { Sortable } from '/src/index.js';
+    <script type="module">
+      import { Sortable } from '/src/index.js'
 
-    // `dragStarts` exposes a counter the test asserts against; each
-    // sortable's `onStart` increments its own counter so tests don't
-    // need to disambiguate flaky pointer-event reorder semantics.
-    window.dragStarts = { default: 0, custom: 0 };
+      // `dragStarts` exposes a counter the test asserts against; each
+      // sortable's `onStart` increments its own counter so tests don't
+      // need to disambiguate flaky pointer-event reorder semantics.
+      window.dragStarts = { default: 0, custom: 0 }
 
-    // Default — ignore defaults to 'a, img'.
-    window.sortableDefault = new Sortable(document.getElementById('ignore-test'), {
-      animation: 0,
-      onStart: () => { window.dragStarts.default += 1; },
-    });
+      // Default — ignore defaults to 'a, img'.
+      window.sortableDefault = new Sortable(
+        document.getElementById('ignore-test'),
+        {
+          animation: 0,
+          onStart: () => {
+            window.dragStarts.default += 1
+          },
+        }
+      )
 
-    // Custom — overrides default so links remain draggable but buttons do not.
-    window.sortableCustom = new Sortable(document.getElementById('ignore-custom'), {
-      ignore: 'input, button',
-      animation: 0,
-      onStart: () => { window.dragStarts.custom += 1; },
-    });
-  </script>
-</body>
+      // Custom — overrides default so links remain draggable but buttons do not.
+      window.sortableCustom = new Sortable(
+        document.getElementById('ignore-custom'),
+        {
+          ignore: 'input, button',
+          animation: 0,
+          onStart: () => {
+            window.dragStarts.custom += 1
+          },
+        }
+      )
+    </script>
+  </body>
 </html>

--- a/tests/unit/controlled-parity.spec.ts
+++ b/tests/unit/controlled-parity.spec.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { Sortable } from '../../src/index'
+
+/**
+ * Unit coverage for the 2026-07 SortableJS-parity fixes driven by the
+ * Visibox design-system integration:
+ *
+ * 1. The placeholder is a CLONE of the dragged item (not a bare gray box),
+ *    marked with `data-resortable-placeholder` and excluded from item
+ *    queries even though it matches the consumer's `draggable` selector.
+ * 2. The ghost is marked with `data-resortable-ghost` and excluded from
+ *    item queries (it can live inside the zone when `fallbackOnBody` is
+ *    false, where it would otherwise corrupt index math).
+ * 3. `multiDragKey` gates click-to-select: plain clicks select nothing and
+ *    steal no focus; modifier+click toggles; shift+click extends a range.
+ * 4. Dragging an UNselected item does not add it to the selection.
+ */
+
+function makeList(count = 4): HTMLElement {
+  const ul = document.createElement('ul')
+  for (let i = 0; i < count; i++) {
+    const li = document.createElement('li')
+    li.className = 'item'
+    li.id = `it-${i}`
+    li.dataset.id = `it-${i}`
+    li.textContent = `Item ${i}`
+    ul.appendChild(li)
+  }
+  document.body.appendChild(ul)
+  return ul
+}
+
+// jsdom lacks the DragEvent / PointerEvent constructors — fall back to a
+// plain Event cast, same pattern as controlled-mode.spec.ts.
+function mkDrag(type: string): DragEvent {
+  try {
+    return new DragEvent(type, { bubbles: true, cancelable: true })
+  } catch {
+    return new Event(type, { bubbles: true, cancelable: true }) as DragEvent
+  }
+}
+
+function mkPointer(type: string, pointerId = 1): PointerEvent {
+  const initProps = {
+    pointerId,
+    isPrimary: true,
+    button: 0,
+  }
+  try {
+    return new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      ...initProps,
+    })
+  } catch {
+    const ev = new MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    }) as unknown as PointerEvent
+    // MouseEvent's own props are getter-only — define, don't assign.
+    Object.defineProperties(ev, {
+      pointerId: { value: pointerId },
+      isPrimary: { value: true },
+    })
+    return ev
+  }
+}
+
+function drag(from: HTMLElement, over: HTMLElement, drop = true): void {
+  from.dispatchEvent(mkDrag('dragstart'))
+  over.dispatchEvent(mkDrag('dragover'))
+  if (drop) over.dispatchEvent(mkDrag('drop'))
+  from.dispatchEvent(mkDrag('dragend'))
+}
+
+function click(el: HTMLElement, init: MouseEventInit = {}): void {
+  el.dispatchEvent(
+    new MouseEvent('click', { bubbles: true, cancelable: true, ...init })
+  )
+}
+
+describe('controlled-mode parity fixes (2026-07)', () => {
+  let ul: HTMLElement
+  let sortable: Sortable
+
+  beforeEach(() => {
+    document.body.innerHTML = ''
+    ul = makeList()
+  })
+
+  afterEach(() => {
+    sortable?.destroy()
+  })
+
+  describe('placeholder is a clone of the dragged item', () => {
+    it('carries the item classes and content, minus identity attributes', () => {
+      sortable = new Sortable(ul, {
+        controlled: true,
+        draggable: '.item',
+        animation: 0,
+      })
+
+      const item = ul.children[0] as HTMLElement
+      item.dispatchEvent(mkDrag('dragstart'))
+
+      const ph = ul.querySelector<HTMLElement>('[data-resortable-placeholder]')
+      expect(ph).not.toBeNull()
+      expect(ph!.classList.contains('item')).toBe(true)
+      expect(ph!.textContent).toBe('Item 0')
+      // Identity stripped — no duplicate id/data-id in the DOM
+      expect(ph!.id).toBe('')
+      expect(ph!.dataset.id).toBeUndefined()
+      expect(document.querySelectorAll('#it-0').length).toBe(1)
+
+      item.dispatchEvent(mkDrag('dragend'))
+      expect(ul.querySelector('[data-resortable-placeholder]')).toBeNull()
+    })
+
+    it('is excluded from index math even though it matches `draggable`', () => {
+      const newIndexes: number[][] = []
+      sortable = new Sortable(ul, {
+        controlled: true,
+        draggable: '.item',
+        animation: 0,
+        onEnd: (evt) => {
+          if (evt.newIndexes) newIndexes.push(evt.newIndexes)
+        },
+      })
+
+      drag(ul.children[0] as HTMLElement, ul.children[2] as HTMLElement)
+      expect(newIndexes).toEqual([[2]])
+      // Controlled: consumer DOM untouched
+      expect(
+        Array.from(ul.querySelectorAll('.item')).map((el) => el.id)
+      ).toEqual(['it-0', 'it-1', 'it-2', 'it-3'])
+    })
+  })
+
+  describe('multiDragKey', () => {
+    it('plain click selects nothing and does not steal focus', () => {
+      sortable = new Sortable(ul, {
+        multiDrag: true,
+        multiDragKey: 'meta',
+        draggable: '.item',
+      })
+
+      const item = ul.children[1] as HTMLElement
+      click(item)
+
+      expect(item.classList.contains('sortable-selected')).toBe(false)
+      expect(item.getAttribute('aria-selected')).not.toBe('true')
+      expect(document.activeElement).not.toBe(item)
+    })
+
+    it('modifier+click toggles selection additively', () => {
+      sortable = new Sortable(ul, {
+        multiDrag: true,
+        multiDragKey: 'meta',
+        draggable: '.item',
+      })
+
+      const a = ul.children[0] as HTMLElement
+      const b = ul.children[2] as HTMLElement
+      click(a, { metaKey: true })
+      click(b, { metaKey: true })
+      expect(a.classList.contains('sortable-selected')).toBe(true)
+      expect(b.classList.contains('sortable-selected')).toBe(true)
+
+      click(b, { metaKey: true })
+      expect(b.classList.contains('sortable-selected')).toBe(false)
+      expect(a.classList.contains('sortable-selected')).toBe(true)
+    })
+
+    it('shift+click extends a range from the last selection', () => {
+      sortable = new Sortable(ul, {
+        multiDrag: true,
+        multiDragKey: 'meta',
+        draggable: '.item',
+      })
+
+      click(ul.children[0] as HTMLElement, { metaKey: true })
+      click(ul.children[2] as HTMLElement, { shiftKey: true })
+
+      const selected = Array.from(
+        ul.querySelectorAll('.sortable-selected')
+      ).map((el) => el.id)
+      expect(selected).toEqual(['it-0', 'it-1', 'it-2'])
+    })
+
+    it('without multiDragKey, plain click still selects (legacy default)', () => {
+      sortable = new Sortable(ul, { multiDrag: true, draggable: '.item' })
+
+      const item = ul.children[1] as HTMLElement
+      click(item)
+      expect(item.classList.contains('sortable-selected')).toBe(true)
+    })
+  })
+
+  describe('drag does not mutate the selection', () => {
+    it('dragging an unselected item leaves the selection untouched', () => {
+      sortable = new Sortable(ul, {
+        controlled: true,
+        multiDrag: true,
+        multiDragKey: 'meta',
+        draggable: '.item',
+        animation: 0,
+        // Pointer pipeline commits on pointerdown in this test
+        fallbackTolerance: 0,
+      })
+
+      // Select it-0 explicitly, then drag it-2 (unselected)
+      click(ul.children[0] as HTMLElement, { metaKey: true })
+      const dragged = ul.children[2] as HTMLElement
+      dragged.dispatchEvent(mkPointer('pointerdown', 1))
+
+      expect(dragged.classList.contains('sortable-selected')).toBe(false)
+      expect(
+        (ul.children[0] as HTMLElement).classList.contains('sortable-selected')
+      ).toBe(true)
+
+      document.dispatchEvent(mkPointer('pointerup', 1))
+    })
+  })
+
+  describe('ghost exclusion from item queries', () => {
+    it('the pointer-pipeline ghost never appears in getItems()', () => {
+      sortable = new Sortable(ul, {
+        controlled: true,
+        draggable: '.item',
+        animation: 0,
+        fallbackTolerance: 0,
+      })
+
+      const dragged = ul.children[1] as HTMLElement
+      dragged.dispatchEvent(mkPointer('pointerdown', 2))
+
+      const ghost = document.querySelector<HTMLElement>(
+        '[data-resortable-ghost]'
+      )
+      expect(ghost).not.toBeNull()
+      expect(ghost!.classList.contains('item')).toBe(true)
+      // Item queries see exactly the four real items
+      expect(sortable.dropZone.getItems().map((el) => el.id)).toEqual([
+        'it-0',
+        'it-1',
+        'it-2',
+        'it-3',
+      ])
+
+      document.dispatchEvent(mkPointer('pointerup', 2))
+      expect(document.querySelector('[data-resortable-ghost]')).toBeNull()
+    })
+  })
+
+  describe('scroll option', () => {
+    it('accepts scroll options without error and cleans up on destroy', () => {
+      sortable = new Sortable(ul, {
+        draggable: '.item',
+        scroll: true,
+        scrollSensitivity: 200,
+        scrollSpeed: 15,
+      })
+      expect(() => sortable.destroy()).not.toThrow()
+    })
+  })
+})

--- a/tests/unit/fallback-mode.spec.ts
+++ b/tests/unit/fallback-mode.spec.ts
@@ -352,7 +352,9 @@ describe('fallbackTolerance state machine (#29 PR3)', () => {
     document.dispatchEvent(makePointer('pointermove', 50, 24))
 
     expect(dm.isDragging).toBe(false)
-    expect(chooseSpy).not.toHaveBeenCalled()
+    // Legacy parity: `choose` fires at tap start, but the drag itself
+    // (start event, ghost, global state) must NOT have committed.
+    expect(chooseSpy).toHaveBeenCalledTimes(1)
     expect(startSpy).not.toHaveBeenCalled()
 
     document.dispatchEvent(makePointer('pointerup', 50, 24))
@@ -389,7 +391,7 @@ describe('fallbackTolerance state machine (#29 PR3)', () => {
     dm.detach()
   })
 
-  it('tolerance > 0: pointerup before threshold fires no drag events', () => {
+  it('tolerance > 0: pointerup before threshold is a click — choose/unchoose only, no drag', () => {
     const container = makeContainer()
     const target = container.firstElementChild as HTMLElement
     const zone = new DropZone(container)
@@ -401,9 +403,11 @@ describe('fallbackTolerance state machine (#29 PR3)', () => {
     dm.attach()
 
     const chooseSpy = vi.fn()
+    const unchooseSpy = vi.fn()
     const startSpy = vi.fn()
     const endSpy = vi.fn()
     events.on('choose', chooseSpy)
+    events.on('unchoose', unchooseSpy)
     events.on('start', startSpy)
     events.on('end', endSpy)
 
@@ -412,9 +416,13 @@ describe('fallbackTolerance state machine (#29 PR3)', () => {
     document.dispatchEvent(makePointer('pointerup', 53, 21))
 
     expect(dm.isDragging).toBe(false)
-    expect(chooseSpy).not.toHaveBeenCalled()
+    // Legacy parity: choose at tap start, balanced by unchoose on the
+    // abandoned tap. No drag lifecycle events, no chosen class left over.
+    expect(chooseSpy).toHaveBeenCalledTimes(1)
+    expect(unchooseSpy).toHaveBeenCalledTimes(1)
     expect(startSpy).not.toHaveBeenCalled()
     expect(endSpy).not.toHaveBeenCalled()
+    expect(target.classList.contains('sortable-chosen')).toBe(false)
     dm.detach()
   })
 })

--- a/tests/unit/ignore-option.test.ts
+++ b/tests/unit/ignore-option.test.ts
@@ -71,6 +71,8 @@ function makeManager(
   const dm = new DragManager(zone, events, undefined, {
     delayOnTouchOnly: 0,
     ignore: options?.ignore,
+    // Commit on pointerdown (explicit, independent of the default).
+    fallbackTolerance: 0,
   })
   dm.attach()
   return { dm, events }
@@ -210,6 +212,8 @@ describe('ignore option (issue #30)', () => {
       delayOnTouchOnly: 0,
       handle: '.drag-handle',
       // ignore defaults to 'a, img'
+      // Commit on pointerdown (explicit, independent of the default).
+      fallbackTolerance: 0,
     })
     dm.attach()
 

--- a/tests/unit/on-move.spec.ts
+++ b/tests/unit/on-move.spec.ts
@@ -59,9 +59,13 @@ function makeDragEvent(
 }
 
 function ids(container: HTMLElement): string[] {
-  return Array.from(container.querySelectorAll('.sortable-item')).map(
-    (el) => (el as HTMLElement).dataset.id ?? ''
-  )
+  // The placeholder is a clone of a real item (same classes), so exclude it
+  // via its canonical marker when reading the list order.
+  return Array.from(
+    container.querySelectorAll(
+      '.sortable-item:not([data-resortable-placeholder])'
+    )
+  ).map((el) => (el as HTMLElement).dataset.id ?? '')
 }
 
 describe('onMove (#33)', () => {
@@ -157,12 +161,9 @@ describe('onMove (#33)', () => {
 
     // The placeholder should now sit immediately after item-3 (dragging
     // down → naturalAfter = true).
-    // Placeholder element is created by GhostManager with the configured
-    // `ghostClass` (default `sortable-ghost`). We track it by querying the
-    // DOM directly — it's a non-`.sortable-item` child carrying that class.
-    const placeholder = container.querySelector(
-      '.sortable-ghost:not(.sortable-item)'
-    )
+    // The placeholder is a clone of the dragged item (so it shares its
+    // classes) marked with the canonical data attribute.
+    const placeholder = container.querySelector('[data-resortable-placeholder]')
     expect(placeholder).not.toBeNull()
     expect(placeholder?.previousElementSibling).toBe(item3)
   })
@@ -178,12 +179,9 @@ describe('onMove (#33)', () => {
     item1.dispatchEvent(makeDragEvent('dragstart'))
     item3.dispatchEvent(makeDragEvent('dragover'))
 
-    // Placeholder element is created by GhostManager with the configured
-    // `ghostClass` (default `sortable-ghost`). We track it by querying the
-    // DOM directly — it's a non-`.sortable-item` child carrying that class.
-    const placeholder = container.querySelector(
-      '.sortable-ghost:not(.sortable-item)'
-    )
+    // The placeholder is a clone of the dragged item (so it shares its
+    // classes) marked with the canonical data attribute.
+    const placeholder = container.querySelector('[data-resortable-placeholder]')
     expect(placeholder).not.toBeNull()
     expect(placeholder?.nextElementSibling).toBe(item3)
   })
@@ -266,12 +264,9 @@ describe('onMove (#33)', () => {
     item3.dispatchEvent(makeDragEvent('dragstart'))
     item1.dispatchEvent(makeDragEvent('dragover'))
 
-    // Placeholder element is created by GhostManager with the configured
-    // `ghostClass` (default `sortable-ghost`). We track it by querying the
-    // DOM directly — it's a non-`.sortable-item` child carrying that class.
-    const placeholder = container.querySelector(
-      '.sortable-ghost:not(.sortable-item)'
-    )
+    // The placeholder is a clone of the dragged item (so it shares its
+    // classes) marked with the canonical data attribute.
+    const placeholder = container.querySelector('[data-resortable-placeholder]')
     expect(placeholder).not.toBeNull()
     expect(placeholder?.previousElementSibling).toBe(item1)
   })


### PR DESCRIPTION
Five defects found by wiring the React adapter (#106) into a downstream design-system Controller and live-testing in Storybook, plus one missing feature.

## Fixes

### 1. Placeholder is now a clone of the dragged item
SortableJS's in-list drop indicator is the item itself wearing `ghostClass`. Ours was a bare gray `<li>` — next to rich item content (thumbnails, titles) it read as a rendering glitch. `createPlaceholder` now clones the dragged element, strips identity attributes (`id`, `dataIdAttr`, ARIA, `tabindex`), fixes its footprint, and keeps it hit-transparent.

### 2. Ghost excluded from item queries
With `fallbackOnBody: false` (default) the cursor-following ghost clone lives **inside the zone element** and keeps the item's classes — so it matched the consumer's `draggable` selector and was counted by `DropZone.getItems()`. Every index computed mid-drag was off, visible as an end-of-list placement bias. The ghost now carries `data-resortable-ghost` and is filtered out alongside the placeholder.

### 3. Controlled placement follows the pointer
The reorder branch decided insert-before vs insert-after from `compareDocumentPosition(placeholder, over)`. Two problems: it oscillates (each placeholder move flips their relative DOM order, so hovering one item ping-pongs), and it has no notion of grid geometry. Placement is now cursor-vs-midpoint along the detected layout axis — first two visible items on the same row → horizontal (covers rows and wrapping grids, where the hovered item's own row decides), otherwise vertical. Same rule applied when entering a zone over a sibling. DOM order remains the fallback for coordinate-less events (jsdom, synthetic tests); cross-list fallback defaults to insert-before.

### 4. `multiDragKey` option — selection is an explicit gesture
With `multiDrag: true`, every plain click toggled selection additively, and dragging an unselected item silently selected it. In an app where plain click has meaning (the consumer app: click = trigger clip), selection accumulated invisibly and a later drag moved the whole hidden selection. When `multiDragKey` (`'ctrl' | 'meta' | 'shift' | 'alt'`) is set: modifier+click toggles, shift+click extends a range, plain click does nothing — no selection, no focus steal (which also kills the focus ring browsers paint on click-focused items). Dragging an unselected item now never mutates the selection, in any mode. Default `null` keeps the old click-to-select behavior. SortableJS MultiDrag parity.

### 5. `fallbackTolerance` semantics tightened (default stays 0)
- `choose` (and `chosenClass`) now fire at pointerdown even when a tolerance is set — SortableJS parity — balanced by `unchoose` when the tap is released below the threshold.
- The pointermove that crosses the threshold is also processed as the first drag move, so single-move drags (automation, fast flicks) reorder instead of committing at their final position as a no-op.
- The ghost's grab-point anchors to the pointerdown position rather than the commit event (the pointer has already traveled by commit time).
- No `setPointerCapture` during the tolerance window — Firefox under synthesized input (Playwright) freezes pointermove coordinates while capture is held, making the threshold impossible to cross. Capture is taken at commit, as before.
- Default remains **0** (SortableJS parity, and Firefox automation can't cross a nonzero threshold — see above). Apps where plain click has its own meaning should pass a few px so clicks don't churn a full drag start/teardown; the consumer app passes `fallbackTolerance: 5`.

## Feature

### `scroll` / `scrollSensitivity` / `scrollSpeed` core options
SortableJS Scroll-plugin parity: `scroll: true` installs an **instance-owned** `AutoScrollPlugin` (bypassing the global `PluginSystem` name registry, so per-instance sensitivity/speed can't clash across sortables) and uninstalls it on `destroy()`.

## Tests
- New `tests/unit/controlled-parity.spec.ts` (9 tests): placeholder-clone semantics, ghost exclusion, `multiDragKey` gating, drag-doesn't-select, scroll option lifecycle
- `fallback-mode` unit + e2e updated for choose-at-tapstart / unchoose-on-abandoned-tap
- `on-move.spec.ts` / `ignore-option.test.ts` updated for the clone placeholder
- Local: 274 unit tests, full chromium + firefox e2e green (single remaining failure is the pre-existing "empty target zone" on-move spec, which fails on main too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdYhCz2wBSCMuJTUZ14igj