### PR TITLE
docs: generalize consumer-app references in comments and design notes

### DIFF
--- a/docs/plans/2026-07-09-controlled-mode-design.md
+++ b/docs/plans/2026-07-09-controlled-mode-design.md
@@ -104,7 +104,7 @@ newIndexes?: number[]   // per items[], indices in `to` after commit (contiguous
 ## Follow-on (separate designs)
 
 1. **`resortable/react`** — `useSortable({ onSort, ...options })` returning a callback ref (see `2026-07-09-react-adapter-design.md` for the authoritative API); forces `controlled: true`; `onSort(intent)` where intent is `{ dataIds, from, to, oldIndexes, newIndexes, pullMode }`; focus restore; StrictMode-safe mount/destroy. Cross-list state coordination stays in userland (the intent is assembled from the source list's `end` event; `onAdd`/`onRemove` pass-throughs serve split-state consumers).
-2. **Visibox adoption** — bind the adapter in DS container components (`SongWidget`/`ClipWidget` already stub `dragPreview`, `Grabber`, "binding lives in the container"); map `onSort` → existing `MOVE_SONGS` / `MOVE_CLIP(S)` IPC.
+2. **Downstream adoption** — bind the adapter in the consuming app's container components; map `onSort` → the app's existing move actions.
 
 ## Decisions
 

--- a/src/plugins/MarqueeSelectPlugin.ts
+++ b/src/plugins/MarqueeSelectPlugin.ts
@@ -386,8 +386,8 @@ export class MarqueeSelectPlugin extends BasePlugin {
    * Selector for surfaces that BLOCK marquee-start / click-away-deselect.
    * An entry with a `hitSelector` only claims that sub-area (a song row
    * blocks on its drag handle, but its empty body is valid marquee-start
-   * space — legacy Visibox MultiSelect exceptions were `.clip, .handle`,
-   * never the whole `.song`).
+   * space — a typical consumer blocks on `.clip, .handle`, never the
+   * whole `.song` row).
    */
   private scopedBlockingSelector(sortable: SortableInstance): string {
     return this.scopeEntries(sortable)
@@ -676,7 +676,7 @@ export class MarqueeSelectPlugin extends BasePlugin {
   /**
    * The scope kind of an existing selection (or null when empty) — an
    * additive/subtractive marquee stays locked to the kind already selected,
-   * matching the mode-locking in Visibox's legacy MultiSelect.
+   * matching classic multi-select mode-locking.
    */
   private kindOfSnapshot(
     sortable: SortableInstance,
@@ -766,8 +766,8 @@ export class MarqueeSelectPlugin extends BasePlugin {
   /**
    * Convert a viewport point into the marquee's coordinate space:
    * content coordinates of the scroll container when scroll-anchored
-   * (clamped inside the scrollable content, like the legacy Visibox
-   * marquee), viewport coordinates otherwise.
+   * (clamped inside the scrollable content), viewport coordinates
+   * otherwise.
    */
   private toMarqueePoint(
     sortable: SortableInstance,
@@ -920,7 +920,7 @@ export class MarqueeSelectPlugin extends BasePlugin {
   /**
    * Auto-scroll the anchored container while the pointer sits near its
    * top/bottom edge, stretching the marquee and re-hit-testing as content
-   * moves. Time-based speed (px/ms) like the legacy Visibox marquee.
+   * moves. Time-based speed (px/ms), not per-event steps.
    */
   private updateAutoScroll(
     sortable: SortableInstance,

--- a/tests/e2e/controlled-pointer.spec.ts
+++ b/tests/e2e/controlled-pointer.spec.ts
@@ -2,8 +2,8 @@ import { expect, test, Page } from '@playwright/test'
 
 /**
  * Controlled-mode POINTER-pipeline drags against items whose descendants
- * re-enable `pointer-events` — the structure that broke the Visibox
- * design-system integration.
+ * re-enable `pointer-events` — the structure that broke the first
+ * real-world controlled-mode integration.
  *
  * The cursor-following ghost is a clone positioned exactly under the
  * cursor. Its inline `pointer-events: none` is defeated by consumer CSS

--- a/tests/unit/autoscroll-behavior.spec.ts
+++ b/tests/unit/autoscroll-behavior.spec.ts
@@ -3,7 +3,7 @@ import { AutoScrollPlugin } from '../../src/plugins/AutoScrollPlugin'
 import type { SortableInstance } from '../../src/types/index'
 
 /**
- * Unit coverage for the 2026-07 AutoScroll rewrite (Visibox QA findings):
+ * Unit coverage for the 2026-07 AutoScroll rewrite (downstream QA findings):
  *
  * 1. No scrolling before a real cursor position is observed —
  *    lastMousePosition starts at (0,0) and scrolling toward it on drag

--- a/tests/unit/controlled-parity.spec.ts
+++ b/tests/unit/controlled-parity.spec.ts
@@ -3,7 +3,7 @@ import { Sortable } from '../../src/index'
 
 /**
  * Unit coverage for the 2026-07 SortableJS-parity fixes driven by the
- * Visibox design-system integration:
+ * first real-world controlled-mode integration:
  *
  * 1. The placeholder is a CLONE of the dragged item (not a bare gray box),
  *    marked with `data-resortable-placeholder` and excluded from item

--- a/tests/unit/marquee-select.test.ts
+++ b/tests/unit/marquee-select.test.ts
@@ -1030,7 +1030,7 @@ describe('MarqueeSelectPlugin', () => {
       ;(sortableB.options as { draggable?: string }).draggable = '.clip'
       ;(sortableSongs.options as { draggable?: string }).draggable = '.song'
 
-      // Song rows CONTAIN the clip grids (like the Visibox controller).
+      // Song rows CONTAIN the clip grids (nested-list layout).
       songs[0].appendChild(sortableA.element)
       songs[1].appendChild(sortableB.element)
       wrapper.appendChild(sortableSongs.element)


### PR DESCRIPTION
Removes downstream-app-specific naming from source comments, test headers, and the controlled-mode design doc, replacing it with generic consumer/integration language.

Comment/doc-only change — no behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HdYhCz2wBSCMuJTUZ14igj

<!-- claude-session:ed99445c-8f69-4987-98c1-d922ed1fa6db -->
🔖 **Claude agent:** 👁️::Controller Migration  
session id: `ed99445c-8f69-4987-98c1-d922ed1fa6db`