### PR TITLE
test(e2e): clamp empty-target drop point to viewport (macOS onMove flake)

### DIFF
--- a/tests/e2e/on-move.spec.ts
+++ b/tests/e2e/on-move.spec.ts
@@ -443,13 +443,19 @@ test.describe('onMove (#60) — cross-zone enter (pointer pipeline)', () => {
       ghostClass: 'sortable-ghost',
     })
 
-    // Drop a-1 onto the empty target container.
+    // Drop a-1 onto the empty target container. Scroll it into view and clamp
+    // the drop point to the viewport: the drag pipeline resolves the target via
+    // `document.elementFromPoint`, which returns null for coordinates below the
+    // fold. On taller layouts (macOS runners) the container's raw center falls
+    // ~20px past the 720px viewport, so onMove never fired. See CI regression.
     const from = await center(page, sharedItem('a-1'))
+    await page.locator(SHARED_A_2).scrollIntoViewIfNeeded()
     const targetBox = await page.locator(SHARED_A_2).boundingBox()
     if (!targetBox) throw new Error('no bounding box for target')
+    const innerHeight = await page.evaluate(() => window.innerHeight)
     const to = {
       x: targetBox.x + targetBox.width / 2,
-      y: targetBox.y + targetBox.height / 2,
+      y: Math.min(targetBox.y + targetBox.height / 2, innerHeight - 10),
     }
     await page.mouse.move(from.x, from.y)
     await page.mouse.down()


### PR DESCRIPTION
## Problem

macOS CI e2e (`e2e-tests-hosted-macos`, runs on push to main) fails on `on-move.spec.ts:416` — "dropping into an empty target zone". Fails on macOS **chromium + webkit**; passes on Linux/Windows chromium, Windows webkit, and macOS firefox.

## Root cause — test bug, not library bug

- Test drops onto the empty container's **center, y≈742**. Viewport is **720** tall.
- Point is ~20px **below the fold** → `document.elementFromPoint` (used by the drag pipeline to resolve the target container) returns `null` → container never detected → `onMove` never fires → `log.length === 0`.
- macOS's taller layout pushes the container below the fold; shorter layouts (Linux/Windows/firefox) kept the point on-screen → passed.

Library behavior is correct: a point below the viewport legitimately hit-tests to nothing.

## Fix

`scrollIntoViewIfNeeded()` + clamp drop `y` to `innerHeight - 10`, so the drop point is always inside both the container and the viewport.

## Verified

- Reproduced the failure locally on macOS chromium; fix makes it pass.
- Full `on-move` spec: 9/9 pass.
- `npm run check`: 0 errors.
- webkit not installed locally, but root cause is engine-agnostic (viewport hit-testing) so the fix covers it too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-session:f21b8957-b832-4c8c-862a-03a35d77fb6b -->
🔖 **Claude agent:** resortable-d5  
session id: `f21b8957-b832-4c8c-862a-03a35d77fb6b`