### PR TITLE
docs: update for 2.0.0 stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Modern TypeScript rewrite of Sortable.js — reorderable drag-and-drop lists.
 
-> **Alpha — Not ready for production use.** This library is under active development and has not been published to npm. APIs will change. If you need a drag-and-drop library today, use [SortableJS](https://github.com/SortableJS/Sortable).
-
 > **Migrating from Sortable.js?** See the [migration guide](./docs/migration-from-sortable-v1.md) for the option/plugin/breaking-change delta.
 
 ## Features
@@ -16,7 +14,7 @@ Modern TypeScript rewrite of Sortable.js — reorderable drag-and-drop lists.
 - **Multi-Drag** — Ctrl+Click / Shift+Click selection, drag multiple items together
 - **Plugin System** — AutoScroll, Swap plugins (extensible architecture)
 - **TypeScript** — Strict types with full IntelliSense support
-- **Small** — ~17KB gzipped (ESM)
+- **Small** — ~19KB gzipped (ESM)
 
 ## Installation
 
@@ -26,18 +24,16 @@ Modern TypeScript rewrite of Sortable.js — reorderable drag-and-drop lists.
 npm install resortable
 ```
 
-> Resortable is not yet published to npm (`2.0.0-alpha.1` is the current in-repo version). Until first publish, install from a Git ref: `npm install jjeff/resortable`.
-
 ### CDN (UMD)
 
-Once published, the UMD bundle exposes a `window.Sortable` global and works without a bundler. Version-pin to avoid surprise breaking changes:
+The UMD bundle exposes a `window.Sortable` global and works without a bundler. Version-pin to avoid surprise breaking changes:
 
 ```html
 <!-- unpkg -->
-<script src="https://unpkg.com/resortable@2.0.0-alpha.1/dist/sortable.umd.js"></script>
+<script src="https://unpkg.com/resortable@2.0.0/dist/sortable.umd.js"></script>
 
 <!-- or jsDelivr -->
-<script src="https://cdn.jsdelivr.net/npm/resortable@2.0.0-alpha.1/dist/sortable.umd.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/resortable@2.0.0/dist/sortable.umd.js"></script>
 
 <script>
   // The UMD build attaches the library as `window.Sortable`
@@ -178,7 +174,7 @@ See the [Plugin Development Guide](./docs/plugin-development.md) for the plugin 
 
 ## API Reference
 
-Full TypeDoc-generated API reference: [jjeff.github.io/resortable/api/](https://jjeff.github.io/resortable/api/) *(coming soon — TypeDoc-generated, deployed via GitHub Pages)*.
+Full TypeDoc-generated API reference: [jjeff.github.io/resortable/api/](https://jjeff.github.io/resortable/api/).
 
 ## Framework wrappers
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,13 @@
 
 ## Supported Versions
 
-Resortable is in active pre-1.0 development. Only the latest published version
-on the `main` branch receives security fixes.
+Resortable follows semantic versioning. Only the latest published `2.x`
+release on npm receives security fixes.
 
 | Version | Supported |
 | --- | --- |
-| `2.0.0-beta.*` (and later) | ✅ |
-| `2.0.0-alpha.*` | ❌ (pre-release; upgrade to beta) |
+| `2.0.x` (latest) | ✅ |
+| `2.0.0-alpha.*` / `2.0.0-beta.*` (pre-release) | ❌ |
 | `1.x` | n/a (never published — see [migration guide][mg]) |
 
 ## Reporting a Vulnerability

--- a/docs/migration-from-sortable-v1.md
+++ b/docs/migration-from-sortable-v1.md
@@ -1,4 +1,4 @@
-# Migrating from Sortable.js v1 to Resortable v2.0.0-alpha.1
+# Migrating from Sortable.js v1 to Resortable v2.0.0
 
 This guide is for users with a working Sortable.js v1.x codebase porting to Resortable v2.
 


### PR DESCRIPTION
Now that `resortable@2.0.0` is live on npm, remove the alpha "not ready / not published" warnings and correct stale references.

## Changes
- **README**
  - Remove the alpha *"Not ready for production use"* banner.
  - Remove the *"not yet published, install from a Git ref"* note (npm install is now correct).
  - Pin CDN examples to `@2.0.0` (were `@2.0.0-alpha.1`).
  - Correct ESM size: **~19KB** gzipped (was ~17KB; verified via `gzip -c dist/sortable.esm.js`).
  - Drop *"coming soon"* on the API reference — it's live at https://jjeff.github.io/resortable/api/ (verified 200).
- **SECURITY** — supported-versions table now marks `2.0.x` as supported; alpha/beta as pre-release/unsupported.
- **Migration guide** — retitle to `v2.0.0`.

## Note
`docs/api/media/migration-from-sortable-v1.md` still shows the old alpha title, but it's **generated** TypeDoc output — it refreshes on the next `docs:build` / Pages deploy, so I didn't hand-edit it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-session:c58dd3cf-0e9d-4997-9e43-db840033e794 -->
🔖 **Claude agent:** resortable-d5  
session id: `c58dd3cf-0e9d-4997-9e43-db840033e794`