### PR TITLE
fix: hide the ghost during pointer hit-testing so rich item content can't swallow it

### DIFF
--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -1457,11 +1457,20 @@ export class DragManager implements DragManagerInterface {
     const activeDrag = globalDragState.getActiveDrag(dragId)
     if (!activeDrag) return
 
-    // Find the element under the mouse cursor. Optional call: older jsdom
-    // builds (CI) don't implement elementFromPoint, and this path is now
-    // reachable from unit tests via the capture-phase commit's first-move
-    // processing.
+    // Find the element under the mouse cursor. The cursor-following ghost
+    // sits exactly there: its inline `pointer-events: none` normally keeps
+    // it hit-transparent, but consumer CSS that re-enables pointer-events on
+    // item DESCENDANTS (`.item .overlay { pointer-events: auto }`) defeats
+    // the inherited none — elementFromPoint then returns the ghost's
+    // interior and, since the ghost is an identity-stripped clone, every
+    // index lookup on it misses. Hide the ghost for the hit test (legacy
+    // parity: Sortable.js `_hideGhostForTarget`). Optional call: older
+    // jsdom builds (CI) don't implement elementFromPoint.
+    const ghostEl = this.ghostManager.getGhostElement()
+    const savedGhostDisplay = ghostEl?.style.display
+    if (ghostEl) ghostEl.style.display = 'none'
     const elementUnderMouse = document.elementFromPoint?.(e.clientX, e.clientY)
+    if (ghostEl) ghostEl.style.display = savedGhostDisplay ?? ''
     const over = elementUnderMouse?.closest(
       this.draggable
     ) as HTMLElement | null

--- a/tests/e2e/controlled-pointer.spec.ts
+++ b/tests/e2e/controlled-pointer.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test, Page } from '@playwright/test'
+
+/**
+ * Controlled-mode POINTER-pipeline drags against items whose descendants
+ * re-enable `pointer-events` — the structure that broke the Visibox
+ * design-system integration.
+ *
+ * The cursor-following ghost is a clone positioned exactly under the
+ * cursor. Its inline `pointer-events: none` is defeated by consumer CSS
+ * like `.item .overlay { pointer-events: auto }`: elementFromPoint returns
+ * the ghost's interior, the identity-stripped clone misses every index
+ * lookup, and the placeholder never moves. The fix hides the ghost for the
+ * hit test (legacy parity: Sortable.js `_hideGhostForTarget`).
+ */
+
+async function buildControlledList(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    document.getElementById('ctl-pointer-list')?.remove()
+    const ul = document.createElement('ul')
+    ul.id = 'ctl-pointer-list'
+    ul.style.cssText =
+      'display:flex;gap:4px;list-style:none;padding:8px;position:absolute;top:40px;left:40px;background:#eef'
+    for (let i = 0; i < 4; i++) {
+      const li = document.createElement('li')
+      li.id = `cp-${i}`
+      li.className = 'cp-item'
+      li.style.cssText =
+        'width:50px;height:50px;background:#8ac;position:relative'
+      // Mirror rich item content that re-enables pointer-events on
+      // descendants (thumbnails, overlays, anchors).
+      li.innerHTML = `<div class="cp-overlay" style="position:absolute;inset:0;pointer-events:auto">${i}</div>`
+      ul.appendChild(li)
+    }
+    document.body.appendChild(ul)
+
+    interface WindowWithSortable extends Window {
+      Sortable?: typeof import('../../src/index.js').Sortable
+      __cpIntents?: Array<{ oldIndexes?: number[]; newIndexes?: number[] }>
+    }
+    const win = window as WindowWithSortable
+    const Sortable = win.Sortable
+    if (!Sortable) throw new Error('Sortable not loaded on window')
+    win.__cpIntents = []
+    new Sortable(ul, {
+      controlled: true,
+      draggable: '.cp-item',
+      dataIdAttr: 'id',
+      animation: 0,
+      onEnd: (evt) => {
+        win.__cpIntents?.push({
+          oldIndexes: evt.oldIndexes,
+          newIndexes: evt.newIndexes,
+        })
+      },
+    })
+  })
+}
+
+test.describe('controlled pointer drags with pointer-events:auto descendants', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/playground.html')
+    await page.waitForFunction(() => window.resortableLoaded === true)
+  })
+
+  test('placeholder tracks the cursor mid-list and the intent lands there', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    await buildControlledList(page)
+
+    const from = await page.locator('#cp-0').boundingBox()
+    const to = await page.locator('#cp-2').boundingBox()
+    if (!from || !to) throw new Error('missing boxes')
+
+    await page.mouse.move(from.x + 25, from.y + 25)
+    await page.mouse.down()
+    // Land right of cp-2's midpoint → insert AFTER it.
+    await page.mouse.move(to.x + 30, to.y + 25, { steps: 8 })
+
+    // Mid-drag: the placeholder (a clone of the dragged item) must have
+    // moved next to cp-2 — not be stuck at the start of the list.
+    const midState = await page.evaluate(() => {
+      const ul = document.getElementById('ctl-pointer-list')
+      if (!ul) return null
+      return Array.from(ul.children).map((el) =>
+        el.hasAttribute('data-resortable-placeholder')
+          ? 'PH'
+          : el.hasAttribute('data-resortable-ghost')
+            ? 'GHOST'
+            : el.id
+      )
+    })
+    expect(midState).not.toBeNull()
+    const phIdx = midState!.indexOf('PH')
+    const c2Idx = midState!.indexOf('cp-2')
+    expect(phIdx).toBeGreaterThan(c2Idx)
+
+    await page.mouse.up()
+
+    // Controlled: consumer DOM untouched, intent reports the drop index.
+    // Poll — the ghost settles onto the drop position with a short
+    // animation before it's removed.
+    await expect
+      .poll(async () =>
+        page.evaluate(() =>
+          Array.from(
+            document.querySelectorAll('#ctl-pointer-list .cp-item')
+          ).map((el) => el.id)
+        )
+      )
+      .toEqual(['cp-0', 'cp-1', 'cp-2', 'cp-3'])
+
+    const intents = await page.evaluate(
+      () =>
+        (
+          window as unknown as {
+            __cpIntents: Array<{ oldIndexes?: number[]; newIndexes?: number[] }>
+          }
+        ).__cpIntents
+    )
+    expect(intents.length).toBe(1)
+    expect(intents[0].oldIndexes).toEqual([0])
+    expect(intents[0].newIndexes).toEqual([2])
+  })
+})


### PR DESCRIPTION
Follow-up to #111, found during live Storybook QA of the the consumer app integration.

## Problem

The cursor-following ghost sits exactly under the pointer. Its inline `pointer-events: none` normally keeps it hit-transparent, but consumer CSS that re-enables pointer-events on item **descendants** (`.item .overlay { pointer-events: auto }` — the consumer app's clip thumbnails do this) defeats the inherited `none`. `document.elementFromPoint` then returns the ghost's own interior, and since the ghost is an identity-stripped clone, every index lookup on it misses — the placeholder never moves and drops become no-ops. Symptom in the consumer app: clips could effectively only be dropped where the placeholder started.

## Fix

Hide the ghost for the duration of the hit test and restore it immediately after — legacy parity with Sortable.js `_hideGhostForTarget()`.

## Test

New `tests/e2e/controlled-pointer.spec.ts` mirrors the failing structure (items whose overlay children re-enable pointer-events, dragged via the pointer pipeline) and asserts mid-drag placeholder tracking plus the final intent indices. Passes on chromium + firefox; fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdYhCz2wBSCMuJTUZ14igj

<!-- claude-session:ed99445c-8f69-4987-98c1-d922ed1fa6db -->
🔖 **Claude agent:** missioncontrol-53  
session id: `ed99445c-8f69-4987-98c1-d922ed1fa6db`