### PR TITLE
fix: ignore keys typed into editable elements inside sortable items

### DIFF
--- a/src/core/KeyboardManager.ts
+++ b/src/core/KeyboardManager.ts
@@ -159,6 +159,14 @@ export class KeyboardManager {
   private onKeyDown = (e: KeyboardEvent): void => {
     const target = e.target as HTMLElement
 
+    // Never hijack keys while the user is typing. A text field or
+    // contentEditable region (e.g. an inline-editable item title) can live
+    // INSIDE a sortable item; without this guard, Space/arrows/Escape were
+    // treated as keyboard-DnD commands and never reached the field.
+    if (target.isContentEditable || target.matches('input, textarea, select')) {
+      return
+    }
+
     // Handle events on sortable items or the container
     // When using container.press() in tests, the target is the container
     // When pressing keys normally, the target is the focused element

--- a/tests/unit/keyboard-manager.test.ts
+++ b/tests/unit/keyboard-manager.test.ts
@@ -478,4 +478,42 @@ describe('KeyboardManager', () => {
       })
     })
   })
+
+  describe('Editable targets', () => {
+    it('ignores keys typed into a contentEditable region inside an item', () => {
+      keyboardManager.attach()
+      const title = document.createElement('span')
+      title.contentEditable = 'true'
+      items[0].appendChild(title)
+      // jsdom doesn't implement isContentEditable; force the accessor.
+      Object.defineProperty(title, 'isContentEditable', { value: true })
+
+      const event = new KeyboardEvent('keydown', {
+        key: ' ',
+        bubbles: true,
+        cancelable: true,
+      })
+      title.dispatchEvent(event)
+
+      // Space while typing must NOT be treated as keyboard-DnD grab:
+      // no preventDefault, no selection change.
+      expect(event.defaultPrevented).toBe(false)
+      expect(selectionManager.getSelected()).toHaveLength(0)
+    })
+
+    it('ignores keys typed into an input inside an item', () => {
+      keyboardManager.attach()
+      const input = document.createElement('input')
+      items[0].appendChild(input)
+
+      const event = new KeyboardEvent('keydown', {
+        key: 'ArrowDown',
+        bubbles: true,
+        cancelable: true,
+      })
+      input.dispatchEvent(event)
+
+      expect(event.defaultPrevented).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
KeyboardManager hijacked keydown events bubbling out of editable elements (contentEditable regions, inputs) nested inside sortable items — Space was treated as keyboard-DnD grab and never typed, arrows moved DnD focus instead of the caret.

Found live in a downstream Controller migration: the song title is a contentEditable inside the sortable song row; typing a space while renaming was swallowed.

Guard at the top of onKeyDown: bail when `target.isContentEditable` or the target matches `input, textarea, select`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdYhCz2wBSCMuJTUZ14igj

<!-- claude-session:ed99445c-8f69-4987-98c1-d922ed1fa6db -->
🔖 **Claude agent:** 👁️::Controller Migration  
session id: `ed99445c-8f69-4987-98c1-d922ed1fa6db`