### PR TITLE
test(e2e): un-skip & rewrite skipped e2e/unit suites (#36 #73 #74 #76 #77 #79)

### DIFF
--- a/tests/e2e/advanced-events.spec.ts
+++ b/tests/e2e/advanced-events.spec.ts
@@ -1,8 +1,35 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
 import { dragAndDropWithAnimation } from './helpers/animations'
+
+// Playwright's atomic page.dragAndDrop() (used for onChoose/onEnd-order tests
+// below) fires too fast for Chromium/WebKit to dispatch the intermediate
+// pointermove-driven events that onSort/onChange/onMove rely on. Driving the
+// pointer through discrete mouse.move steps — mirroring the pattern in
+// tests/e2e/on-move.spec.ts — reliably produces those intermediate events.
+// Tracked in #73.
+async function center(
+  page: Page,
+  selector: string
+): Promise<{ x: number; y: number }> {
+  const box = await page.locator(selector).boundingBox()
+  if (!box) throw new Error(`no bounding box for ${selector}`)
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
+async function dragWithSteps(
+  page: Page,
+  from: { x: number; y: number },
+  to: { x: number; y: number }
+): Promise<void> {
+  await page.mouse.move(from.x, from.y)
+  await page.mouse.down()
+  await page.mouse.move(from.x, from.y, { steps: 3 })
+  await page.mouse.move(to.x, to.y, { steps: 10 })
+  await page.mouse.up()
+}
 
 test.describe('Advanced Event Callbacks', () => {
   test.beforeEach(async ({ page }) => {
@@ -58,20 +85,39 @@ test.describe('Advanced Event Callbacks', () => {
     await page.mouse.up()
   })
 
-  // onSort, onChange, and onMove fire during intermediate dragover events.
-  // Playwright's HTML5 dragAndDrop() doesn't reliably trigger these intermediate
-  // events because the drag is too atomic. These events work in manual testing
-  // and via the pointer events path. Tracked in #73.
+  // Not a test-timing issue: the pointer pipeline's same-zone reorder branch
+  // (DragManager.onPointerMove, ~line 1635) only emits `'update'` — `'sort'`
+  // and `'change'` are only emitted by the HTML5-native `onDragOver` handler
+  // (DragManager.ts:970 and :991). No amount of stepped page.mouse.move
+  // driving will make onSort fire through this pipeline; it's a real gap
+  // between the two drag pipelines, not exercised by this rewrite's mandate
+  // (pure test-infra). tests/e2e/fallback-mode.spec.ts's pointer-driven
+  // `onSort` wiring hits the same gap — see its comment around line 707
+  // ("we don't lock down the exact set"), which deliberately avoids
+  // asserting `sort` fires. Confirmed via direct instrumentation of
+  // DragManager.onPointerMove: with the correct `Sortable.get()` teardown
+  // (see below), `dispatchMove` and `onMove` both fire correctly, but
+  // `'sort'` is never emitted for this same-zone pointer drag. Tracked
+  // under #73 as a follow-up (DragManager pointer/HTML5 parity), not fixed
+  // here.
   test.skip('should fire onSort event when sorting changes', async ({
     page,
   }) => {
     await page.evaluate(() => {
       const basicList = document.getElementById('basic-list')
       if (!basicList || !window.Sortable) return
-      const existing = window.sortables?.find(
-        (s: { el: HTMLElement }) => s.el === basicList
-      )
-      if (existing) (existing as { destroy: () => void }).destroy()
+      // The bootstrap script tracks instances by `{el, destroy}`, but
+      // Sortable's actual property is `element` — that lookup always misses,
+      // leaving the bootstrap instance attached alongside this one (see
+      // tests/e2e/on-move.spec.ts's `replaceSortable`). Look it up via the
+      // static registry instead so the stale instance (with no onSort) isn't
+      // the one that ends up handling the drag.
+      const existing = (
+        window.Sortable as unknown as {
+          get: (el: HTMLElement) => { destroy: () => void } | null
+        }
+      ).get(basicList)
+      if (existing) existing.destroy()
       window.eventLog = []
       new window.Sortable(basicList, {
         animation: 0,
@@ -87,27 +133,34 @@ test.describe('Advanced Event Callbacks', () => {
       })
     })
 
-    await dragAndDropWithAnimation(
-      page,
-      '#basic-list [data-id="basic-1"]',
-      '#basic-list [data-id="basic-3"]'
-    )
+    const from = await center(page, '#basic-list [data-id="basic-1"]')
+    const to = await center(page, '#basic-list [data-id="basic-3"]')
+    await dragWithSteps(page, from, to)
 
     const eventLog = await page.evaluate(() => window.eventLog ?? [])
     expect(eventLog.some((e: any) => e.type === 'sort')).toBeTruthy()
   })
 
-  // Tracked in #73 — atomic dragAndDrop swallows intermediate events.
+  // Same root cause as onSort above: DragManager.onPointerMove's same-zone
+  // branch only emits `'update'` (DragManager.ts:1706) — `'change'` is only
+  // emitted by the HTML5-native `onDragOver` handler (DragManager.ts:991).
+  // The pointer pipeline structurally never fires `'change'`; this isn't
+  // fixable by adjusting how the mouse is driven. Tracked under #73 as a
+  // follow-up (DragManager pointer/HTML5 parity), not fixed here.
   test.skip('should fire onChange event when order changes within same list', async ({
     page,
   }) => {
     await page.evaluate(() => {
       const basicList = document.getElementById('basic-list')
       if (!basicList || !window.Sortable) return
-      const existing = window.sortables?.find(
-        (s: { el: HTMLElement }) => s.el === basicList
-      )
-      if (existing) (existing as { destroy: () => void }).destroy()
+      // See the onSort test above — Sortable.get() is required to actually
+      // destroy the bootstrap instance instead of silently no-op'ing.
+      const existing = (
+        window.Sortable as unknown as {
+          get: (el: HTMLElement) => { destroy: () => void } | null
+        }
+      ).get(basicList)
+      if (existing) existing.destroy()
       window.eventLog = []
       new window.Sortable(basicList, {
         animation: 0,
@@ -122,28 +175,26 @@ test.describe('Advanced Event Callbacks', () => {
       })
     })
 
-    await dragAndDropWithAnimation(
-      page,
-      '#basic-list [data-id="basic-1"]',
-      '#basic-list [data-id="basic-2"]'
-    )
+    const from = await center(page, '#basic-list [data-id="basic-1"]')
+    const to = await center(page, '#basic-list [data-id="basic-2"]')
+    await dragWithSteps(page, from, to)
 
     const eventLog = await page.evaluate(() => window.eventLog ?? [])
     expect(eventLog.some((e: any) => e.type === 'change')).toBeTruthy()
   })
 
-  // Tracked in #73 — atomic dragAndDrop swallows intermediate events.
-  // onMove is covered via the pointer pipeline in tests/e2e/on-move.spec.ts.
-  test.skip('should fire onMove event during drag operations', async ({
-    page,
-  }) => {
+  test('should fire onMove event during drag operations', async ({ page }) => {
     await page.evaluate(() => {
       const basicList = document.getElementById('basic-list')
       if (!basicList || !window.Sortable) return
-      const existing = window.sortables?.find(
-        (s: { el: HTMLElement }) => s.el === basicList
-      )
-      if (existing) (existing as { destroy: () => void }).destroy()
+      // See the onSort test above — Sortable.get() is required to actually
+      // destroy the bootstrap instance instead of silently no-op'ing.
+      const existing = (
+        window.Sortable as unknown as {
+          get: (el: HTMLElement) => { destroy: () => void } | null
+        }
+      ).get(basicList)
+      if (existing) existing.destroy()
       window.moveEventCount = 0
       new window.Sortable(basicList, {
         animation: 0,
@@ -159,20 +210,9 @@ test.describe('Advanced Event Callbacks', () => {
       })
     })
 
-    const item1 = page.locator('#basic-list [data-id="basic-1"]')
-    const item3 = page.locator('#basic-list [data-id="basic-3"]')
-
-    await item1.hover()
-    await page.mouse.down()
-
-    const item3Box = await item3.boundingBox()
-    if (!item3Box) throw new Error('Could not get bounding box for item3')
-    await page.mouse.move(
-      item3Box.x + item3Box.width / 2,
-      item3Box.y + item3Box.height / 2
-    )
-    await page.waitForTimeout(100)
-    await page.mouse.up()
+    const from = await center(page, '#basic-list [data-id="basic-1"]')
+    const to = await center(page, '#basic-list [data-id="basic-3"]')
+    await dragWithSteps(page, from, to)
 
     const moveCount = await page.evaluate(() => window.moveEventCount ?? 0)
     expect(moveCount).toBeGreaterThan(0)

--- a/tests/e2e/animation.spec.ts
+++ b/tests/e2e/animation.spec.ts
@@ -1,259 +1,287 @@
-import { test, expect } from '@playwright/test'
+/* eslint-disable @typescript-eslint/no-unsafe-assignment */
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { test, expect, type Page } from '@playwright/test'
+import {
+  dragAndDropWithAnimation,
+  waitForAnimations,
+} from './helpers/animations'
 
-// FIXME: Suite needs rework against current drag pipeline — tracked in #79.
-test.describe.skip('Animation System - Full Integration (TODO)', () => {
+/**
+ * #79 — FLIP animation suite, rewritten against the pointer drag pipeline.
+ *
+ * Same root cause as #73: `locator.dragTo()` is an atomic Playwright action
+ * that collapses the whole gesture into a single step, so the pointer
+ * pipeline's `pointerdown`/`pointermove`/`pointerup` sequence never fires
+ * the way it does for real input, and intermediate drag/animation states
+ * aren't observable. This suite drives drags via `page.dragAndDrop` (already
+ * proven reliable for this pipeline in on-move.spec.ts) or raw `page.mouse`
+ * when a test needs to inspect a mid-drag state (the ghost visibility test).
+ *
+ * Targets `/playground.html` instead of the original
+ * `examples/simple-list.html` / `examples/multi-list.html` fixtures — those
+ * two pages import from `../dist/sortable.esm.js`, which doesn't exist until
+ * `npm run build` runs, and the e2e CI job never builds dist. Every other
+ * e2e spec already avoids those two example pages for the same reason;
+ * playground.html imports straight from `src/` via Vite, matching
+ * on-move.spec.ts's fixture.
+ *
+ * Timing: Playwright's `page.clock` fake-timer API does NOT drive the Web
+ * Animations API that `AnimationManager` uses for FLIP (`element.animate()`
+ * runs off the compositor's document timeline, not `setTimeout` /
+ * `requestAnimationFrame`), so `page.clock.fastForward()` cannot advance a
+ * FLIP animation. Instead we assert directly on the `Animation` objects
+ * `element.animate()` creates (duration/easing/keyframes) for deterministic,
+ * non-timing-based checks, and use `waitForAnimations()` (which awaits each
+ * animation's `.finished` promise) rather than a fixed `waitForTimeout` when
+ * we need the reorder to have settled.
+ */
+
+const BASIC_LIST = '#basic-list'
+const basicItem = (id: string): string =>
+  `${BASIC_LIST} [data-id="basic-${id}"]`
+
+const SHARED_1 = '#shared-a-1'
+const SHARED_2 = '#shared-a-2'
+const sharedItem = (id: string): string => `.sortable-item[data-id="${id}"]`
+
+async function idsIn(page: Page, listSelector: string): Promise<string[]> {
+  return page.$$eval(
+    `${listSelector} .sortable-item:not(.sortable-ghost)`,
+    (els) =>
+      (els as HTMLElement[])
+        .map((el) => el.dataset.id ?? '')
+        .filter((id) => id !== '')
+  )
+}
+
+async function setOption(
+  page: Page,
+  listId: string,
+  key: string,
+  value: unknown
+): Promise<void> {
+  await page.evaluate(
+    ({ listId, key, value }) => {
+      const el = document.getElementById(listId)
+      if (!el || !window.Sortable) return
+      const sortable = (window.Sortable as any).get(el)
+      sortable?.option(key, value)
+    },
+    { listId, key, value }
+  )
+}
+
+/** Timing + keyframes of the first WAAPI animation on `selector`, or null. */
+async function flipInfo(
+  page: Page,
+  selector: string
+): Promise<{
+  duration: number
+  easing: string
+  from: string
+  to: string
+} | null> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel)
+    const anim = el?.getAnimations()[0]
+    const effect = anim?.effect as KeyframeEffect | undefined
+    if (!effect) return null
+    const timing = effect.getTiming()
+    const keyframes = effect.getKeyframes()
+    return {
+      duration: timing.duration as number,
+      easing: timing.easing as string,
+      from: String(keyframes[0]?.transform ?? ''),
+      to: String(keyframes[keyframes.length - 1]?.transform ?? ''),
+    }
+  }, selector)
+}
+
+/** Count of `.sortable-item` elements in `listSelector` with an active/finished WAAPI animation. */
+async function animatingCount(
+  page: Page,
+  listSelector: string
+): Promise<number> {
+  return page.evaluate((sel) => {
+    const items = Array.from(
+      document.querySelectorAll(`${sel} .sortable-item:not(.sortable-ghost)`)
+    )
+    return items.filter((el) => (el as HTMLElement).getAnimations().length > 0)
+      .length
+  }, listSelector)
+}
+
+async function center(
+  page: Page,
+  selector: string
+): Promise<{ x: number; y: number }> {
+  await page.locator(selector).scrollIntoViewIfNeeded()
+  const box = await page.locator(selector).boundingBox()
+  if (!box) throw new Error(`no bounding box for ${selector}`)
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
+test.describe('Animation System - Full Integration (#79)', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/examples/simple-list.html')
+    await page.goto('/playground.html')
+    await page.waitForFunction(() => window.resortableLoaded === true)
+    await expect(page.locator(`${BASIC_LIST} .sortable-item`)).toHaveCount(4)
   })
 
   test('should animate item reordering with FLIP technique', async ({
     page,
   }) => {
-    // Get initial positions
-    const items = page.locator('.sortable-item')
-    const firstItem = items.nth(0)
-    const secondItem = items.nth(1)
+    // basic-1 (index 0) dragged DOWN onto basic-2 (index 1) inserts AFTER
+    // basic-2 (natural drag-down placement) — an adjacent swap.
+    await page.dragAndDrop(basicItem('1'), basicItem('2'))
 
-    const firstInitialBox = await firstItem.boundingBox()
-    const secondInitialBox = await secondItem.boundingBox()
+    // FLIP: AnimationManager captures the pre-move rect (First), performs
+    // the DOM move (Last), then Inverts via a `translate()` keyframe
+    // animating back to neutral (Play) — see
+    // src/animation/AnimationManager.ts `animateReorder`.
+    const flip = await flipInfo(page, basicItem('2'))
+    expect(flip).not.toBeNull()
+    expect(flip?.duration).toBe(150)
+    expect(flip?.from).not.toBe('translate(0px, 0px)')
+    // Chromium normalizes the authored `'translate(0, 0)'` keyframe value
+    // (src/animation/AnimationManager.ts) to `'translate(0px, 0px)'` when
+    // read back via `getKeyframes()`.
+    expect(flip?.to).toBe('translate(0px, 0px)')
 
-    // Drag first item to second position
-    await firstItem.dragTo(secondItem)
-
-    // Wait for animation to complete
-    await page.waitForTimeout(200)
-
-    // Verify positions have swapped
-    const firstFinalBox = await firstItem.boundingBox()
-    const secondFinalBox = await secondItem.boundingBox()
-
-    // First item should be approximately where second was
-    expect(firstFinalBox?.y).toBeCloseTo(secondInitialBox?.y || 0, 0)
-    // Second item should be approximately where first was
-    expect(secondFinalBox?.y).toBeCloseTo(firstInitialBox?.y || 0, 0)
+    await waitForAnimations(page)
+    expect(await idsIn(page, BASIC_LIST)).toEqual([
+      'basic-2',
+      'basic-1',
+      'basic-3',
+      'basic-4',
+    ])
   })
 
   test('should respect animation duration option', async ({ page }) => {
-    // Create sortable with longer animation
-    await page.evaluate(() => {
-      const list = document.getElementById('simple-list')
-      if (list) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        new (window as any).Sortable(list, {
-          animation: 500, // Longer animation
-          ghostClass: 'sortable-ghost',
-          chosenClass: 'sortable-chosen',
-        })
-      }
-    })
+    await setOption(page, 'basic-list', 'animation', 500)
 
-    const items = page.locator('.sortable-item')
-    const firstItem = items.nth(0)
-    const lastItem = items.nth(4)
+    // Drag basic-1 (top) DOWN onto basic-4 (last) — natural placement =
+    // insert AFTER basic-4.
+    await page.dragAndDrop(basicItem('1'), basicItem('4'))
 
-    // Start drag
-    await firstItem.dragTo(lastItem)
+    const flip = await flipInfo(page, basicItem('2'))
+    expect(flip?.duration).toBe(500)
 
-    // Animation should take 500ms, check at halfway point
-    await page.waitForTimeout(250)
-
-    // Items should still be transitioning (this is hard to test precisely)
-    // Just verify drag completes successfully
-    await page.waitForTimeout(300)
-
-    // Verify final position
-    const itemTexts = await items.allTextContents()
-    expect(itemTexts[4]).toContain('Item 1')
+    await waitForAnimations(page)
+    expect(await idsIn(page, BASIC_LIST)).toEqual([
+      'basic-2',
+      'basic-3',
+      'basic-4',
+      'basic-1',
+    ])
   })
 
   test('should skip animation when duration is 0', async ({ page }) => {
-    // Create sortable with no animation
-    await page.evaluate(() => {
-      const list = document.getElementById('simple-list')
-      if (list) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        new (window as any).Sortable(list, {
-          animation: 0, // No animation
-          ghostClass: 'sortable-ghost',
-          chosenClass: 'sortable-chosen',
-        })
-      }
-    })
+    await setOption(page, 'basic-list', 'animation', 0)
 
-    const items = page.locator('.sortable-item')
-    const firstItem = items.nth(0)
-    const secondItem = items.nth(1)
+    await page.dragAndDrop(basicItem('1'), basicItem('2'))
 
-    // Drag should be instant
-    await firstItem.dragTo(secondItem)
-
-    // No need to wait for animation
-    const itemTexts = await items.allTextContents()
-    expect(itemTexts[0]).toContain('Item 2')
-    expect(itemTexts[1]).toContain('Item 1')
+    // With animation: 0, AnimationManager.animateReorder runs the DOM move
+    // synchronously and never calls element.animate() — no WAAPI animations
+    // at all, and the reorder is already complete (no wait needed).
+    expect(await animatingCount(page, BASIC_LIST)).toBe(0)
+    expect(await idsIn(page, BASIC_LIST)).toEqual([
+      'basic-2',
+      'basic-1',
+      'basic-3',
+      'basic-4',
+    ])
   })
 
   test('should animate ghost element appearance and removal', async ({
     page,
   }) => {
-    // Enable ghost class
-    await page.evaluate(() => {
-      const list = document.getElementById('simple-list')
-      if (list) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        new (window as any).Sortable(list, {
-          animation: 150,
-          ghostClass: 'sortable-ghost',
-          chosenClass: 'sortable-chosen',
-        })
-      }
-    })
+    const from = await center(page, basicItem('1'))
+    const to = await center(page, basicItem('2'))
 
-    const items = page.locator('.sortable-item')
-    const firstItem = items.nth(0)
-    const secondItem = items.nth(1)
-
-    // Start dragging
-    await firstItem.hover()
+    await page.mouse.move(from.x, from.y)
     await page.mouse.down()
+    await page.mouse.move(from.x, from.y, { steps: 3 })
+    await page.mouse.move(to.x, to.y, { steps: 10 })
 
-    // Move to trigger ghost
-    await secondItem.hover()
-
-    // Ghost should be visible with reduced opacity
-    const ghost = page.locator('.sortable-ghost')
+    const ghost = page.locator(`${BASIC_LIST} .sortable-ghost`)
     await expect(ghost).toBeVisible()
 
-    // Complete drag
     await page.mouse.up()
 
-    // Ghost should be removed
-    await expect(ghost).not.toBeVisible()
+    await expect(ghost).toHaveCount(0)
   })
 
   test('should animate items when moving between lists', async ({ page }) => {
-    // Navigate to multi-list example
-    await page.goto('/examples/multi-list.html')
+    const list1Items = page.locator(`${SHARED_1} .sortable-item`)
+    const list2Items = page.locator(`${SHARED_2} .sortable-item`)
 
-    // Get items from both lists
-    const list1Items = page.locator('#list1 .sortable-item')
-    const list2Items = page.locator('#list2 .sortable-item')
-
-    const firstItem = list1Items.nth(0)
-    const list2 = page.locator('#list2')
-
-    // Initial counts
     const list1InitialCount = await list1Items.count()
     const list2InitialCount = await list2Items.count()
 
-    // Drag from list1 to list2
-    await firstItem.dragTo(list2)
+    await dragAndDropWithAnimation(page, sharedItem('a-1'), sharedItem('a-6'))
 
-    // Wait for animation
-    await page.waitForTimeout(200)
-
-    // Verify counts changed
-    expect(await list1Items.count()).toBe(list1InitialCount - 1)
-    expect(await list2Items.count()).toBe(list2InitialCount + 1)
-
-    // Verify item text moved
-    const list2Texts = await list2Items.allTextContents()
-    expect(list2Texts).toContain('List 1 - Item 1')
+    await expect(list1Items).toHaveCount(list1InitialCount - 1)
+    await expect(list2Items).toHaveCount(list2InitialCount + 1)
+    expect(await idsIn(page, SHARED_2)).toContain('a-1')
   })
 
   test('should support custom easing functions', async ({ page }) => {
-    // Create sortable with custom easing
-    await page.evaluate(() => {
-      const list = document.getElementById('simple-list')
-      if (list) {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
-        new (window as any).Sortable(list, {
-          animation: 300,
-          easing: 'ease-in-out', // Custom easing
-          ghostClass: 'sortable-ghost',
-          chosenClass: 'sortable-chosen',
-        })
-      }
-    })
+    await setOption(page, 'basic-list', 'animation', 300)
+    await setOption(page, 'basic-list', 'easing', 'ease-in-out')
 
-    const items = page.locator('.sortable-item')
-    const firstItem = items.nth(0)
-    const lastItem = items.nth(4)
+    await page.dragAndDrop(basicItem('1'), basicItem('4'))
 
-    // Perform drag with custom easing
-    await firstItem.dragTo(lastItem)
+    const flip = await flipInfo(page, basicItem('2'))
+    expect(flip?.duration).toBe(300)
+    expect(flip?.easing).toBe('ease-in-out')
 
-    // Wait for animation with custom easing
-    await page.waitForTimeout(350)
-
-    // Verify move completed
-    const itemTexts = await items.allTextContents()
-    expect(itemTexts[4]).toContain('Item 1')
+    await waitForAnimations(page)
+    expect(await idsIn(page, BASIC_LIST)).toEqual([
+      'basic-2',
+      'basic-3',
+      'basic-4',
+      'basic-1',
+    ])
   })
 
   test('should handle rapid successive drags with animation cancellation', async ({
     page,
   }) => {
-    const items = page.locator('.sortable-item')
-    const firstItem = items.nth(0)
-    const secondItem = items.nth(1)
-    const thirdItem = items.nth(2)
+    // Chain three drags without waiting for each 150ms FLIP animation to
+    // settle — later drags can start while earlier animations are still
+    // running. The interesting property isn't the exact final order (that's
+    // an implementation detail of overlapping animations), it's that the
+    // data set survives intact: no item duplicated or dropped.
+    await page.dragAndDrop(basicItem('1'), basicItem('2'))
+    await page.dragAndDrop(basicItem('2'), basicItem('3'))
+    await page.dragAndDrop(basicItem('3'), basicItem('1'))
 
-    // Perform rapid drags without waiting for animations
-    await firstItem.dragTo(secondItem)
-    await page.waitForTimeout(50) // Start animation
+    await waitForAnimations(page)
 
-    // Start new drag before previous animation completes
-    await secondItem.dragTo(thirdItem)
-    await page.waitForTimeout(50)
-
-    // Another rapid drag
-    await thirdItem.dragTo(firstItem)
-
-    // Wait for all animations to settle
-    await page.waitForTimeout(200)
-
-    // Verify final state is consistent
-    const itemTexts = await items.allTextContents()
-    expect(itemTexts).toHaveLength(5)
-
-    // All items should still be present
-    expect(itemTexts.join(',')).toMatch(/Item 1/)
-    expect(itemTexts.join(',')).toMatch(/Item 2/)
-    expect(itemTexts.join(',')).toMatch(/Item 3/)
+    const order = await idsIn(page, BASIC_LIST)
+    expect(order).toHaveLength(4)
+    expect(new Set(order)).toEqual(
+      new Set(['basic-1', 'basic-2', 'basic-3', 'basic-4'])
+    )
   })
 
   test('should animate items affected by reordering', async ({ page }) => {
-    const items = page.locator('.sortable-item')
-    const firstItem = items.nth(0)
-    const lastItem = items.nth(4)
+    // Drag basic-1 (index 0) to the last slot — basic-2/3/4 all shift up
+    // one row, so all four items should receive a FLIP animation, not just
+    // the dragged one.
+    await page.dragAndDrop(basicItem('1'), basicItem('4'))
 
-    // Get initial positions of all items
-    const initialPositions = await Promise.all(
-      [0, 1, 2, 3, 4].map(async (i) => {
-        const box = await items.nth(i).boundingBox()
-        return box?.y || 0
-      })
-    )
+    expect(await animatingCount(page, BASIC_LIST)).toBe(4)
 
-    // Drag first to last - all items in between should shift up
-    await firstItem.dragTo(lastItem)
-
-    // Wait for animation
-    await page.waitForTimeout(200)
-
-    // Get final positions
-    const finalPositions = await Promise.all(
-      [0, 1, 2, 3, 4].map(async (i) => {
-        const box = await items.nth(i).boundingBox()
-        return box?.y || 0
-      })
-    )
-
-    // Items 2-5 (now at positions 0-3) should have moved up
-    expect(finalPositions[0]).toBeCloseTo(initialPositions[1], 0)
-    expect(finalPositions[1]).toBeCloseTo(initialPositions[2], 0)
-    expect(finalPositions[2]).toBeCloseTo(initialPositions[3], 0)
-    expect(finalPositions[3]).toBeCloseTo(initialPositions[4], 0)
+    await waitForAnimations(page)
+    expect(await idsIn(page, BASIC_LIST)).toEqual([
+      'basic-2',
+      'basic-3',
+      'basic-4',
+      'basic-1',
+    ])
   })
 })

--- a/tests/e2e/animation.spec.ts
+++ b/tests/e2e/animation.spec.ts
@@ -145,10 +145,11 @@ test.describe('Animation System - Full Integration (#79)', () => {
     expect(flip).not.toBeNull()
     expect(flip?.duration).toBe(150)
     expect(flip?.from).not.toBe('translate(0px, 0px)')
-    // Chromium normalizes the authored `'translate(0, 0)'` keyframe value
-    // (src/animation/AnimationManager.ts) to `'translate(0px, 0px)'` when
-    // read back via `getKeyframes()`.
-    expect(flip?.to).toBe('translate(0px, 0px)')
+    // Chromium/WebKit normalize the authored `'translate(0, 0)'` keyframe
+    // value (src/animation/AnimationManager.ts) to `'translate(0px, 0px)'`
+    // when read back via `getKeyframes()`; Firefox collapses the neutral
+    // value to the single-arg shorthand `'translate(0px)'`. Accept both.
+    expect(flip?.to).toMatch(/^translate\(0px(, 0px)?\)$/)
 
     await waitForAnimations(page)
     expect(await idsIn(page, BASIC_LIST)).toEqual([

--- a/tests/e2e/basic-sortable.spec.ts
+++ b/tests/e2e/basic-sortable.spec.ts
@@ -97,74 +97,34 @@ test.describe('Basic Sortable Functionality', () => {
     )
   })
 
-  // FIXME: Hover state does not apply the expected transform on .sortable-item
-  // in chromium (un-skip attempt failed). Tracked in #74.
-  test.skip('shows hover effects on sortable items', async ({ page }) => {
-    const item = page.locator('#basic-list [data-id="basic-1"]')
+  // Removed (#74): "shows hover effects on sortable items" asserted a
+  // translateY transform on `#basic-list .sortable-item:hover`, but
+  // playground.html (a deliberately bare-bones dev harness — see its own
+  // header copy) has never had a `.sortable-item:hover` rule. Checked the
+  // pre-split combined page (git show 6f2c031^:index.html): #basic-list
+  // used plain `.test-item` styling there too; the hover-transform only
+  // ever existed on unrelated marketing demo sections (`.smooth-list`,
+  // `.spring-list`) that don't exist in this fixture. Nothing to restore —
+  // the test encoded a false assumption, not a regression.
 
-    await item.hover()
-
-    // Check if hover styles are applied by verifying computed styles
-    const transform = await item.evaluate(
-      (el: Element) => window.getComputedStyle(el).transform
-    )
-
-    // The CSS should apply a translateY transform on hover
-    expect(transform).not.toBe('none')
-  })
-
-  // FIXME: Pointer-event touch simulation is non-deterministic — tracked in #74.
-  test.skip('handles touch input for drag and drop', async ({ page }) => {
-    // Simulate touch drag by using dispatchEvent with pointer events
-    const sourceItem = page.locator('#basic-list [data-id="basic-1"]')
-    const targetItem = page.locator('#basic-list [data-id="basic-3"]')
-
-    // Get bounding boxes for touch coordinates
-    const sourceBox = await sourceItem.boundingBox()
-    const targetBox = await targetItem.boundingBox()
-
-    if (!sourceBox || !targetBox) {
-      throw new Error('Could not get element bounding boxes')
-    }
-
-    // Simulate touch-based drag with pointer events
-    await page.dispatchEvent('#basic-list [data-id="basic-1"]', 'pointerdown', {
-      pointerId: 1,
-      pointerType: 'touch',
-      isPrimary: true,
-      clientX: sourceBox.x + sourceBox.width / 2,
-      clientY: sourceBox.y + sourceBox.height / 2,
-      button: 0,
-    })
-
-    await page.dispatchEvent('body', 'pointermove', {
-      pointerId: 1,
-      pointerType: 'touch',
-      isPrimary: true,
-      clientX: targetBox.x + targetBox.width / 2,
-      clientY: targetBox.y + targetBox.height / 2,
-      button: 0,
-    })
-
-    await page.dispatchEvent('body', 'pointerup', {
-      pointerId: 1,
-      pointerType: 'touch',
-      isPrimary: true,
-      clientX: targetBox.x + targetBox.width / 2,
-      clientY: targetBox.y + targetBox.height / 2,
-      button: 0,
-    })
-
-    // Wait for the drag operation to complete
-    await page.waitForTimeout(100)
-
-    // Verify the items were reordered
-    const items = page.locator('#basic-list .sortable-item')
-    await expect(items.nth(0)).toHaveAttribute('data-id', 'basic-2')
-    await expect(items.nth(1)).toHaveAttribute('data-id', 'basic-1')
-    await expect(items.nth(2)).toHaveAttribute('data-id', 'basic-3')
-    await expect(items.nth(3)).toHaveAttribute('data-id', 'basic-4')
-  })
+  // Removed (#74): "handles touch input for drag and drop" drove a touch
+  // drag via raw `page.dispatchEvent(..., { pointerType: 'touch' })`.
+  // Playwright's real Touchscreen API only exposes `tap(x, y)` (single
+  // touchstart+touchend) — there's no public multi-step touch-drag gesture
+  // to rewrite this against. The dispatchEvent approach dispatches
+  // untrusted synthetic events that don't reliably drive a full drag
+  // session (see the sibling "handles pen input" / "handles multi-touch
+  // pointer events" tests below, which use the same technique and only
+  // assert *no* reorder happens) — that's the source of the flakiness.
+  // DragManager's pointer handlers (`onPointerDown`/`onPointerMove`/
+  // `onPointerUp`) don't branch on pointerType, so the code path a real
+  // touch drag exercises is already covered:
+  //   - the fallback pointer pipeline itself: on-move.spec.ts's
+  //     "forceFallback (pointer pipeline, HTML5 listeners skipped)" suite
+  //   - the touch-specific routing decision (HTML5 DnD disabled, draggable
+  //     set to false when `navigator.maxTouchPoints > 0`): the "applies
+  //     visual feedback classes during drag" test above, which runs for
+  //     real under the touch-enabled "Mobile Chrome" project.
 
   test('handles pen input for drag and drop', async ({ page }) => {
     // Simulate pen drag with pointer events

--- a/tests/e2e/delay-options.spec.ts
+++ b/tests/e2e/delay-options.spec.ts
@@ -1,56 +1,97 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Page } from '@playwright/test'
+
+/**
+ * Dispatch a synthetic touch-type PointerEvent directly on the element at
+ * (x, y). Playwright's `page.touchscreen` only exposes `tap()` (down+up with
+ * no hold), so it can't drive a held touch through `delayOnTouchOnly`. The
+ * library's own pointerdown handler only branches on `event.pointerType`
+ * (see DragManager `onPointerDown`), so a script-dispatched (untrusted)
+ * PointerEvent with `pointerType: 'touch'` exercises the exact same code
+ * path as a real touch — `setPointerCapture` is already wrapped in a
+ * try/catch for synthetic pointers (see DragManager `commitPointerDrag`).
+ */
+async function dispatchTouchPointer(
+  page: Page,
+  type: 'pointerdown' | 'pointermove' | 'pointerup',
+  x: number,
+  y: number,
+  pointerId = 101
+): Promise<void> {
+  await page.evaluate(
+    ({ type, x, y, pointerId }) => {
+      const el = document.elementFromPoint(x, y) ?? document
+      el.dispatchEvent(
+        new PointerEvent(type, {
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          pointerId,
+          pointerType: 'touch',
+          isPrimary: true,
+          button: 0,
+          buttons: type === 'pointerup' ? 0 : 1,
+          clientX: x,
+          clientY: y,
+        })
+      )
+    },
+    { type, x, y, pointerId }
+  )
+}
 
 test.describe('Delay Options', () => {
-  // FIXME: Timing simulation unreliable — tracked in #76.
-  test.skip('should delay drag start with delay option', async ({ page }) => {
+  test('should delay drag start with delay option', async ({ page }) => {
     await page.goto('/tests/e2e/fixtures/delay-test.html')
+    // Fake `setTimeout`/`clearTimeout` so the 300ms `delay` timer can be
+    // crossed deterministically instead of racing real wall-clock waits.
+    await page.clock.install()
 
     const item1 = page.locator('[data-id="item-1"]')
     const item2 = page.locator('[data-id="item-2"]')
 
-    // Start drag but release immediately (before delay)
     const box1 = await item1.boundingBox()
     const box2 = await item2.boundingBox()
     if (!box1 || !box2) throw new Error('Could not get bounding boxes')
+    const center1 = { x: box1.x + box1.width / 2, y: box1.y + box1.height / 2 }
+    const center2 = { x: box2.x + box2.width / 2, y: box2.y + box2.height / 2 }
 
-    // Start drag but don't hold long enough
-    await page.mouse.move(box1.x + box1.width / 2, box1.y + box1.height / 2)
+    // Release before the 300ms delay elapses — drag never starts.
+    await page.mouse.move(center1.x, center1.y)
     await page.mouse.down()
-    await page.waitForTimeout(100) // Wait less than the 300ms delay
-    await page.mouse.move(box2.x + box2.width / 2, box2.y + box2.height / 2)
+    await page.clock.fastForward(100) // less than the 300ms delay
+    await page.mouse.move(center2.x, center2.y)
     await page.mouse.up()
 
-    // Check order hasn't changed
     const items = await page.locator('.sortable-item').all()
     expect(await items[0].getAttribute('data-id')).toBe('item-1')
     expect(await items[1].getAttribute('data-id')).toBe('item-2')
 
-    // Now hold long enough for delay
-    await page.mouse.move(box1.x + box1.width / 2, box1.y + box1.height / 2)
+    // Hold past the delay — drag starts and the drop reorders the list.
+    await page.mouse.move(center1.x, center1.y)
     await page.mouse.down()
-    await page.waitForTimeout(350) // Wait more than the 300ms delay
-    await page.mouse.move(box2.x + box2.width / 2, box2.y + box2.height / 2)
+    await page.clock.fastForward(350) // more than the 300ms delay
+    await page.mouse.move(center2.x, center2.y)
     await page.mouse.up()
 
-    // Check order has changed
     const itemsAfter = await page.locator('.sortable-item').all()
     expect(await itemsAfter[0].getAttribute('data-id')).toBe('item-2')
     expect(await itemsAfter[1].getAttribute('data-id')).toBe('item-1')
   })
 
-  // FIXME: Touch-delay testing — tracked in #76.
-  test.skip('should only delay on touch with delayOnTouchOnly', async ({
-    page,
-  }) => {
+  test('should only delay on touch with delayOnTouchOnly', async ({ page }) => {
     await page.goto('/tests/e2e/fixtures/delay-touch-only.html')
 
     const item1 = page.locator('[data-id="item-1"]')
     const item2 = page.locator('[data-id="item-2"]')
 
-    // Mouse drag should work immediately (no delay)
+    // Mouse drag should work immediately (delay: 0 for mouse).
     await item1.dragTo(item2)
 
-    // Check order has changed
+    // The drag ghost is removed once the 150ms drop animation finishes —
+    // wait it out so it doesn't linger as a stray `.sortable-item` (it has
+    // no `data-id`) when the order is inspected/reset below.
+    await expect(page.locator('.sortable-ghost')).toHaveCount(0)
+
     const items = await page.locator('.sortable-item').all()
     expect(await items[0].getAttribute('data-id')).toBe('item-2')
     expect(await items[1].getAttribute('data-id')).toBe('item-1')
@@ -68,28 +109,43 @@ test.describe('Delay Options', () => {
       items.forEach((item) => container.appendChild(item))
     })
 
-    // Touch drag should require delay
+    // Fake timers so the 400ms `delayOnTouchOnly` timer can be crossed
+    // deterministically for the touch-path assertions below.
+    await page.clock.install()
+
     const box1 = await item1.boundingBox()
     const box2 = await item2.boundingBox()
     if (!box1 || !box2) throw new Error('Could not get bounding boxes')
+    const center1 = { x: box1.x + box1.width / 2, y: box1.y + box1.height / 2 }
+    const center2 = { x: box2.x + box2.width / 2, y: box2.y + box2.height / 2 }
 
-    // Simulate touch without enough delay
-    await page.touchscreen.tap(
-      box1.x + box1.width / 2,
-      box1.y + box1.height / 2
-    )
+    // Touch released before the 400ms delayOnTouchOnly elapses — no reorder.
+    await dispatchTouchPointer(page, 'pointerdown', center1.x, center1.y)
+    await page.clock.fastForward(200) // less than the 400ms touch delay
+    await dispatchTouchPointer(page, 'pointerup', center1.x, center1.y)
 
-    // Check order hasn't changed
-    const itemsAfterTouch = await page.locator('.sortable-item').all()
-    expect(await itemsAfterTouch[0].getAttribute('data-id')).toBe('item-1')
-    expect(await itemsAfterTouch[1].getAttribute('data-id')).toBe('item-2')
+    const itemsAfterQuickTouch = await page.locator('.sortable-item').all()
+    expect(await itemsAfterQuickTouch[0].getAttribute('data-id')).toBe('item-1')
+    expect(await itemsAfterQuickTouch[1].getAttribute('data-id')).toBe('item-2')
+
+    // Touch held past the delay — drag starts and the drop reorders the list.
+    await dispatchTouchPointer(page, 'pointerdown', center1.x, center1.y)
+    await page.clock.fastForward(450) // more than the 400ms touch delay
+    await dispatchTouchPointer(page, 'pointermove', center2.x, center2.y)
+    await dispatchTouchPointer(page, 'pointerup', center2.x, center2.y)
+
+    const itemsAfterHeldTouch = await page.locator('.sortable-item').all()
+    expect(await itemsAfterHeldTouch[0].getAttribute('data-id')).toBe('item-2')
+    expect(await itemsAfterHeldTouch[1].getAttribute('data-id')).toBe('item-1')
   })
 
-  // FIXME: Threshold cancellation simulation — tracked in #76.
-  test.skip('should cancel delayed drag if moved beyond threshold', async ({
+  test('should cancel delayed drag if moved beyond threshold', async ({
     page,
   }) => {
     await page.goto('/tests/e2e/fixtures/delay-threshold.html')
+    // Fake `setTimeout`/`clearTimeout` so the 300ms `delay` timer can be
+    // crossed deterministically instead of racing real wall-clock waits.
+    await page.clock.install()
 
     const item1 = page.locator('[data-id="item-1"]')
     const item2 = page.locator('[data-id="item-2"]')
@@ -97,44 +153,31 @@ test.describe('Delay Options', () => {
     const box1 = await item1.boundingBox()
     const box2 = await item2.boundingBox()
     if (!box1 || !box2) throw new Error('Could not get bounding boxes')
+    const center1 = { x: box1.x + box1.width / 2, y: box1.y + box1.height / 2 }
+    const center2 = { x: box2.x + box2.width / 2, y: box2.y + box2.height / 2 }
 
-    // Start drag and move beyond threshold before delay completes
-    await page.mouse.move(box1.x + box1.width / 2, box1.y + box1.height / 2)
+    // Move beyond the 10px threshold before the delay completes — cancels
+    // the pending drag even though the delay later elapses.
+    await page.mouse.move(center1.x, center1.y)
     await page.mouse.down()
-    await page.waitForTimeout(100) // Wait less than the 300ms delay
-
-    // Move beyond the 10px threshold
-    await page.mouse.move(
-      box1.x + box1.width / 2 + 15,
-      box1.y + box1.height / 2 + 15
-    )
-    await page.waitForTimeout(250) // Complete the delay time
-
-    // Try to drag to item2
-    await page.mouse.move(box2.x + box2.width / 2, box2.y + box2.height / 2)
+    await page.clock.fastForward(100) // less than the 300ms delay
+    await page.mouse.move(center1.x + 15, center1.y + 15) // beyond the 10px threshold
+    await page.clock.fastForward(250) // would complete the delay, if not cancelled
+    await page.mouse.move(center2.x, center2.y)
     await page.mouse.up()
 
-    // Check order hasn't changed (drag was cancelled)
     const items = await page.locator('.sortable-item').all()
     expect(await items[0].getAttribute('data-id')).toBe('item-1')
     expect(await items[1].getAttribute('data-id')).toBe('item-2')
 
-    // Now drag without exceeding threshold
-    await page.mouse.move(box1.x + box1.width / 2, box1.y + box1.height / 2)
+    // Move within the threshold — the delayed drag commits normally.
+    await page.mouse.move(center1.x, center1.y)
     await page.mouse.down()
-
-    // Move slightly but stay within threshold
-    await page.mouse.move(
-      box1.x + box1.width / 2 + 3,
-      box1.y + box1.height / 2 + 3
-    )
-    await page.waitForTimeout(350) // Wait for delay to complete
-
-    // Now drag to item2
-    await page.mouse.move(box2.x + box2.width / 2, box2.y + box2.height / 2)
+    await page.mouse.move(center1.x + 3, center1.y + 3) // within the 10px threshold
+    await page.clock.fastForward(350) // more than the 300ms delay
+    await page.mouse.move(center2.x, center2.y)
     await page.mouse.up()
 
-    // Check order has changed
     const itemsAfter = await page.locator('.sortable-item').all()
     expect(await itemsAfter[0].getAttribute('data-id')).toBe('item-2')
     expect(await itemsAfter[1].getAttribute('data-id')).toBe('item-1')

--- a/tests/e2e/feature-demos.spec.ts
+++ b/tests/e2e/feature-demos.spec.ts
@@ -222,10 +222,13 @@ test.describe('Feature Demos', () => {
   })
 
   test.describe('Delay Functionality', () => {
-    // FIXME: Delay timing simulation is unreliable — tracked in #76.
-    test.skip('requires holding for delay period before drag starts', async ({
+    test('requires holding for delay period before drag starts', async ({
       page,
     }) => {
+      // Fake `setTimeout`/`clearTimeout` so the 300ms `delay` timer can be
+      // crossed deterministically instead of racing real wall-clock waits.
+      await page.clock.install()
+
       const firstItem = page.locator('#delay-list .delay-item').first()
       const lastItem = page.locator('#delay-list .delay-item').last()
 
@@ -233,11 +236,28 @@ test.describe('Feature Demos', () => {
         .locator('#delay-list .delay-item')
         .evaluateAll((els) => els.map((el) => el.dataset.id))
 
+      // The demo page is long — raw page.mouse coordinates (unlike
+      // locator actions) don't auto-scroll, so the list must be scrolled
+      // into view first or the coordinates land outside the viewport.
+      await firstItem.scrollIntoViewIfNeeded()
+
+      const firstBox = await firstItem.boundingBox()
+      const lastBox = await lastItem.boundingBox()
+      if (!firstBox || !lastBox) throw new Error('Could not get bounding boxes')
+      const firstCenter = {
+        x: firstBox.x + firstBox.width / 2,
+        y: firstBox.y + firstBox.height / 2,
+      }
+      const lastCenter = {
+        x: lastBox.x + lastBox.width / 2,
+        y: lastBox.y + lastBox.height / 2,
+      }
+
       // Quick click and drag (should not work due to delay)
-      await firstItem.hover()
+      await page.mouse.move(firstCenter.x, firstCenter.y)
       await page.mouse.down()
-      await page.waitForTimeout(100) // Less than 300ms delay
-      await lastItem.hover()
+      await page.clock.fastForward(100) // less than the 300ms delay
+      await page.mouse.move(lastCenter.x, lastCenter.y)
       await page.mouse.up()
 
       const orderAfterQuickDrag = await page
@@ -246,13 +266,11 @@ test.describe('Feature Demos', () => {
       expect(orderAfterQuickDrag).toEqual(initialOrder)
 
       // Hold and drag (should work)
-      await firstItem.hover()
+      await page.mouse.move(firstCenter.x, firstCenter.y)
       await page.mouse.down()
-      await page.waitForTimeout(350) // More than 300ms delay
-      await lastItem.hover()
+      await page.clock.fastForward(350) // more than the 300ms delay
+      await page.mouse.move(lastCenter.x, lastCenter.y)
       await page.mouse.up()
-
-      await page.waitForTimeout(200)
 
       const orderAfterDelayedDrag = await page
         .locator('#delay-list .delay-item')

--- a/tests/e2e/ghost-elements.spec.ts
+++ b/tests/e2e/ghost-elements.spec.ts
@@ -27,57 +27,37 @@ test.describe('Ghost Element Functionality', () => {
     await page.mouse.up()
   })
 
-  // FIXME: Atomic dragAndDrop prevents observing intermediate drag class state.
-  // Tracked in #73.
-  test.skip('applies drag class during drag operation - TODO: Flaky due to atomic drag operations', async ({
-    page,
-  }) => {
-    // @todo: This test is flaky because dragAndDrop is atomic in some browsers,
-    // making it impossible to reliably check intermediate states during drag.
-    // The functionality works correctly, but the test timing is unreliable.
-    // This should be reimplemented with a more controllable drag simulation.
-
+  // Playwright's atomic dragAndDrop() completes too fast to observe
+  // intermediate drag-class state. Driving the pointer through discrete
+  // mouse.move steps — mirroring tests/e2e/on-move.spec.ts — lets us assert
+  // on the class mid-drag before releasing. Tracked in #73.
+  test('applies drag class during drag operation', async ({ page }) => {
     const firstItem = page.locator('#basic-list [data-id="basic-1"]')
+    const thirdItem = page.locator('#basic-list [data-id="basic-3"]')
 
-    // Start drag using dragAndDrop to ensure proper event sequence
-    // but interrupt it to check classes during drag
-    const dragPromise = page.dragAndDrop(
-      '#basic-list [data-id="basic-1"]',
-      '#basic-list [data-id="basic-3"]',
-      {
-        // Use steps to slow down the drag so we can check classes
-        sourcePosition: { x: 10, y: 10 },
-        targetPosition: { x: 10, y: 10 },
-      }
-    )
-
-    // Wait a bit for drag to start
-    await page.waitForTimeout(100)
-
-    // Check classes are applied during drag
-    // Note: This might be flaky as dragAndDrop is atomic in some browsers
-    // If this continues to fail, we may need to skip this specific test
-    const hasChosenClass = await firstItem.evaluate((el) =>
-      el.classList.contains('sortable-chosen')
-    )
-    const hasDragClass = await firstItem.evaluate((el) =>
-      el.classList.contains('sortable-drag')
-    )
-
-    // Complete the drag
-    await dragPromise
-
-    // If classes weren't detected during drag (due to atomic operation),
-    // at least verify they're removed after
-    if (!hasChosenClass && !hasDragClass) {
-      // Skip the during-drag assertion if we couldn't catch it
-      // This can happen when dragAndDrop is atomic in some browsers
-    } else {
-      expect(hasChosenClass).toBeTruthy()
-      expect(hasDragClass).toBeTruthy()
+    const fromBox = await firstItem.boundingBox()
+    const toBox = await thirdItem.boundingBox()
+    if (!fromBox || !toBox) throw new Error('missing bounding box')
+    const from = {
+      x: fromBox.x + fromBox.width / 2,
+      y: fromBox.y + fromBox.height / 2,
     }
+    const to = { x: toBox.x + toBox.width / 2, y: toBox.y + toBox.height / 2 }
 
-    // Check classes are removed after drag
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.mouse.move(from.x, from.y, { steps: 3 })
+
+    // Both classes are applied as soon as the ghost is created (commit
+    // phase), which happens immediately since basic-list uses the default
+    // (zero) fallbackTolerance.
+    await expect(firstItem).toHaveClass(/sortable-chosen/)
+    await expect(firstItem).toHaveClass(/sortable-drag/)
+
+    await page.mouse.move(to.x, to.y, { steps: 10 })
+    await page.mouse.up()
+
+    // Classes are removed after drag completes.
     await expect(firstItem).not.toHaveClass(/sortable-chosen/)
     await expect(firstItem).not.toHaveClass(/sortable-drag/)
   })

--- a/tests/e2e/ghost-elements.spec.ts
+++ b/tests/e2e/ghost-elements.spec.ts
@@ -31,7 +31,14 @@ test.describe('Ghost Element Functionality', () => {
   // intermediate drag-class state. Driving the pointer through discrete
   // mouse.move steps — mirroring tests/e2e/on-move.spec.ts — lets us assert
   // on the class mid-drag before releasing. Tracked in #73.
-  test('applies drag class during drag operation', async ({ page }) => {
+  test('applies drag class during drag operation', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      testInfo.project.name === 'Mobile Chrome' ||
+        testInfo.project.name === 'Mobile Safari',
+      'mouse-driven drag is non-deterministic on mobile touch emulation — tracked in #48/#62'
+    )
     const firstItem = page.locator('#basic-list [data-id="basic-1"]')
     const thirdItem = page.locator('#basic-list [data-id="basic-3"]')
 

--- a/tests/e2e/keyboard-navigation.spec.ts
+++ b/tests/e2e/keyboard-navigation.spec.ts
@@ -88,6 +88,37 @@ test.describe('Keyboard Navigation', () => {
     await expect(secondItem).toHaveAttribute('aria-selected', 'true')
   })
 
+  test('extends selection across items with Shift+ArrowDown', async ({
+    page,
+  }) => {
+    const container = page.locator('#basic-list')
+    const firstItem = page.locator('#basic-list [data-id="basic-1"]')
+    const secondItem = page.locator('#basic-list [data-id="basic-2"]')
+    const thirdItem = page.locator('#basic-list [data-id="basic-3"]')
+
+    // Wait for initialization
+    await page.waitForTimeout(100)
+
+    // Focus and select the first item
+    await firstItem.focus()
+    await container.press('Space')
+    await expect(firstItem).toHaveAttribute('aria-selected', 'true')
+
+    // Extend the selection downward with Shift+ArrowDown
+    await container.press('Shift+ArrowDown')
+    await expect(firstItem).toHaveAttribute('aria-selected', 'true')
+    await expect(secondItem).toHaveAttribute('aria-selected', 'true')
+    await expect(secondItem).toHaveClass(/sortable-selected/)
+    await expect(secondItem).toBeFocused()
+
+    // Extend again - selection should now cover three items
+    await container.press('Shift+ArrowDown')
+    await expect(firstItem).toHaveAttribute('aria-selected', 'true')
+    await expect(secondItem).toHaveAttribute('aria-selected', 'true')
+    await expect(thirdItem).toHaveAttribute('aria-selected', 'true')
+    await expect(thirdItem).toBeFocused()
+  })
+
   test('performs keyboard drag and drop with Enter key', async ({ page }) => {
     const container = page.locator('#basic-list')
     const items = page.locator('#basic-list .sortable-item')

--- a/tests/e2e/swap-behavior.spec.ts
+++ b/tests/e2e/swap-behavior.spec.ts
@@ -1,215 +1,468 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
-/* eslint-disable @typescript-eslint/no-unsafe-call */
-/* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
 
-// FIXME: Suite needs CSS-positioned fixtures — tracked in #77.
-test.describe.skip(
-  'Swap Behavior Options - TODO: Requires CSS positioning for accurate overlap calculation',
-  () => {
-    // These tests are skipped because:
-    // 1. Swap threshold calculations depend on proper CSS positioning and getBoundingClientRect
-    // 2. The functionality is implemented but needs visual layout for testing
-    // 3. Consider testing with existing page elements that have proper CSS applied
-    test.beforeEach(async ({ page }) => {
-      await page.goto('/')
-    })
+/**
+ * Coverage for `swapThreshold` / `invertSwap` / `invertedSwapThreshold` /
+ * `direction` (#77). Previously skipped: the inline fixtures built plain
+ * `document.createElement` markup with no explicit sizing, so
+ * `getBoundingClientRect()` overlap math (the whole point of these options)
+ * was unpredictable.
+ *
+ * Two things had to be fixed, not just fixture CSS:
+ *
+ * 1. **Geometry** — mirrors `fallback-mode.spec.ts`: `position: absolute`
+ *    fixtures with explicit item width/height so every rect is known in
+ *    advance and overlap fractions are computable exactly.
+ *
+ * 2. **Which pipeline `shouldSwap()` is even wired into.** `DragManager`
+ *    has exactly two call sites for the threshold gate: the native HTML5
+ *    `dragover` handler, and `handleControlledMove` (shared by both
+ *    pipelines when `controlled: true`). The *uncontrolled* pointer path
+ *    that `page.mouse` normally drives (see `on-move.spec.ts`) reorders
+ *    immediately on `over !== movingElement` — it never consults
+ *    `swapThreshold` at all. Native HTML5 `dragstart`/`dragover` can't be
+ *    triggered by Playwright's synthetic mouse input here either (same
+ *    constraint documented in `on-move.spec.ts`). So `controlled: true` is
+ *    the only way to exercise the threshold gate via `page.mouse` — the
+ *    fixtures below all use it, and assertions read the placeholder's
+ *    position (`data-resortable-placeholder`, same signal
+ *    `controlled-pointer.spec.ts` uses) instead of real DOM item order,
+ *    since controlled mode never structurally moves the real items mid-drag.
+ */
 
-    test.skip('should respect swapThreshold option', async ({ page }) => {
-      // Create a test list with swapThreshold set to 0.5
-      await page.evaluate(() => {
-        const container = document.createElement('div')
-        container.id = 'test-list'
-        container.style.padding = '20px'
-        container.innerHTML = `
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Item 1</div>
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Item 2</div>
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Item 3</div>
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Item 4</div>
-      `
-        document
-          .querySelectorAll('.container')
-          .forEach((el) => ((el as HTMLElement).style.display = 'none'))
-        document.body.appendChild(container)
-        const Sortable = window.Sortable as any
-        if (!Sortable) return
-        new Sortable(container, {
-          swapThreshold: 0.5,
-          animation: 0,
-        })
-      })
+/**
+ * Mouse Y for a given vertical overlap fraction against `targetTop`.
+ *
+ * The ghost (item-sized, tracks the cursor) has `top = mouseY - grabOffset`
+ * where `grabOffset` is how far below the dragged item's own top edge it
+ * was grabbed. Solving `overlap = 1 - |mouseY - targetTop - grabOffset| /
+ * itemHeight` for the branch where the ghost's bottom clips at the
+ * target's bottom gives `mouseY = targetTop + grabOffset +
+ * itemHeight * (1 - overlap)`.
+ *
+ * `grabOffset` also decides which side of the target's midpoint the cursor
+ * lands on (`handleControlledMove`'s `naturalAfter` — insert after the
+ * target when the cursor is past its midpoint). A small `grabOffset` puts
+ * LOW overlaps past the midpoint (used for the inverted-threshold cases,
+ * where the swap fires at low overlap); a `grabOffset` around a quarter of
+ * the item size puts HIGH overlaps past the midpoint too (used for the
+ * normal-threshold cases, where the swap fires at high overlap) — pick
+ * per-test so the swap is a real index change, not a same-index no-op.
+ */
+function overlapY(
+  targetTop: number,
+  itemHeight: number,
+  overlap: number,
+  grabOffset: number
+): number {
+  return targetTop + grabOffset + itemHeight * (1 - overlap)
+}
 
-      const item1 = page.locator('.sortable-item').first()
-      const item2 = page.locator('.sortable-item').nth(1)
+/** Horizontal counterpart of {@link overlapY}. */
+function overlapX(
+  targetLeft: number,
+  itemWidth: number,
+  overlap: number,
+  grabOffset: number
+): number {
+  return targetLeft + grabOffset + itemWidth * (1 - overlap)
+}
 
-      // Get initial positions
-      const item1Box = await item1.boundingBox()
-      const item2Box = await item2.boundingBox()
+/**
+ * DOM order of `container`'s children, labeled the same way
+ * `controlled-pointer.spec.ts` does: the placeholder is `'PH'`, the ghost
+ * (if hit) is `'GHOST'`, everything else reports its `data-id`. Swap
+ * outcome is read from where `'PH'` lands relative to the target's id.
+ */
+async function childLabels(page: Page, containerId: string): Promise<string[]> {
+  return page.evaluate((id) => {
+    const el = document.getElementById(id)
+    if (!el) return []
+    return Array.from(el.children).map((c) =>
+      c.hasAttribute('data-resortable-placeholder')
+        ? 'PH'
+        : c.hasAttribute('data-resortable-ghost')
+          ? 'GHOST'
+          : ((c as HTMLElement).dataset.id ?? '')
+    )
+  }, containerId)
+}
 
-      // Start drag on item1
-      await item1.hover()
-      await page.mouse.down()
+test.describe('Swap Behavior Options (#77)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/playground.html')
+    await page.waitForFunction(() => window.resortableLoaded === true)
+  })
 
-      // Move to 30% overlap with item2 (should not swap with 0.5 threshold)
-      const partialOverlapY = item2Box!.y + item2Box!.height * 0.3
-      await page.mouse.move(item1Box!.x + 10, partialOverlapY)
-      await page.waitForTimeout(100)
-
-      // Check that items haven't swapped
-      let items = await page.locator('.sortable-item').allTextContents()
-      expect(items).toEqual(['Item 1', 'Item 2', 'Item 3', 'Item 4'])
-
-      // Move to 60% overlap (should swap with 0.5 threshold)
-      const fullOverlapY = item2Box!.y + item2Box!.height * 0.6
-      await page.mouse.move(item1Box!.x + 10, fullOverlapY)
-      await page.waitForTimeout(100)
-
-      // Release drag
-      await page.mouse.up()
-
-      // Check that items have swapped
-      items = await page.locator('.sortable-item').allTextContents()
-      expect(items).toEqual(['Item 2', 'Item 1', 'Item 3', 'Item 4'])
-    })
-
-    test.skip('should handle invertSwap option', async ({ page }) => {
-      await page.evaluate(() => {
-        const container = document.createElement('div')
-        container.id = 'test-list'
-        container.style.padding = '20px'
-        container.innerHTML = `
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Item A</div>
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Item B</div>
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Item C</div>
-      `
-        document
-          .querySelectorAll('.container')
-          .forEach((el) => ((el as HTMLElement).style.display = 'none'))
-        document.body.appendChild(container)
-        const Sortable = window.Sortable as any
-        if (!Sortable) return
-        new Sortable(container, {
-          invertSwap: true,
-          swapThreshold: 0.5,
-          animation: 0,
-        })
-      })
-
-      const itemA = page.locator('.sortable-item').first()
-      const itemB = page.locator('.sortable-item').nth(1)
-
-      const itemABox = await itemA.boundingBox()
-      const itemBBox = await itemB.boundingBox()
-
-      // Start drag on itemA
-      await itemA.hover()
-      await page.mouse.down()
-
-      // With invertSwap, small overlap should trigger swap
-      const smallOverlapY = itemBBox!.y + itemBBox!.height * 0.2
-      await page.mouse.move(itemABox!.x + 10, smallOverlapY)
-      await page.waitForTimeout(100)
-      await page.mouse.up()
-
-      // Check that items have swapped due to inverted behavior
-      const items = await page.locator('.sortable-item').allTextContents()
-      expect(items).toEqual(['Item B', 'Item A', 'Item C'])
-    })
-
-    test.skip('should respect direction option for horizontal sorting', async ({
-      page,
-    }) => {
-      await page.evaluate(() => {
-        const container = document.createElement('div')
-        container.id = 'horizontal-list'
-        container.style.display = 'flex'
-        container.style.padding = '20px'
-        container.innerHTML = `
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Card 1</div>
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Card 2</div>
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Card 3</div>
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Card 4</div>
-      `
-        document
-          .querySelectorAll('.container')
-          .forEach((el) => ((el as HTMLElement).style.display = 'none'))
-        document.body.appendChild(container)
-        const Sortable = window.Sortable as any
-        if (!Sortable) return
-        new Sortable(container, {
-          direction: 'horizontal',
-          swapThreshold: 0.5,
-          animation: 0,
-        })
-      })
-
-      const card1 = page.locator('.sortable-item').first()
-      const card2 = page.locator('.sortable-item').nth(1)
-
-      const card1Box = await card1.boundingBox()
-      const card2Box = await card2.boundingBox()
-
-      // Start drag on card1
-      await card1.hover()
-      await page.mouse.down()
-
-      // Move horizontally to overlap with card2
-      const overlapX = card2Box!.x + card2Box!.width * 0.6
-      await page.mouse.move(overlapX, card1Box!.y + 10)
-      await page.waitForTimeout(100)
-      await page.mouse.up()
-
-      // Check that items have swapped horizontally
-      const items = await page.locator('.sortable-item').allTextContents()
-      expect(items).toEqual(['Card 2', 'Card 1', 'Card 3', 'Card 4'])
-    })
-
-    test.skip('should use invertedSwapThreshold when invertSwap is true', async ({
-      page,
-    }) => {
-      await page.evaluate(() => {
-        const container = document.createElement('div')
-        container.id = 'test-list'
-        container.style.padding = '20px'
-        container.innerHTML = `
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Item 1</div>
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Item 2</div>
-        <div class="sortable-item" style="padding: 20px; margin: 5px; background: #f0f0f0;">Item 3</div>
-      `
-        document
-          .querySelectorAll('.container')
-          .forEach((el) => ((el as HTMLElement).style.display = 'none'))
-        document.body.appendChild(container)
-        const Sortable = window.Sortable as any
-        if (!Sortable) return
-        new Sortable(container, {
-          invertSwap: true,
-          swapThreshold: 0.8,
-          invertedSwapThreshold: 0.3,
-          animation: 0,
-        })
-      })
-
-      const item1 = page.locator('.sortable-item').first()
-      const item2 = page.locator('.sortable-item').nth(1)
-
-      const item1Box = await item1.boundingBox()
-      const item2Box = await item2.boundingBox()
-
-      // Start drag on item1
-      await item1.hover()
-      await page.mouse.down()
-
-      // Move to 25% overlap (less than invertedSwapThreshold of 0.3, should swap)
-      const smallOverlapY = item2Box!.y + item2Box!.height * 0.25
-      await page.mouse.move(item1Box!.x + 10, smallOverlapY)
-      await page.waitForTimeout(100)
-      await page.mouse.up()
-
-      // Check that items have swapped
-      const items = await page.locator('.sortable-item').allTextContents()
-      expect(items).toEqual(['Item 2', 'Item 1', 'Item 3'])
-    })
+  function skipMobile(testInfo: { project: { name: string } }): boolean {
+    return /Mobile/.test(testInfo.project.name)
   }
-)
+
+  test('should respect swapThreshold option', async ({ page }, testInfo) => {
+    test.skip(
+      skipMobile(testInfo),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    const LIST = '#swap-threshold-list'
+    const ITEM_HEIGHT = 60
+
+    await page.evaluate(() => {
+      document.getElementById('swap-threshold-list')?.remove()
+      const container = document.createElement('div')
+      container.id = 'swap-threshold-list'
+      container.style.cssText =
+        'position:absolute;top:40px;left:40px;width:220px;background:#eef'
+      container.innerHTML = `
+        <div class="sortable-item" data-id="st-1" style="width:220px;height:60px;background:#ccc;">Item 1</div>
+        <div class="sortable-item" data-id="st-2" style="width:220px;height:60px;background:#ddd;">Item 2</div>
+        <div class="sortable-item" data-id="st-3" style="width:220px;height:60px;background:#ccc;">Item 3</div>
+        <div class="sortable-item" data-id="st-4" style="width:220px;height:60px;background:#ddd;">Item 4</div>
+      `
+      document.body.appendChild(container)
+
+      interface WindowWithSortable extends Window {
+        Sortable?: typeof import('../../src/index.js').Sortable
+      }
+      const win = window as WindowWithSortable
+      const Sortable = win.Sortable
+      if (!Sortable) throw new Error('Sortable not loaded on window')
+      new Sortable(container, {
+        controlled: true,
+        swapThreshold: 0.5,
+        animation: 0,
+      })
+    })
+
+    const item1Box = await page
+      .locator(`${LIST} [data-id="st-1"]`)
+      .boundingBox()
+    const item2Box = await page
+      .locator(`${LIST} [data-id="st-2"]`)
+      .boundingBox()
+    if (!item1Box || !item2Box) throw new Error('missing item boxes')
+
+    // Grab offset of 15 (a quarter of the 60px item height) keeps the 60%
+    // overlap stage's cursor past item2's midpoint — see {@link overlapY}.
+    const GRAB_OFFSET = 15
+    const grabX = item1Box.x + item1Box.width / 2
+    const grabY = item1Box.y + GRAB_OFFSET
+
+    await page.mouse.move(grabX, grabY)
+    await page.mouse.down()
+
+    // 30% overlap — below the 0.5 threshold, must NOT swap. `st-1` (the
+    // dragged item) stays in the DOM — hidden, not removed — so it appears
+    // right after the placeholder; the ghost lives inside the zone
+    // (`fallbackOnBody` defaults to false) and sorts last.
+    await page.mouse.move(
+      grabX,
+      overlapY(item2Box.y, ITEM_HEIGHT, 0.3, GRAB_OFFSET),
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-threshold-list')).toEqual([
+      'PH',
+      'st-1',
+      'st-2',
+      'st-3',
+      'st-4',
+      'GHOST',
+    ])
+
+    // 60% overlap — above the 0.5 threshold, must swap.
+    await page.mouse.move(
+      grabX,
+      overlapY(item2Box.y, ITEM_HEIGHT, 0.6, GRAB_OFFSET),
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-threshold-list')).toEqual([
+      'st-1',
+      'st-2',
+      'PH',
+      'st-3',
+      'st-4',
+      'GHOST',
+    ])
+
+    await page.mouse.up()
+  })
+
+  test('should handle invertSwap option', async ({ page }, testInfo) => {
+    test.skip(
+      skipMobile(testInfo),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    const LIST = '#swap-invert-list'
+    const ITEM_HEIGHT = 60
+
+    await page.evaluate(() => {
+      document.getElementById('swap-invert-list')?.remove()
+      const container = document.createElement('div')
+      container.id = 'swap-invert-list'
+      container.style.cssText =
+        'position:absolute;top:40px;left:40px;width:220px;background:#efe'
+      container.innerHTML = `
+        <div class="sortable-item" data-id="iv-a" style="width:220px;height:60px;background:#cdc;">Item A</div>
+        <div class="sortable-item" data-id="iv-b" style="width:220px;height:60px;background:#dcd;">Item B</div>
+        <div class="sortable-item" data-id="iv-c" style="width:220px;height:60px;background:#cdc;">Item C</div>
+      `
+      document.body.appendChild(container)
+
+      interface WindowWithSortable extends Window {
+        Sortable?: typeof import('../../src/index.js').Sortable
+      }
+      const win = window as WindowWithSortable
+      const Sortable = win.Sortable
+      if (!Sortable) throw new Error('Sortable not loaded on window')
+      new Sortable(container, {
+        controlled: true,
+        invertSwap: true,
+        swapThreshold: 0.5,
+        animation: 0,
+      })
+    })
+
+    const itemABox = await page
+      .locator(`${LIST} [data-id="iv-a"]`)
+      .boundingBox()
+    const itemBBox = await page
+      .locator(`${LIST} [data-id="iv-b"]`)
+      .boundingBox()
+    if (!itemABox || !itemBBox) throw new Error('missing item boxes')
+
+    // Grab offset near the item's top edge keeps the low-overlap (0.2) swap
+    // stage's cursor past item B's midpoint — see {@link overlapY}.
+    const GRAB_OFFSET = 5
+    const grabX = itemABox.x + itemABox.width / 2
+    const grabY = itemABox.y + GRAB_OFFSET
+
+    await page.mouse.move(grabX, grabY)
+    await page.mouse.down()
+
+    // 80% overlap — inverted rule swaps only when overlap < threshold, so a
+    // LARGE overlap must NOT swap.
+    await page.mouse.move(
+      grabX,
+      overlapY(itemBBox.y, ITEM_HEIGHT, 0.8, GRAB_OFFSET),
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-invert-list')).toEqual([
+      'PH',
+      'iv-a',
+      'iv-b',
+      'iv-c',
+      'GHOST',
+    ])
+
+    // 20% overlap — below the 0.5 threshold, inverted rule swaps.
+    await page.mouse.move(
+      grabX,
+      overlapY(itemBBox.y, ITEM_HEIGHT, 0.2, GRAB_OFFSET),
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-invert-list')).toEqual([
+      'iv-a',
+      'iv-b',
+      'PH',
+      'iv-c',
+      'GHOST',
+    ])
+
+    await page.mouse.up()
+  })
+
+  test('should respect direction option for horizontal sorting', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      skipMobile(testInfo),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    const LIST = '#swap-direction-list'
+    const ITEM_WIDTH = 100
+
+    await page.evaluate(() => {
+      document.getElementById('swap-direction-list')?.remove()
+      const container = document.createElement('div')
+      container.id = 'swap-direction-list'
+      container.style.cssText =
+        'position:absolute;top:40px;left:40px;width:400px;display:flex;background:#eef'
+      container.innerHTML = `
+        <div class="sortable-item" data-id="card-1" style="width:100px;height:60px;flex-shrink:0;background:#ccc;">Card 1</div>
+        <div class="sortable-item" data-id="card-2" style="width:100px;height:60px;flex-shrink:0;background:#ddd;">Card 2</div>
+        <div class="sortable-item" data-id="card-3" style="width:100px;height:60px;flex-shrink:0;background:#ccc;">Card 3</div>
+        <div class="sortable-item" data-id="card-4" style="width:100px;height:60px;flex-shrink:0;background:#ddd;">Card 4</div>
+      `
+      document.body.appendChild(container)
+
+      interface WindowWithSortable extends Window {
+        Sortable?: typeof import('../../src/index.js').Sortable
+      }
+      const win = window as WindowWithSortable
+      const Sortable = win.Sortable
+      if (!Sortable) throw new Error('Sortable not loaded on window')
+      new Sortable(container, {
+        controlled: true,
+        direction: 'horizontal',
+        swapThreshold: 0.5,
+        animation: 0,
+      })
+    })
+
+    const card1Box = await page
+      .locator(`${LIST} [data-id="card-1"]`)
+      .boundingBox()
+    const card2Box = await page
+      .locator(`${LIST} [data-id="card-2"]`)
+      .boundingBox()
+    if (!card1Box || !card2Box) throw new Error('missing item boxes')
+
+    // Grab offset of 20 (a fifth of the 100px item width) keeps the 60%
+    // overlap stage's cursor past card2's midpoint — see {@link overlapY}.
+    const GRAB_OFFSET = 20
+    const grabX = card1Box.x + GRAB_OFFSET
+    const grabY = card1Box.y + card1Box.height / 2
+
+    await page.mouse.move(grabX, grabY)
+    await page.mouse.down()
+
+    // 30% overlap — below the 0.5 threshold, must NOT swap.
+    await page.mouse.move(
+      overlapX(card2Box.x, ITEM_WIDTH, 0.3, GRAB_OFFSET),
+      grabY,
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-direction-list')).toEqual([
+      'PH',
+      'card-1',
+      'card-2',
+      'card-3',
+      'card-4',
+      'GHOST',
+    ])
+
+    // 60% overlap — above the 0.5 threshold, must swap.
+    await page.mouse.move(
+      overlapX(card2Box.x, ITEM_WIDTH, 0.6, GRAB_OFFSET),
+      grabY,
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-direction-list')).toEqual([
+      'card-1',
+      'card-2',
+      'PH',
+      'card-3',
+      'card-4',
+      'GHOST',
+    ])
+
+    await page.mouse.up()
+  })
+
+  test('should use invertedSwapThreshold when invertSwap is true', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      skipMobile(testInfo),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    const LIST = '#swap-inverted-threshold-list'
+    const ITEM_HEIGHT = 60
+
+    await page.evaluate(() => {
+      document.getElementById('swap-inverted-threshold-list')?.remove()
+      const container = document.createElement('div')
+      container.id = 'swap-inverted-threshold-list'
+      container.style.cssText =
+        'position:absolute;top:40px;left:40px;width:220px;background:#fee'
+      container.innerHTML = `
+        <div class="sortable-item" data-id="ivt-1" style="width:220px;height:60px;background:#dcc;">Item 1</div>
+        <div class="sortable-item" data-id="ivt-2" style="width:220px;height:60px;background:#ddc;">Item 2</div>
+        <div class="sortable-item" data-id="ivt-3" style="width:220px;height:60px;background:#dcc;">Item 3</div>
+      `
+      document.body.appendChild(container)
+
+      interface WindowWithSortable extends Window {
+        Sortable?: typeof import('../../src/index.js').Sortable
+      }
+      const win = window as WindowWithSortable
+      const Sortable = win.Sortable
+      if (!Sortable) throw new Error('Sortable not loaded on window')
+      new Sortable(container, {
+        controlled: true,
+        invertSwap: true,
+        swapThreshold: 0.8,
+        invertedSwapThreshold: 0.3,
+        animation: 0,
+      })
+    })
+
+    const item1Box = await page
+      .locator(`${LIST} [data-id="ivt-1"]`)
+      .boundingBox()
+    const item2Box = await page
+      .locator(`${LIST} [data-id="ivt-2"]`)
+      .boundingBox()
+    if (!item1Box || !item2Box) throw new Error('missing item boxes')
+
+    // Grab offset near the item's top edge keeps the low-overlap (0.25) swap
+    // stage's cursor past item2's midpoint — see {@link overlapY}.
+    const GRAB_OFFSET = 5
+    const grabX = item1Box.x + item1Box.width / 2
+    const grabY = item1Box.y + GRAB_OFFSET
+
+    await page.mouse.move(grabX, grabY)
+    await page.mouse.down()
+
+    // 50% overlap — not below invertedSwapThreshold (0.3), must NOT swap.
+    // (Also above swapThreshold (0.8)? No — but invertSwap replaces the
+    // normal gate entirely, so only the `< invertedSwapThreshold` check
+    // applies here.)
+    await page.mouse.move(
+      grabX,
+      overlapY(item2Box.y, ITEM_HEIGHT, 0.5, GRAB_OFFSET),
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-inverted-threshold-list')).toEqual([
+      'PH',
+      'ivt-1',
+      'ivt-2',
+      'ivt-3',
+      'GHOST',
+    ])
+
+    // 25% overlap — below invertedSwapThreshold (0.3), must swap.
+    await page.mouse.move(
+      grabX,
+      overlapY(item2Box.y, ITEM_HEIGHT, 0.25, GRAB_OFFSET),
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-inverted-threshold-list')).toEqual([
+      'ivt-1',
+      'ivt-2',
+      'PH',
+      'ivt-3',
+      'GHOST',
+    ])
+
+    await page.mouse.up()
+  })
+})

--- a/tests/unit/keyboard-manager.test.ts
+++ b/tests/unit/keyboard-manager.test.ts
@@ -338,8 +338,7 @@ describe('KeyboardManager', () => {
       keyboardManager.attach()
     })
 
-    // TODO: Implement Shift+Arrow for extending selection
-    it.skip('should extend selection with Shift+ArrowDown', () => {
+    it('should extend selection with Shift+ArrowDown', () => {
       selectionManager.select(items[1])
       selectionManager.setFocus(items[1])
 
@@ -355,7 +354,7 @@ describe('KeyboardManager', () => {
       expect(selectionManager.getFocused()).toBe(items[2])
     })
 
-    it.skip('should extend selection with Shift+ArrowUp', () => {
+    it('should extend selection with Shift+ArrowUp', () => {
       selectionManager.select(items[2])
       selectionManager.setFocus(items[2])
 


### PR DESCRIPTION
## Summary

Un-skips and rewrites a batch of skipped e2e/unit suites discovered during the #35 skip-triage. Test-only — no library source changes (the one real bug found, `sort:false`, is split into its own PR so it gets its own changelog entry/release).

Most of these shared one root cause: Playwright's atomic `page.dragAndDrop`/`locator.dragTo` fires too fast to observe mid-drag states. The repo already solved this in `tests/e2e/on-move.spec.ts` with low-level `page.mouse` steps; these mirror that pattern.

## What's in here

| Issue | Suite | Result |
| --- | --- | --- |
| #36 | Shift+Arrow keyboard selection | feature was already implemented; un-skipped 2 unit tests + added e2e. **Pass** |
| #73 | `advanced-events` / `ghost-elements` atomic-drag rewrite | **2/4** rewritten to pointer pipeline (onMove, drag-class). See below re: the other 2. |
| #74 | `basic-sortable` hover + touch | hover asserted a CSS rule the fixture never had (traced pre-split history) → deleted; touch was redundant + unfixable via Playwright's tap-only touch API → deleted. Both justified. |
| #76 | `delay-options` timing | made deterministic via Playwright's `page.clock` API. **4/4** |
| #77 | `swap-behavior` threshold suite | added CSS-positioned fixtures + `controlled: true` (uncontrolled pointer pipeline never checks `swapThreshold`). **4/4** |
| #79 | `animation` FLIP suite | rewrote 8 tests to pointer pipeline + WAAPI assertions; verified 40/40 with `--repeat-each=5`. **8/8** |

`npm run check`: 0 errors. Full unit suite: 292/292.

## #73 is partial (by design)

2 of #73's 4 tests stay skipped because they need a **library change, not a test fix**: the pointer pipeline's same-zone reorder only emits `'update'`, never `'sort'`/`'change'` (those fire only in the HTML5-native `onDragOver` path). No stepped-mouse pattern can make them fire. Tracked in #121 (pointer/HTML5 pipeline parity — also covers #77's finding that the uncontrolled pointer path ignores `swapThreshold`).

## Infra note

Relies on the `PW_PORT` override already merged to `main` (`playwright.config.ts` + `vite.config.ts`), which lets parallel worktrees each serve on their own port.

Closes #36
Closes #73
Closes #74
Closes #76
Closes #77
Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vym6FXPvjGgsmK9CX4m9xU
