### PR TITLE
feat: multi-list marquee selection, handle-scoped modifier clicks, controlled React selection

### DIFF
--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -278,6 +278,7 @@ export class DragManager implements DragManagerInterface {
         deselectOnClickOutside: options?.deselectOnClickOutside,
         multiDrag: options?.multiSelect,
         multiDragKey: options?.multiDragKey,
+        handle: this.handle,
         controlled: this.controlled,
         ghostManager: this.ghostManager,
         draggable: this.draggable,
@@ -1125,10 +1126,13 @@ export class DragManager implements DragManagerInterface {
     // Check if the element is draggable
     if (!this.isDraggable(target)) return
 
-    // Check if drag should be allowed based on handle/filter options
+    // Check if drag should be allowed based on handle/filter options.
+    // preventDefault, but do NOT stopPropagation: the event must keep
+    // bubbling so ancestor listeners (e.g. MarqueeSelectPlugin's lasso
+    // start on a song row's empty space) still see presses that aren't
+    // drag-eligible for THIS zone.
     if (!this.shouldAllowDrag(e, target)) {
       e.preventDefault()
-      e.stopPropagation()
       return
     }
 

--- a/src/core/InstanceRegistry.ts
+++ b/src/core/InstanceRegistry.ts
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Element → Sortable instance registry
+ *
+ * Lives in its own module (rather than as a private WeakMap in `index.ts`)
+ * so plugins can resolve an arbitrary DOM node to its owning Sortable
+ * instance without importing the main entry point (which imports the
+ * plugins — a cycle).
+ *
+ * @internal
+ */
+import type { SortableInstance } from '../types/index.js'
+
+const instances = new WeakMap<HTMLElement, SortableInstance>()
+
+/** Register an instance under its container element. */
+export function registerInstance(
+  element: HTMLElement,
+  instance: SortableInstance
+): void {
+  instances.set(element, instance)
+}
+
+/** Remove an instance's registration (called from destroy()). */
+export function unregisterInstance(element: HTMLElement): void {
+  instances.delete(element)
+}
+
+/** Look up the instance bound to exactly this element. */
+export function getInstance(
+  element: HTMLElement
+): SortableInstance | undefined {
+  return instances.get(element)
+}
+
+/**
+ * Resolve the Sortable instance that owns a node: the nearest ancestor
+ * (starting at the node itself) registered as a sortable container.
+ */
+export function findOwningInstance(
+  node: Element | null
+): SortableInstance | undefined {
+  for (
+    let el = node instanceof HTMLElement ? node : node?.parentElement;
+    el;
+    el = el.parentElement
+  ) {
+    const instance = instances.get(el)
+    if (instance) return instance
+  }
+  return undefined
+}

--- a/src/core/KeyboardManager.ts
+++ b/src/core/KeyboardManager.ts
@@ -38,6 +38,10 @@ export class KeyboardManager {
   // When set, click-to-select requires this modifier key; plain clicks pass
   // through to the app untouched (see the `multiDragKey` option).
   private multiDragKey: 'ctrl' | 'meta' | 'shift' | 'alt' | null
+  // With a drag `handle` configured, modifier-click selection follows it:
+  // clicks elsewhere in the item (e.g. inside a nested sortable) pass
+  // through. Matches drag semantics — the handle is the item's grab surface.
+  private handle: string | null
   private dataIdAttr: string
   private onDocumentClick: ((e: MouseEvent) => void) | null = null
 
@@ -59,6 +63,7 @@ export class KeyboardManager {
       deselectOnClickOutside?: boolean
       multiDrag?: boolean
       multiDragKey?: 'ctrl' | 'meta' | 'shift' | 'alt' | null
+      handle?: string
       controlled?: boolean
       ghostManager?: GhostManager
       draggable?: string
@@ -68,6 +73,7 @@ export class KeyboardManager {
     this.deselectOnClickOutside = options?.deselectOnClickOutside ?? true
     this.multiDrag = options?.multiDrag ?? false
     this.multiDragKey = options?.multiDragKey ?? null
+    this.handle = options?.handle ?? null
     this.controlled = options?.controlled ?? false
     this.ghostManager = options?.ghostManager
     this.draggableSelector = options?.draggable ?? '.sortable-item'
@@ -305,6 +311,13 @@ export class KeyboardManager {
     // does nothing here — no selection, no focus steal — so the app keeps
     // its own plain-click semantics (e.g. activating/triggering the item).
     if (this.multiDragKey) {
+      // Selection clicks follow the drag handle when one is configured.
+      // Without this, a modifier-click on content nested inside the item
+      // (including a nested sortable's own items) would bubble here and
+      // toggle the OUTER item too.
+      if (this.handle && !(e.target as HTMLElement).closest(this.handle)) {
+        return
+      }
       if (e.shiftKey && this.selectionManager.getLastSelected()) {
         e.preventDefault()
         const last = this.selectionManager.getLastSelected()

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,10 +37,16 @@ import { AnimationManager } from './animation/AnimationManager.js'
 import { DragManager } from './core/DragManager.js'
 import { DropZone } from './core/DropZone.js'
 import { EventSystem } from './core/EventSystem.js'
+import {
+  getInstance,
+  registerInstance,
+  unregisterInstance,
+} from './core/InstanceRegistry.js'
 import { PluginSystem } from './core/PluginSystem.js'
 import { AutoScrollPlugin } from './plugins/AutoScrollPlugin.js'
 import {
   SortableOptions,
+  type SortableInstance,
   type SortablePlugin,
   type SortableEvents,
 } from './types/index.js'
@@ -75,12 +81,19 @@ export {
 } from './core/EventSystem.js'
 export { SelectionManager } from './core/SelectionManager.js'
 export { KeyboardManager } from './core/KeyboardManager.js'
+// Plugins consumers wire up themselves (no `./plugins` subpath export yet)
+export {
+  MarqueeSelectPlugin,
+  type MarqueeSelectOptions,
+  type MarqueeScopeEntry,
+  type MarqueeFilterConfig,
+} from './plugins/MarqueeSelectPlugin.js'
 export { GroupManager } from './core/GroupManager.js'
 export { GhostManager, type CreateGhostOptions } from './core/GhostManager.js'
 export { AnimationManager } from './animation/AnimationManager.js'
 
-// WeakMap to track Sortable instances by their elements
-const sortableInstances = new WeakMap<HTMLElement, Sortable>()
+// Element → instance tracking lives in core/InstanceRegistry.ts so plugins
+// can resolve owning instances without importing this module (cycle).
 
 /**
  * @beta
@@ -147,7 +160,7 @@ export class Sortable {
    * @public
    */
   public static get(element: HTMLElement): Sortable | undefined {
-    return sortableInstances.get(element)
+    return getInstance(element) as Sortable | undefined
   }
 
   /**
@@ -233,8 +246,7 @@ export class Sortable {
       }
 
       // Check if current element has a Sortable instance
-      // We'll need to track instances in a WeakMap
-      const sortable = sortableInstances.get(current)
+      const sortable = getInstance(current) as Sortable | undefined
       if (sortable) {
         return sortable
       }
@@ -296,7 +308,7 @@ export class Sortable {
     this.options = { ...defaultOptions, ...options }
 
     // Track this instance
-    sortableInstances.set(element, this)
+    registerInstance(element, this as unknown as SortableInstance)
 
     // Create animation manager first
     this.animationManager = new AnimationManager({
@@ -498,7 +510,7 @@ export class Sortable {
 
     this.dragManager.detach()
     // Remove from instance tracking
-    sortableInstances.delete(this.element)
+    unregisterInstance(this.element)
   }
 
   /**

--- a/src/plugins/MarqueeSelectPlugin.ts
+++ b/src/plugins/MarqueeSelectPlugin.ts
@@ -6,10 +6,21 @@
  * Provides Finder/Explorer-style marquee selection:
  *  - Click+drag on empty space to draw a selection rectangle
  *  - Alt+drag on items to start marquee instead of dragging
- *  - Shift held = additive, Alt held = subtractive
+ *  - Shift held at marquee start = additive, Alt held = subtractive
+ *    (cached at start — releasing the key mid-drag doesn't flip the mode)
+ *  - Optional multi-list `scope`: one marquee selects across MANY sortable
+ *    lists (each item's owning instance resolved via the instance
+ *    registry), with the first intersected kind locking the mode
+ *  - Optional `scrollContainer`: the marquee anchors to the container's
+ *    content (it stretches while the container scrolls) and dragging near
+ *    the container's top/bottom edge auto-scrolls it
  */
 
-import type { SortableInstance } from '../types/index.js'
+import type {
+  SelectionManagerInterface,
+  SortableInstance,
+} from '../types/index.js'
+import { findOwningInstance } from '../core/InstanceRegistry.js'
 import { BasePlugin, PluginUtils } from './PluginUtils.js'
 
 /** Filter config for include/exclude CSS selectors */
@@ -18,6 +29,22 @@ export interface MarqueeFilterConfig {
   include?: string
   /** Block when target matches this selector */
   exclude?: string
+}
+
+/**
+ * One kind of selectable item participating in a multi-list marquee.
+ * Kinds are mutually exclusive per marquee: the first kind the rectangle
+ * touches locks the mode until the selection is cleared (Finder-style
+ * "you're selecting clips OR songs, never both").
+ */
+export interface MarqueeScopeEntry {
+  /** CSS selector matching the participating items (e.g. `.clip`) */
+  itemSelector: string
+  /**
+   * Sub-element of the item that must intersect the marquee (e.g. a drag
+   * handle). Items without a match never intersect.
+   */
+  hitSelector?: string
 }
 
 export interface MarqueeSelectOptions {
@@ -39,18 +66,69 @@ export interface MarqueeSelectOptions {
   touchHoldDelay?: number
   /** Pixels of movement allowed during touch hold before cancelling. Default: 10 */
   touchHoldThreshold?: number
+  /**
+   * Multi-list scope. When set, the marquee hit-tests every element
+   * matching each entry's `itemSelector` inside the marquee area, resolves
+   * each item's owning Sortable instance, and applies selection through
+   * that instance (so per-instance `select` events fire normally). When
+   * omitted, only the installing instance's own items participate.
+   */
+  scope?: MarqueeScopeEntry[]
+  /**
+   * Scrollable container to anchor the marquee to. The marquee element is
+   * appended inside it (content coordinates, so it stretches while the
+   * container scrolls) and pointer positions near the container's top or
+   * bottom edge auto-scroll it. HTMLElement or CSS selector.
+   */
+  scrollContainer?: HTMLElement | string
+  /** Distance (px) from the scrollContainer edge that triggers auto-scroll. Default: 30 */
+  autoScrollDistance?: number
+  /** Auto-scroll speed in px per millisecond. Default: 0.3 */
+  autoScrollSpeed?: number
+}
+
+type ResolvedMarqueeOptions = Required<
+  Omit<MarqueeSelectOptions, 'scope' | 'scrollContainer'>
+> &
+  Pick<MarqueeSelectOptions, 'scope' | 'scrollContainer'>
+
+/** A scoped item with its owning instance and scope-entry index. */
+interface ScopedItem {
+  el: HTMLElement
+  instance: SortableInstance
+  kind: number
 }
 
 interface MarqueeState {
   active: boolean
+  /** Start/current points — content coords when scroll-anchored, else viewport */
   startX: number
   startY: number
   currentX: number
   currentY: number
+  /** Last raw pointer position (viewport coords) — drives edge auto-scroll */
+  lastClientX: number
+  lastClientY: number
   marqueeEl: HTMLElement | null
   pointerId: number | null
-  initialSelectionSnapshot: Set<HTMLElement>
-  anchorGroupName: string | null
+  /** Selection snapshot per participating instance, taken at marquee start */
+  snapshot: Map<SortableInstance, Set<HTMLElement>>
+  /** Additive (shift) / subtractive (alt) mode, cached at marquee start */
+  additive: boolean
+  subtractive: boolean
+  /** Scope-entry index the marquee is locked to (null until first hit) */
+  lockedKind: number | null
+  /** Edge auto-scroll direction currently engaged */
+  scrolling: 'up' | 'down' | false
+  scrollRaf: number | null
+  /**
+   * Scroll container's content size captured at marquee start. The marquee
+   * element itself lives INSIDE the container, so its growing rect inflates
+   * live scrollWidth/Height — clamping against the live values let the
+   * auto-scroll chase a bottom edge the marquee kept extending, scrolling
+   * forever past the real content.
+   */
+  contentLimit: { w: number; h: number } | null
   /** Touch hold timer ID (waiting for hold to confirm marquee intent) */
   holdTimer: number | null
   /** Whether marquee was triggered via touch hold */
@@ -67,7 +145,7 @@ type TouchDocumentHandlers = {
   upHandler: (e: TouchEvent) => void
 }
 
-const DEFAULT_OPTIONS: Required<MarqueeSelectOptions> = {
+const DEFAULT_OPTIONS: ResolvedMarqueeOptions = {
   marqueeClass: 'sortable-marquee',
   threshold: 5,
   altDragOnItems: true,
@@ -77,6 +155,10 @@ const DEFAULT_OPTIONS: Required<MarqueeSelectOptions> = {
   deselectFilter: {},
   touchHoldDelay: 300,
   touchHoldThreshold: 10,
+  scope: undefined,
+  scrollContainer: undefined,
+  autoScrollDistance: 30,
+  autoScrollSpeed: 0.3,
 }
 
 function createDefaultState(): MarqueeState {
@@ -86,10 +168,17 @@ function createDefaultState(): MarqueeState {
     startY: 0,
     currentX: 0,
     currentY: 0,
+    lastClientX: 0,
+    lastClientY: 0,
     marqueeEl: null,
     pointerId: null,
-    initialSelectionSnapshot: new Set(),
-    anchorGroupName: null,
+    snapshot: new Map(),
+    additive: false,
+    subtractive: false,
+    lockedKind: null,
+    scrolling: false,
+    scrollRaf: null,
+    contentLimit: null,
     holdTimer: null,
     isTouchHold: false,
   }
@@ -103,12 +192,12 @@ function getMarqueeRect(state: MarqueeState): DOMRect {
   return new DOMRect(x, y, w, h)
 }
 
-function resolveMarqueeArea(area: HTMLElement | string): HTMLElement {
-  if (area instanceof HTMLElement) return area
-  const el = document.querySelector<HTMLElement>(area)
+function resolveElement(ref: HTMLElement | string, what: string): HTMLElement {
+  if (ref instanceof HTMLElement) return ref
+  const el = document.querySelector<HTMLElement>(ref)
   if (!el)
     throw new Error(
-      `MarqueeSelectPlugin: marqueeArea selector "${area}" matched no element`
+      `MarqueeSelectPlugin: ${what} selector "${ref}" matched no element`
     )
   return el
 }
@@ -137,7 +226,7 @@ export class MarqueeSelectPlugin extends BasePlugin {
   public readonly name = 'MarqueeSelect'
   public readonly version = '2.0.0'
 
-  private opts: Required<MarqueeSelectOptions>
+  private opts: ResolvedMarqueeOptions
   private documentHandlers = new WeakMap<SortableInstance, DocumentHandlers>()
   private captureHandler = new WeakMap<
     SortableInstance,
@@ -148,6 +237,7 @@ export class MarqueeSelectPlugin extends BasePlugin {
     SortableInstance,
     (e: PointerEvent) => void
   >()
+  private scrollElement = new WeakMap<SortableInstance, HTMLElement>()
   private savedUserSelect = new WeakMap<SortableInstance, string>()
   private touchDocumentHandlers = new WeakMap<
     SortableInstance,
@@ -155,7 +245,7 @@ export class MarqueeSelectPlugin extends BasePlugin {
   >()
   private throttledUpdateSelection: WeakMap<
     SortableInstance,
-    (sortable: SortableInstance, state: MarqueeState, e: PointerEvent) => void
+    (sortable: SortableInstance, state: MarqueeState) => void
   > = new WeakMap()
 
   public static create(options?: MarqueeSelectOptions): MarqueeSelectPlugin {
@@ -164,7 +254,11 @@ export class MarqueeSelectPlugin extends BasePlugin {
 
   constructor(options?: MarqueeSelectOptions) {
     super()
-    this.opts = { ...DEFAULT_OPTIONS, ...options }
+    // Drop explicit-undefined entries so they can't clobber defaults.
+    const defined = Object.fromEntries(
+      Object.entries(options ?? {}).filter(([, v]) => v !== undefined)
+    )
+    this.opts = { ...DEFAULT_OPTIONS, ...defined }
   }
 
   protected onInstall(sortable: SortableInstance): void {
@@ -172,21 +266,25 @@ export class MarqueeSelectPlugin extends BasePlugin {
 
     // Throttled selection update (~60fps)
     const throttled = PluginUtils.throttle((...args: unknown[]) => {
-      const [s, st, ev] = args as [SortableInstance, MarqueeState, PointerEvent]
-      this.updateSelection(s, st, ev)
+      const [s, st] = args as [SortableInstance, MarqueeState]
+      this.updateSelection(s, st)
     }, 16)
     this.throttledUpdateSelection.set(
       sortable,
-      throttled as (
-        s: SortableInstance,
-        st: MarqueeState,
-        e: PointerEvent
-      ) => void
+      throttled as (s: SortableInstance, st: MarqueeState) => void
     )
 
     // Resolve and store the marquee area element
-    const area = resolveMarqueeArea(this.opts.marqueeArea)
+    const area = resolveElement(this.opts.marqueeArea, 'marqueeArea')
     this.areaElement.set(sortable, area)
+
+    // Resolve the scroll-anchor container, when configured
+    if (this.opts.scrollContainer) {
+      this.scrollElement.set(
+        sortable,
+        resolveElement(this.opts.scrollContainer, 'scrollContainer')
+      )
+    }
 
     // Attach pointerdown on the resolved area (manual, not addDOMListener,
     // to avoid key collisions when multiple instances target <html>)
@@ -219,6 +317,7 @@ export class MarqueeSelectPlugin extends BasePlugin {
       this.areaElement.delete(sortable)
       this.areaHandler.delete(sortable)
     }
+    this.scrollElement.delete(sortable)
 
     // Clean up capture handler (not tracked by BasePlugin since it's on document)
     const handler = this.captureHandler.get(sortable)
@@ -229,6 +328,73 @@ export class MarqueeSelectPlugin extends BasePlugin {
 
     // Remove data attribute
     delete sortable.element.dataset.marqueeClickAway
+  }
+
+  // ── Scope resolution ───────────────────────────────────────
+
+  /** The item kinds this marquee selects across (single-list fallback). */
+  private scopeEntries(sortable: SortableInstance): MarqueeScopeEntry[] {
+    if (this.opts.scope && this.opts.scope.length > 0) return this.opts.scope
+    return [{ itemSelector: sortable.options.draggable ?? '.sortable-item' }]
+  }
+
+  /** Root under which scoped items are queried. */
+  private scopeRoot(sortable: SortableInstance): ParentNode {
+    const scroll = this.scrollElement.get(sortable)
+    if (scroll) return scroll
+    const area = this.areaElement.get(sortable)
+    if (area && !isGlobalArea(area)) return area
+    return document
+  }
+
+  /**
+   * Collect every participating item with its owning instance. In
+   * single-list mode the owner is always the installing instance; in
+   * multi-list `scope` mode it's resolved via the instance registry.
+   */
+  private collectScopedItems(sortable: SortableInstance): ScopedItem[] {
+    const entries = this.scopeEntries(sortable)
+    const root = this.scopeRoot(sortable)
+    const out: ScopedItem[] = []
+    entries.forEach((entry, kind) => {
+      root.querySelectorAll<HTMLElement>(entry.itemSelector).forEach((el) => {
+        if (
+          el.hasAttribute('data-resortable-placeholder') ||
+          el.hasAttribute('data-resortable-ghost')
+        )
+          return
+        const instance = this.opts.scope
+          ? findOwningInstance(el)
+          : sortable.element.contains(el)
+            ? sortable
+            : undefined
+        if (!instance) return
+        out.push({ el, instance, kind })
+      })
+    })
+    return out
+  }
+
+  /** Selector matching ANY scoped item (alt+drag-on-item path). */
+  private scopedItemSelector(sortable: SortableInstance): string {
+    return this.scopeEntries(sortable)
+      .map((e) => e.itemSelector)
+      .join(', ')
+  }
+
+  /**
+   * Selector for surfaces that BLOCK marquee-start / click-away-deselect.
+   * An entry with a `hitSelector` only claims that sub-area (a song row
+   * blocks on its drag handle, but its empty body is valid marquee-start
+   * space — legacy Visibox MultiSelect exceptions were `.clip, .handle`,
+   * never the whole `.song`).
+   */
+  private scopedBlockingSelector(sortable: SortableInstance): string {
+    return this.scopeEntries(sortable)
+      .map((e) =>
+        e.hitSelector ? `${e.itemSelector} ${e.hitSelector}` : e.itemSelector
+      )
+      .join(', ')
   }
 
   // ── Pointer-down paths ─────────────────────────────────────
@@ -279,25 +445,23 @@ export class MarqueeSelectPlugin extends BasePlugin {
     // Prevent compatibility mouse events (click, mousedown, etc.)
     e.preventDefault()
 
-    const sm = sortable.dragManager?.selectionManager
-    const snapshot = new Set<HTMLElement>()
-    if (sm) {
-      sm.selectedElements.forEach((el) => snapshot.add(el))
-    }
-
+    const touchScroll = this.scrollElement.get(sortable)
     const state: MarqueeState = {
-      active: false,
+      ...createDefaultState(),
+      contentLimit: touchScroll
+        ? { w: touchScroll.scrollWidth, h: touchScroll.scrollHeight }
+        : null,
       startX,
       startY,
       currentX: startX,
       currentY: startY,
-      marqueeEl: null,
+      lastClientX: startX,
+      lastClientY: startY,
       pointerId,
-      initialSelectionSnapshot: snapshot,
-      anchorGroupName: null,
-      holdTimer: null,
+      snapshot: this.takeSnapshot(sortable),
       isTouchHold: true,
     }
+    state.lockedKind = this.kindOfSnapshot(sortable, state.snapshot)
 
     // ── Hold-period listeners (touch events, NOT pointer events) ──
 
@@ -319,7 +483,7 @@ export class MarqueeSelectPlugin extends BasePlugin {
       const touch = ev.changedTouches[0]
       cancelHold()
       // Handle click-away deselection for quick taps on empty space
-      if (touch && sm) {
+      if (touch) {
         const target = document.elementFromPoint(touch.clientX, touch.clientY)
         if (
           this.shouldDeselectOnClick(
@@ -327,7 +491,7 @@ export class MarqueeSelectPlugin extends BasePlugin {
             sortable
           )
         ) {
-          sm.clearSelection()
+          this.clearScopedSelections(sortable)
         }
       }
     }
@@ -352,7 +516,13 @@ export class MarqueeSelectPlugin extends BasePlugin {
       document.removeEventListener('touchend', onHoldTouchEnd)
       document.removeEventListener('touchcancel', onHoldTouchEnd)
 
-      // Hold succeeded — commit to marquee
+      // Hold succeeded — commit to marquee. Anchor the start point now
+      // (content coords when scroll-anchored).
+      const anchored = this.toMarqueePoint(sortable, startX, startY)
+      state.startX = anchored.x
+      state.startY = anchored.y
+      state.currentX = anchored.x
+      state.currentY = anchored.y
       this.setState(sortable, state)
       this.savedUserSelect.set(sortable, document.body.style.userSelect)
       suppressTextSelection()
@@ -369,8 +539,6 @@ export class MarqueeSelectPlugin extends BasePlugin {
             clientX: touch.clientX,
             clientY: touch.clientY,
             pointerId,
-            shiftKey: false,
-            altKey: false,
           } as unknown as PointerEvent,
           sortable
         )
@@ -406,14 +574,13 @@ export class MarqueeSelectPlugin extends BasePlugin {
     if (!e.altKey) return
     if (!this.canStartMarquee(e, sortable)) return
 
-    // Only intercept if target is inside this sortable's container
-    const el = sortable.element
-    if (!el.contains(e.target as Node)) return
-
-    // Must be on an actual item for alt+item path
-    const draggableSelector = sortable.options.draggable ?? '.sortable-item'
-    const target = (e.target as HTMLElement).closest(draggableSelector)
+    // Must be on a scoped item for the alt+item path. In single-list mode
+    // the item must also live inside this instance's container.
+    const target = (e.target as HTMLElement).closest<HTMLElement>(
+      this.scopedItemSelector(sortable)
+    )
     if (!target) return
+    if (!this.opts.scope && !sortable.element.contains(target)) return
 
     // Stop propagation so DragManager never sees this event
     e.stopPropagation()
@@ -447,9 +614,8 @@ export class MarqueeSelectPlugin extends BasePlugin {
   ): boolean {
     const target = e.target as HTMLElement
 
-    // Always exclude draggable items
-    const draggableSelector = sortable.options.draggable ?? '.sortable-item'
-    if (target.closest(draggableSelector)) return false
+    // Always exclude the participating items' grab surfaces
+    if (target.closest(this.scopedBlockingSelector(sortable))) return false
 
     const filter = this.opts.marqueeFilter
 
@@ -472,9 +638,8 @@ export class MarqueeSelectPlugin extends BasePlugin {
     // Guard: target must be an Element (not Document or other node types)
     if (!(target instanceof HTMLElement)) return true
 
-    // Don't deselect when clicking on a draggable item
-    const draggableSelector = sortable.options.draggable ?? '.sortable-item'
-    if (target.closest(draggableSelector)) return false
+    // Don't deselect when clicking on a participating item's grab surface
+    if (target.closest(this.scopedBlockingSelector(sortable))) return false
 
     const filter = this.opts.deselectFilter
 
@@ -487,31 +652,97 @@ export class MarqueeSelectPlugin extends BasePlugin {
     return true
   }
 
+  // ── Snapshot / selection helpers ───────────────────────────
+
+  /** Current selection per participating instance. */
+  private takeSnapshot(
+    sortable: SortableInstance
+  ): Map<SortableInstance, Set<HTMLElement>> {
+    const snapshot = new Map<SortableInstance, Set<HTMLElement>>()
+    for (const { instance } of this.collectScopedItems(sortable)) {
+      if (snapshot.has(instance)) continue
+      const sm = instance.dragManager?.selectionManager
+      snapshot.set(instance, new Set(sm ? sm.selectedElements : []))
+    }
+    // The installing instance always participates, even when it currently
+    // hosts no scoped items.
+    if (!snapshot.has(sortable)) {
+      const sm = sortable.dragManager?.selectionManager
+      snapshot.set(sortable, new Set(sm ? sm.selectedElements : []))
+    }
+    return snapshot
+  }
+
+  /**
+   * The scope kind of an existing selection (or null when empty) — an
+   * additive/subtractive marquee stays locked to the kind already selected,
+   * matching the mode-locking in Visibox's legacy MultiSelect.
+   */
+  private kindOfSnapshot(
+    sortable: SortableInstance,
+    snapshot: Map<SortableInstance, Set<HTMLElement>>
+  ): number | null {
+    const entries = this.scopeEntries(sortable)
+    for (const selected of snapshot.values()) {
+      for (const el of selected) {
+        const kind = entries.findIndex((entry) =>
+          el.matches(entry.itemSelector)
+        )
+        if (kind !== -1) return kind
+      }
+    }
+    return null
+  }
+
+  /** Clear the selection of every participating instance. */
+  private clearScopedSelections(sortable: SortableInstance): void {
+    const seen = new Set<SortableInstance>()
+    for (const { instance } of this.collectScopedItems(sortable)) {
+      if (seen.has(instance)) continue
+      seen.add(instance)
+      instance.dragManager?.selectionManager?.clearSelection()
+    }
+    if (!seen.has(sortable)) {
+      sortable.dragManager?.selectionManager?.clearSelection()
+    }
+  }
+
   // ── Marquee lifecycle ──────────────────────────────────────
 
   private beginMarquee(e: PointerEvent, sortable: SortableInstance): void {
     // Claim multi-instance lock
     activeMarqueeInstance = sortable
 
-    const sm = sortable.dragManager?.selectionManager
-    const snapshot = new Set<HTMLElement>()
-    if (sm) {
-      sm.selectedElements.forEach((el) => snapshot.add(el))
-    }
+    // Measure the content BEFORE the marquee element exists (see
+    // MarqueeState.contentLimit).
+    const scroll = this.scrollElement.get(sortable)
+    const contentLimit = scroll
+      ? { w: scroll.scrollWidth, h: scroll.scrollHeight }
+      : null
 
+    const start = this.toMarqueePoint(sortable, e.clientX, e.clientY)
     const state: MarqueeState = {
-      active: false, // becomes true after threshold
-      startX: e.clientX,
-      startY: e.clientY,
-      currentX: e.clientX,
-      currentY: e.clientY,
-      marqueeEl: null,
+      ...createDefaultState(),
+      contentLimit,
+      startX: start.x,
+      startY: start.y,
+      currentX: start.x,
+      currentY: start.y,
+      lastClientX: e.clientX,
+      lastClientY: e.clientY,
       pointerId: e.pointerId,
-      initialSelectionSnapshot: snapshot,
-      anchorGroupName: null,
-      holdTimer: null,
-      isTouchHold: false,
+      snapshot: this.takeSnapshot(sortable),
+      // Modifiers are cached at start (legacy parity): releasing shift/alt
+      // mid-drag must not flip the mode and blow away the selection.
+      additive: e.shiftKey,
+      subtractive: !e.shiftKey && e.altKey,
     }
+    // Additive/subtractive marquees stay locked to the kind already
+    // selected; a replace marquee re-locks on its first hit.
+    state.lockedKind =
+      state.additive || state.subtractive
+        ? this.kindOfSnapshot(sortable, state.snapshot)
+        : null
     this.setState(sortable, state)
 
     const area = this.areaElement.get(sortable)
@@ -532,12 +763,40 @@ export class MarqueeSelectPlugin extends BasePlugin {
     document.addEventListener('pointerup', upHandler)
   }
 
+  /**
+   * Convert a viewport point into the marquee's coordinate space:
+   * content coordinates of the scroll container when scroll-anchored
+   * (clamped inside the scrollable content, like the legacy Visibox
+   * marquee), viewport coordinates otherwise.
+   */
+  private toMarqueePoint(
+    sortable: SortableInstance,
+    clientX: number,
+    clientY: number
+  ): { x: number; y: number } {
+    const scroll = this.scrollElement.get(sortable)
+    if (!scroll) return { x: clientX, y: clientY }
+    // Clamp to the content size captured at marquee start when available —
+    // the live scrollWidth/Height include the marquee element itself.
+    const limit = this.getState<MarqueeState>(sortable)?.contentLimit
+    const maxX = (limit?.w ?? scroll.scrollWidth) - 1
+    const maxY = (limit?.h ?? scroll.scrollHeight) - 1
+    const rect = scroll.getBoundingClientRect()
+    return {
+      x: Math.max(1, Math.min(clientX - rect.left + scroll.scrollLeft, maxX)),
+      y: Math.max(1, Math.min(clientY - rect.top + scroll.scrollTop, maxY)),
+    }
+  }
+
   private onPointerMove(e: PointerEvent, sortable: SortableInstance): void {
     const state = this.getState<MarqueeState>(sortable)
     if (!state || state.pointerId !== e.pointerId) return
 
-    state.currentX = e.clientX
-    state.currentY = e.clientY
+    state.lastClientX = e.clientX
+    state.lastClientY = e.clientY
+    const point = this.toMarqueePoint(sortable, e.clientX, e.clientY)
+    state.currentX = point.x
+    state.currentY = point.y
 
     if (!state.active) {
       const dx = state.currentX - state.startX
@@ -554,17 +813,32 @@ export class MarqueeSelectPlugin extends BasePlugin {
       }
 
       state.marqueeEl = this.createMarqueeElement()
-      document.body.appendChild(state.marqueeEl)
+      const scroll = this.scrollElement.get(sortable)
+      if (scroll) {
+        // Content-anchored: absolute inside the scroll container, so the
+        // rectangle stretches while the container scrolls beneath the
+        // pointer. The container needs a positioning context.
+        state.marqueeEl.style.position = 'absolute'
+        if (window.getComputedStyle(scroll).position === 'static') {
+          scroll.style.position = 'relative'
+        }
+        scroll.appendChild(state.marqueeEl)
+      } else {
+        document.body.appendChild(state.marqueeEl)
+      }
       sortable.eventSystem.emit('marqueeStart')
     }
 
     // Always update visual position (unthrottled)
     this.updateMarqueeVisual(state)
 
+    // Edge auto-scroll of the scroll container
+    this.updateAutoScroll(sortable, state)
+
     // Throttled hit-testing
     const throttled = this.throttledUpdateSelection.get(sortable)
     if (throttled) {
-      throttled(sortable, state, e)
+      throttled(sortable, state)
     }
   }
 
@@ -574,8 +848,7 @@ export class MarqueeSelectPlugin extends BasePlugin {
 
     // Click-away deselection: sub-threshold click (marquee never activated)
     if (!state.active && this.shouldDeselectOnClick(e, sortable)) {
-      const sm = sortable.dragManager?.selectionManager
-      if (sm) sm.clearSelection()
+      this.clearScopedSelections(sortable)
     }
 
     this.endMarquee(sortable)
@@ -590,6 +863,13 @@ export class MarqueeSelectPlugin extends BasePlugin {
       window.clearTimeout(state.holdTimer)
       state.holdTimer = null
     }
+
+    // Stop edge auto-scroll
+    if (state.scrollRaf !== null) {
+      window.cancelAnimationFrame(state.scrollRaf)
+      state.scrollRaf = null
+    }
+    state.scrolling = false
 
     // Remove marquee element
     if (state.marqueeEl) {
@@ -635,6 +915,81 @@ export class MarqueeSelectPlugin extends BasePlugin {
     }
   }
 
+  // ── Edge auto-scroll (scrollContainer only) ────────────────
+
+  /**
+   * Auto-scroll the anchored container while the pointer sits near its
+   * top/bottom edge, stretching the marquee and re-hit-testing as content
+   * moves. Time-based speed (px/ms) like the legacy Visibox marquee.
+   */
+  private updateAutoScroll(
+    sortable: SortableInstance,
+    state: MarqueeState
+  ): void {
+    const scroll = this.scrollElement.get(sortable)
+    if (!scroll || !state.active) return
+
+    state.scrolling = this.scrollDirection(state, scroll)
+    if (!state.scrolling || state.scrollRaf !== null) return
+
+    // One loop at a time (guarded by scrollRaf). The frame timestamp lives
+    // in the closure — the loop is the only writer, so re-evaluating the
+    // direction each frame can never reset the clock (a reset made every
+    // elapsed read 0 and the marquee never actually scrolled).
+    let last = 0
+    const tick = (now: number): void => {
+      state.scrollRaf = null
+      if (!state.active) return
+      state.scrolling = this.scrollDirection(state, scroll)
+      if (!state.scrolling) return
+
+      const elapsed = last === 0 ? 0 : now - last
+      last = now
+      const delta = Math.round(elapsed * this.opts.autoScrollSpeed)
+      scroll.scrollBy(0, state.scrolling === 'up' ? -delta : delta)
+
+      // The container moved under a stationary pointer: recompute the
+      // current corner from the last raw pointer position, redraw, and
+      // re-run the (throttled) hit test.
+      const point = this.toMarqueePoint(
+        sortable,
+        state.lastClientX,
+        state.lastClientY
+      )
+      state.currentX = point.x
+      state.currentY = point.y
+      this.updateMarqueeVisual(state)
+      this.throttledUpdateSelection.get(sortable)?.(sortable, state)
+
+      state.scrollRaf = window.requestAnimationFrame(tick)
+    }
+    state.scrollRaf = window.requestAnimationFrame(tick)
+  }
+
+  /** Edge test: which way should the container scroll for the pointer's
+   *  current position — with room left to actually scroll that way. */
+  private scrollDirection(
+    state: MarqueeState,
+    scroll: HTMLElement
+  ): 'up' | 'down' | false {
+    const rect = scroll.getBoundingClientRect()
+    const distance = this.opts.autoScrollDistance
+    if (state.lastClientY < rect.top + distance && scroll.scrollTop > 0) {
+      return 'up'
+    }
+    // "Room to scroll down" is measured against the content captured at
+    // marquee start — the marquee element inflates the live scrollHeight,
+    // which made this chase a bottom edge of its own making.
+    const contentHeight = state.contentLimit?.h ?? scroll.scrollHeight
+    if (
+      state.lastClientY > rect.bottom - distance &&
+      scroll.scrollTop + scroll.clientHeight < contentHeight
+    ) {
+      return 'down'
+    }
+    return false
+  }
+
   // ── Visual ─────────────────────────────────────────────────
 
   private createMarqueeElement(): HTMLElement {
@@ -662,89 +1017,101 @@ export class MarqueeSelectPlugin extends BasePlugin {
 
   // ── Hit-testing & selection ────────────────────────────────
 
-  private updateSelection(
+  /**
+   * The marquee rectangle in VIEWPORT coordinates — computed from state
+   * (not from `marqueeEl.getBoundingClientRect()`, which needs layout):
+   * content coords are mapped back through the scroll container's current
+   * scroll position, so the rect is correct mid-auto-scroll too.
+   */
+  private marqueeViewportRect(
     sortable: SortableInstance,
-    state: MarqueeState,
-    e: PointerEvent
-  ): void {
-    const sm = sortable.dragManager?.selectionManager
-    if (!sm) return
-
-    const marqueeRect = getMarqueeRect(state)
-    const draggableSelector = sortable.options.draggable ?? '.sortable-item'
-    const items = Array.from(
-      sortable.element.querySelectorAll<HTMLElement>(draggableSelector)
+    state: MarqueeState
+  ): DOMRect {
+    const rect = getMarqueeRect(state)
+    const scroll = this.scrollElement.get(sortable)
+    if (!scroll) return rect
+    const c = scroll.getBoundingClientRect()
+    return new DOMRect(
+      rect.x + c.left - scroll.scrollLeft,
+      rect.y + c.top - scroll.scrollTop,
+      rect.width,
+      rect.height
     )
-
-    const intersected = items.filter((item) => {
-      if (!PluginUtils.isVisible(item)) return false
-      const itemRect = PluginUtils.getRect(item)
-      return PluginUtils.rectsOverlap(marqueeRect, itemRect)
-    })
-
-    this.applyMarqueeSelection(sm, state, intersected, e.shiftKey, e.altKey)
   }
 
-  private applyMarqueeSelection(
-    sm: {
-      readonly selectedElements: Set<HTMLElement>
-      select(item: HTMLElement, addToSelection?: boolean): void
-      deselect(item: HTMLElement): void
-      clearSelection(): void
-    },
-    state: MarqueeState,
-    intersected: HTMLElement[],
-    shiftKey: boolean,
-    altKey: boolean
+  private updateSelection(
+    sortable: SortableInstance,
+    state: MarqueeState
   ): void {
-    const snapshot = state.initialSelectionSnapshot
-    const intersectedSet = new Set(intersected)
+    // Throttled — may fire after pointerup already tore the marquee down.
+    if (!state.active) return
 
-    if (altKey) {
-      // Subtractive: restore snapshot, then remove intersected
-      // First restore any snapshot items that were deselected
-      snapshot.forEach((el) => {
-        if (!sm.selectedElements.has(el)) {
-          sm.select(el, true)
-        }
-      })
-      // Deselect items not in snapshot
-      sm.selectedElements.forEach((el) => {
-        if (!snapshot.has(el)) {
-          sm.deselect(el)
-        }
-      })
-      // Now remove intersected from selection
-      intersectedSet.forEach((el) => {
-        if (sm.selectedElements.has(el)) {
-          sm.deselect(el)
-        }
-      })
-    } else if (shiftKey) {
-      // Additive: restore snapshot + add intersected
-      snapshot.forEach((el) => {
-        if (!sm.selectedElements.has(el)) {
-          sm.select(el, true)
-        }
-      })
-      // Deselect items not in snapshot that aren't intersected
-      sm.selectedElements.forEach((el) => {
-        if (!snapshot.has(el) && !intersectedSet.has(el)) {
-          sm.deselect(el)
-        }
-      })
-      // Add intersected
-      intersectedSet.forEach((el) => {
-        if (!sm.selectedElements.has(el)) {
-          sm.select(el, true)
-        }
-      })
-    } else {
-      // Replace: clear all, select only intersected
-      sm.clearSelection()
-      intersected.forEach((el) => {
-        sm.select(el, true)
-      })
+    const marqueeRect = this.marqueeViewportRect(sortable, state)
+
+    const entries = this.scopeEntries(sortable)
+    const items = this.collectScopedItems(sortable)
+    let intersected = items.filter((item) => {
+      if (!PluginUtils.isVisible(item.el)) return false
+      const hitSelector = entries[item.kind]?.hitSelector
+      const hitEl = hitSelector
+        ? item.el.querySelector<HTMLElement>(hitSelector)
+        : item.el
+      if (!hitEl) return false
+      return PluginUtils.rectsOverlap(marqueeRect, PluginUtils.getRect(hitEl))
+    })
+
+    // Mode locking: the first kind the marquee touches wins; other kinds
+    // are ignored for the rest of the marquee.
+    if (state.lockedKind === null && intersected.length > 0) {
+      state.lockedKind = intersected[0].kind
+    }
+    if (state.lockedKind !== null) {
+      intersected = intersected.filter((i) => i.kind === state.lockedKind)
+    }
+
+    this.applyMarqueeSelection(state, items, intersected)
+  }
+
+  /**
+   * Apply the marquee result per participating instance, as a DIFF against
+   * that instance's current selection — one select/deselect (and one
+   * `select` event) per actual change, never a clear-and-rebuild storm.
+   */
+  private applyMarqueeSelection(
+    state: MarqueeState,
+    allItems: ScopedItem[],
+    intersected: ScopedItem[]
+  ): void {
+    const intersectedSet = new Set(intersected.map((i) => i.el))
+
+    // Instances that host scoped items now, plus any that had a snapshot.
+    const instances = new Set<SortableInstance>(state.snapshot.keys())
+    for (const item of allItems) instances.add(item.instance)
+
+    for (const instance of instances) {
+      const sm: SelectionManagerInterface | undefined =
+        instance.dragManager?.selectionManager
+      if (!sm) continue
+      const snap = state.snapshot.get(instance) ?? new Set<HTMLElement>()
+      const here = intersected
+        .filter((i) => i.instance === instance)
+        .map((i) => i.el)
+
+      let wanted: Set<HTMLElement>
+      if (state.subtractive) {
+        wanted = new Set([...snap].filter((el) => !intersectedSet.has(el)))
+      } else if (state.additive) {
+        wanted = new Set([...snap, ...here])
+      } else {
+        wanted = new Set(here)
+      }
+
+      for (const el of Array.from(sm.selectedElements)) {
+        if (!wanted.has(el)) sm.deselect(el)
+      }
+      for (const el of wanted) {
+        if (!sm.selectedElements.has(el)) sm.select(el, true)
+      }
     }
   }
 }

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -8,6 +8,7 @@ export { AutoScrollPlugin, type AutoScrollOptions } from './AutoScrollPlugin.js'
 export {
   MarqueeSelectPlugin,
   type MarqueeSelectOptions,
+  type MarqueeScopeEntry,
   type MarqueeFilterConfig,
 } from './MarqueeSelectPlugin.js'
 export { OnSpillPlugin, type OnSpillOptions } from './OnSpillPlugin.js'

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -43,6 +43,13 @@ export type UseSortableOptions = Omit<
   onSort: (intent: SortIntent) => void
   /** Mirrors multi-drag selection changes out as data-ids */
   onSelectionChange?: (ids: string[]) => void
+  /**
+   * Controlled selection: data-ids that should be selected in this list.
+   * Ids not present in the list are ignored, so a consumer may pass one
+   * app-wide selection array to every zone. Pair with `onSelectionChange`
+   * to make consumer state the single source of truth.
+   */
+  selectedIds?: readonly string[]
   /** Names this zone in cross-list intents (fromId/toId) */
   id?: string
 }
@@ -68,7 +75,12 @@ interface ZoneRecord {
 const zones = new WeakMap<HTMLElement, ZoneRecord>()
 
 /** Option keys the adapter owns — never forwarded to the core instance. */
-const ADAPTER_KEYS = new Set(['onSort', 'onSelectionChange', 'id'])
+const ADAPTER_KEYS = new Set([
+  'onSort',
+  'onSelectionChange',
+  'selectedIds',
+  'id',
+])
 
 /**
  * Core callback options that must read the latest consumer prop at call
@@ -128,6 +140,10 @@ export function useSortable<T extends HTMLElement = HTMLElement>(
   const prevOptionsRef = useRef<UseSortableOptions | null>(null)
   const queuedDiffRef = useRef<Map<string, unknown>>(new Map())
   const flushRafRef = useRef(0)
+  // True while the controlled-selection effect is writing to the
+  // SelectionManager — suppresses the select-event mirror so applying the
+  // consumer's own state never echoes back as onSelectionChange calls.
+  const syncingSelectionRef = useRef(false)
   optionsRef.current = options
 
   const ref = useCallback((el: T | null) => setElement(el), [])
@@ -249,6 +265,7 @@ export function useSortable<T extends HTMLElement = HTMLElement>(
 
     // Selection bridge: elements → data-ids at the boundary.
     sortable.eventSystem.on('select', (event) => {
+      if (syncingSelectionRef.current) return
       const items = event.items ?? []
       optionsRef.current.onSelectionChange?.(
         items.map((el, i) => readId(el, i))
@@ -305,6 +322,43 @@ export function useSortable<T extends HTMLElement = HTMLElement>(
           nextValue as SortableOptions[keyof SortableOptions]
         )
       }
+    }
+  })
+
+  // Controlled selection — when `selectedIds` is provided, consumer state
+  // is authoritative. Runs every render (like the option diff above): the
+  // set of matching DOM nodes can change without the prop's identity
+  // changing (re-renders, cross-list moves). Skipped mid-drag — the
+  // internal selection IS the dragged set; the consumer's post-drop
+  // re-render re-runs the sync. Ids with no matching item here are
+  // ignored, so one app-wide selection array can be passed to every zone.
+  useEffect(() => {
+    const ids = optionsRef.current.selectedIds
+    if (ids === undefined) return
+    const sortable = sortableRef.current
+    const el = sortable?.element
+    if (!sortable || !el || Sortable.active) return
+
+    const attr = dataIdAttr()
+    const selection = sortable.dragManager.selectionManager
+    const wanted: HTMLElement[] = []
+    for (const id of ids) {
+      const item = el.querySelector<HTMLElement>(
+        `[${attr}="${escapeAttr(id)}"]`
+      )
+      if (item) wanted.push(item)
+    }
+    const current = selection.selectedElements
+    const inSync =
+      current.size === wanted.length && wanted.every((w) => current.has(w))
+    if (inSync) return
+
+    syncingSelectionRef.current = true
+    try {
+      selection.clearSelection()
+      for (const item of wanted) selection.select(item, true)
+    } finally {
+      syncingSelectionRef.current = false
     }
   })
 

--- a/tests/unit/controlled-parity.spec.ts
+++ b/tests/unit/controlled-parity.spec.ts
@@ -172,6 +172,35 @@ describe('controlled-mode parity fixes (2026-07)', () => {
       expect(a.classList.contains('sortable-selected')).toBe(true)
     })
 
+    it('with a handle configured, modifier+click selects only via the handle', () => {
+      // Give each item a handle child plus other content.
+      for (const li of Array.from(ul.children)) {
+        const handle = document.createElement('span')
+        handle.className = 'grip'
+        const body = document.createElement('span')
+        body.className = 'body'
+        li.append(handle, body)
+      }
+      sortable = new Sortable(ul, {
+        multiDrag: true,
+        multiDragKey: 'meta',
+        draggable: '.item',
+        handle: '.grip',
+      })
+
+      const item = ul.children[1] as HTMLElement
+      const body = item.querySelector('.body') as HTMLElement
+      const grip = item.querySelector('.grip') as HTMLElement
+
+      // Modifier+click on non-handle content (e.g. a nested sortable's
+      // items) passes through — the outer item must NOT toggle.
+      click(body, { metaKey: true })
+      expect(item.classList.contains('sortable-selected')).toBe(false)
+
+      click(grip, { metaKey: true })
+      expect(item.classList.contains('sortable-selected')).toBe(true)
+    })
+
     it('shift+click extends a range from the last selection', () => {
       sortable = new Sortable(ul, {
         multiDrag: true,

--- a/tests/unit/marquee-select.test.ts
+++ b/tests/unit/marquee-select.test.ts
@@ -441,15 +441,16 @@ describe('MarqueeSelectPlugin', () => {
       // Pre-select item 4
       sm.select(items[4], true)
 
-      // Draw marquee over items 0-1 with Shift
-      const down = pointerEvent('pointerdown', { clientX: 40, clientY: 40 })
-      sortable.element.dispatchEvent(down)
-
-      const move = pointerEvent('pointermove', {
-        clientX: 270,
-        clientY: 95,
+      // Draw marquee over items 0-1 with Shift held at START (the mode is
+      // cached at pointerdown — legacy parity)
+      const down = pointerEvent('pointerdown', {
+        clientX: 40,
+        clientY: 40,
         shiftKey: true,
       })
+      sortable.element.dispatchEvent(down)
+
+      const move = pointerEvent('pointermove', { clientX: 270, clientY: 95 })
       document.dispatchEvent(move)
 
       expect(sm.selectedElements.has(items[0])).toBe(true)
@@ -467,15 +468,16 @@ describe('MarqueeSelectPlugin', () => {
       sm.select(items[1], true)
       sm.select(items[2], true)
 
-      // Draw marquee over items 0-1 with Alt
-      const down = pointerEvent('pointerdown', { clientX: 40, clientY: 40 })
-      sortable.element.dispatchEvent(down)
-
-      const move = pointerEvent('pointermove', {
-        clientX: 270,
-        clientY: 95,
+      // Draw marquee over items 0-1 with Alt held at START (the mode is
+      // cached at pointerdown — legacy parity)
+      const down = pointerEvent('pointerdown', {
+        clientX: 40,
+        clientY: 40,
         altKey: true,
       })
+      sortable.element.dispatchEvent(down)
+
+      const move = pointerEvent('pointermove', { clientX: 270, clientY: 95 })
       document.dispatchEvent(move)
 
       // Items 0 and 1 should be deselected (intersected + alt = subtract)
@@ -926,6 +928,229 @@ describe('MarqueeSelectPlugin', () => {
 
       plugin.uninstall(sortable)
       expect(sortable.element.dataset.marqueeClickAway).toBeUndefined()
+    })
+  })
+
+  describe('Cached modifiers (2026-07 MultiSelect parity)', () => {
+    it('stays additive when shift is released mid-drag', () => {
+      plugin.install(sortable)
+      const sm = sortable.dragManager!.selectionManager
+      sm.select(items[4], true)
+
+      // Shift held at pointerdown only
+      const down = pointerEvent('pointerdown', {
+        clientX: 40,
+        clientY: 40,
+        shiftKey: true,
+      })
+      sortable.element.dispatchEvent(down)
+
+      // Shift already released on every move
+      const move = pointerEvent('pointermove', { clientX: 270, clientY: 95 })
+      document.dispatchEvent(move)
+
+      expect(sm.selectedElements.has(items[0])).toBe(true)
+      expect(sm.selectedElements.has(items[1])).toBe(true)
+      // The snapshot selection survives — the mode was cached at start.
+      expect(sm.selectedElements.has(items[4])).toBe(true)
+    })
+
+    it('does not turn additive when shift is pressed mid-drag', () => {
+      plugin.install(sortable)
+      const sm = sortable.dragManager!.selectionManager
+      sm.select(items[4], true)
+
+      const down = pointerEvent('pointerdown', { clientX: 40, clientY: 40 })
+      sortable.element.dispatchEvent(down)
+
+      const move = pointerEvent('pointermove', {
+        clientX: 270,
+        clientY: 95,
+        shiftKey: true,
+      })
+      document.dispatchEvent(move)
+
+      // Replace mode was cached at start: prior selection is gone.
+      expect(sm.selectedElements.has(items[4])).toBe(false)
+      expect(sm.selectedElements.has(items[0])).toBe(true)
+    })
+  })
+
+  describe('Multi-list scope (2026-07 MultiSelect parity)', () => {
+    let wrapper: HTMLElement
+    let clipsA: HTMLElement[]
+    let clipsB: HTMLElement[]
+    let songs: HTMLElement[]
+    let sortableA: SortableInstance
+    let sortableB: SortableInstance
+    let sortableSongs: SortableInstance
+
+    /** Build `count` items with a class + a nested handle child. */
+    function scopedItems(count: number, cls: string): HTMLElement[] {
+      return Array.from({ length: count }, (_, i) => {
+        const el = document.createElement('div')
+        el.className = cls
+        el.dataset.id = `${cls}-${i + 1}`
+        const handle = document.createElement('span')
+        handle.className = 'handle'
+        el.appendChild(handle)
+        return el
+      })
+    }
+
+    function mockHandleRects(
+      els: HTMLElement[],
+      rects: { x: number; y: number; width: number; height: number }[]
+    ) {
+      els.forEach((item, i) => {
+        const handle = item.querySelector('.handle') as HTMLElement
+        if (rects[i]) {
+          vi.spyOn(handle, 'getBoundingClientRect').mockReturnValue(
+            new DOMRect(rects[i].x, rects[i].y, rects[i].width, rects[i].height)
+          )
+        }
+      })
+    }
+
+    beforeEach(async () => {
+      const { registerInstance } = await import(
+        '../../src/core/InstanceRegistry.js'
+      )
+      wrapper = document.createElement('div')
+      document.body.appendChild(wrapper)
+
+      clipsA = scopedItems(3, 'clip')
+      clipsB = scopedItems(3, 'clip')
+      songs = scopedItems(2, 'song')
+
+      sortableA = createMockSortable(clipsA)
+      sortableB = createMockSortable(clipsB)
+      sortableSongs = createMockSortable(songs)
+      ;(sortableA.options as { draggable?: string }).draggable = '.clip'
+      ;(sortableB.options as { draggable?: string }).draggable = '.clip'
+      ;(sortableSongs.options as { draggable?: string }).draggable = '.song'
+
+      // Song rows CONTAIN the clip grids (like the Visibox controller).
+      songs[0].appendChild(sortableA.element)
+      songs[1].appendChild(sortableB.element)
+      wrapper.appendChild(sortableSongs.element)
+
+      registerInstance(sortableA.element, sortableA)
+      registerInstance(sortableB.element, sortableB)
+      registerInstance(sortableSongs.element, sortableSongs)
+
+      // Rows: song 1 at y=0..200 (clips A at y=50), song 2 at y=200..400
+      // (clips B at y=250). Song handles hug the left edge (x=0..20).
+      mockItemRects(songs, [
+        { x: 0, y: 0, width: 400, height: 200 },
+        { x: 0, y: 200, width: 400, height: 200 },
+      ])
+      mockHandleRects(songs, [
+        { x: 0, y: 0, width: 20, height: 200 },
+        { x: 0, y: 200, width: 20, height: 200 },
+      ])
+      mockItemRects(clipsA, [
+        { x: 50, y: 50, width: 100, height: 40 },
+        { x: 160, y: 50, width: 100, height: 40 },
+        { x: 270, y: 50, width: 100, height: 40 },
+      ])
+      mockItemRects(clipsB, [
+        { x: 50, y: 250, width: 100, height: 40 },
+        { x: 160, y: 250, width: 100, height: 40 },
+        { x: 270, y: 250, width: 100, height: 40 },
+      ])
+
+      vi.spyOn(window, 'getComputedStyle').mockImplementation(
+        () =>
+          ({
+            display: 'block',
+            visibility: 'visible',
+            opacity: '1',
+            position: 'relative',
+          }) as CSSStyleDeclaration
+      )
+
+      plugin = MarqueeSelectPlugin.create({
+        marqueeArea: wrapper,
+        scope: [
+          { itemSelector: '.clip' },
+          { itemSelector: '.song', hitSelector: '.handle' },
+        ],
+      })
+      plugin.install(sortableSongs)
+    })
+
+    afterEach(() => {
+      plugin.uninstall(sortableSongs)
+      wrapper.remove()
+    })
+
+    it("selects clips across MULTIPLE lists through each list's own instance", () => {
+      // Marquee from (40,40) to (200,300) — covers clipsA[0..1] and clipsB[0..1]
+      wrapper.dispatchEvent(
+        pointerEvent('pointerdown', { clientX: 40, clientY: 40 })
+      )
+      document.dispatchEvent(
+        pointerEvent('pointermove', { clientX: 265, clientY: 300 })
+      )
+
+      const smA = sortableA.dragManager!.selectionManager
+      const smB = sortableB.dragManager!.selectionManager
+      expect(smA.selectedElements.has(clipsA[0])).toBe(true)
+      expect(smA.selectedElements.has(clipsA[1])).toBe(true)
+      expect(smA.selectedElements.has(clipsA[2])).toBe(false)
+      expect(smB.selectedElements.has(clipsB[0])).toBe(true)
+      expect(smB.selectedElements.has(clipsB[1])).toBe(true)
+    })
+
+    it('locks the mode to the first intersected kind', () => {
+      // First hit only song 1's handle (x 0..20) → mode locks to songs.
+      wrapper.dispatchEvent(
+        pointerEvent('pointerdown', { clientX: 5, clientY: 40 })
+      )
+      document.dispatchEvent(
+        pointerEvent('pointermove', { clientX: 18, clientY: 95 })
+      )
+      const smSongs = sortableSongs.dragManager!.selectionManager
+      expect(smSongs.selectedElements.has(songs[0])).toBe(true)
+
+      // Extend over clip A1 too — mode already locked to songs; clips ignored
+      document.dispatchEvent(
+        pointerEvent('pointermove', { clientX: 155, clientY: 95 })
+      )
+      const smA = sortableA.dragManager!.selectionManager
+      expect(smA.selectedElements.size).toBe(0)
+      expect(smSongs.selectedElements.has(songs[0])).toBe(true)
+    })
+
+    it('songs are hit by their HANDLE, not the whole row', () => {
+      // Rect over the row body (right of the handle) — no song selected
+      wrapper.dispatchEvent(
+        pointerEvent('pointerdown', { clientX: 380, clientY: 5 })
+      )
+      document.dispatchEvent(
+        pointerEvent('pointermove', { clientX: 390, clientY: 45 })
+      )
+      const smSongs = sortableSongs.dragManager!.selectionManager
+      expect(smSongs.selectedElements.size).toBe(0)
+    })
+
+    it('sub-threshold click-away clears the selection of EVERY scoped list', () => {
+      const smA = sortableA.dragManager!.selectionManager
+      const smB = sortableB.dragManager!.selectionManager
+      smA.select(clipsA[0], true)
+      smB.select(clipsB[0], true)
+
+      // Click empty wrapper space without moving
+      wrapper.dispatchEvent(
+        pointerEvent('pointerdown', { clientX: 395, clientY: 395 })
+      )
+      const up = pointerEvent('pointerup', { clientX: 395, clientY: 395 })
+      Object.defineProperty(up, 'target', { value: wrapper })
+      document.dispatchEvent(up)
+
+      expect(smA.selectedElements.size).toBe(0)
+      expect(smB.selectedElements.size).toBe(0)
     })
   })
 

--- a/tests/unit/react/useSortable.spec.tsx
+++ b/tests/unit/react/useSortable.spec.tsx
@@ -352,6 +352,52 @@ describe('useSortable', () => {
     expect(api.getSelectedIds().sort()).toEqual(['a', 'd'])
   })
 
+  it('controlled selectedIds: prop drives selection, echo is suppressed', () => {
+    const onSelectionChange = vi.fn<(ids: string[]) => void>()
+    const { container, rerender } = render(
+      <Harness
+        options={{
+          animation: 0,
+          multiDrag: true,
+          onSort,
+          onSelectionChange,
+          selectedIds: ['b', 'c'],
+        }}
+        items={ITEMS}
+      />
+    )
+    const list = container.querySelector('ul') as HTMLElement
+
+    // The controlled prop was applied to the SelectionManager…
+    expect(api.getSelectedIds().sort()).toEqual(['b', 'c'])
+    expect(item(list, 'b').classList.contains('sortable-selected')).toBe(true)
+    // …WITHOUT echoing back through onSelectionChange (loop guard).
+    expect(onSelectionChange).not.toHaveBeenCalled()
+
+    // Shrinking the prop deselects; ids not in this list are ignored.
+    rerender(
+      <Harness
+        options={{
+          animation: 0,
+          multiDrag: true,
+          onSort,
+          onSelectionChange,
+          selectedIds: ['c', 'not-here'],
+        }}
+        items={ITEMS}
+      />
+    )
+    expect(api.getSelectedIds()).toEqual(['c'])
+    expect(item(list, 'b').classList.contains('sortable-selected')).toBe(false)
+    expect(onSelectionChange).not.toHaveBeenCalled()
+
+    // User-driven changes still mirror out normally.
+    act(() => {
+      item(list, 'a').dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(onSelectionChange).toHaveBeenCalled()
+  })
+
   it('restores keyboard focus to the moved item after the commit re-render', async () => {
     let order = [...ITEMS]
     const commit = (intent: SortIntent): void => {


### PR DESCRIPTION
Selection parity work for a downstream controller integration — ports the behavior of its legacy `MultiSelect` marquee into the library.

## KeyboardManager — handle-scoped modifier clicks
With a drag `handle` configured, `multiDragKey` modifier-clicks only toggle selection when they land on the handle. Clicks on other item content — including a **nested** sortable's items — pass through. Fixes cmd-clicking a clip also toggling its containing song row.

## resortable/react — controlled `selectedIds`
New option making consumer state the single source of truth: the adapter diffs the prop against the SelectionManager each render (skipping mid-drag) and suppresses the select-event mirror while applying, so the controlled loop never echoes. Ids not present in a zone are ignored, so one app-wide selection array can feed every zone. Pairs with `onSelectionChange`.

## MarqueeSelectPlugin — MultiSelect parity
- **`scope`**: one marquee hit-tests across many lists; each item's owning instance resolves via the new `core/InstanceRegistry`, selection applies through that instance (per-instance `select` events fire normally). Per-entry `hitSelector` (songs hit by their handle) + first-intersected-kind mode locking.
- **Cached modifiers**: shift (additive) / alt (subtractive) captured at marquee **start** — releasing mid-drag no longer flips the mode.
- **`scrollContainer`**: marquee anchors to the container's content (keeps stretching while it scrolls); pointer near the top/bottom edge auto-scrolls (`autoScrollDistance`, `autoScrollSpeed`).
- Selection applied as a per-instance **diff** (no clear-and-rebuild event storms).
- Marquee-start / click-away exclusion honors `hitSelector`: a song row's empty body is valid marquee-start space.

## Refactor
Element→instance WeakMap moved from `index.ts` to `core/InstanceRegistry.ts` (plugins can resolve owners without an import cycle). `Sortable.get()` unchanged.

## Tests
- 6 new marquee tests (multi-list scope, hitSelector, mode locking, cached modifiers ×2, cross-list click-away)
- handle-scoped modifier-click test (controlled-parity)
- controlled `selectedIds` adapter test (drive + echo-suppression + shrink)
- Full unit suite 288 pass; multi-select + controlled-pointer + handle-filter + basic e2e pass on chromium/firefox locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdYhCz2wBSCMuJTUZ14igj

<!-- claude-session:ed99445c-8f69-4987-98c1-d922ed1fa6db -->
🔖 **Claude agent:** missioncontrol-53  
session id: `ed99445c-8f69-4987-98c1-d922ed1fa6db`