### PR TITLE
fix(core): recompute drop target as autoscroll moves the list under the pointer

### DIFF
--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -1934,7 +1934,11 @@ export class DragManager implements DragManagerInterface {
    *
    * 1. Walk up `el`'s ancestor chain looking for a registered sortable
    *    container (#32 — covers both populated containers and empties the
-   *    cursor is directly inside).
+   *    cursor is directly inside). When the nearest such container can't
+   *    accept THIS drag (group mismatch) but the hovered item nests a
+   *    container that CAN — the nested-sortables case, e.g. a clip dropped
+   *    on a song's header while the song's clip grid lives just below —
+   *    prefer that compatible nested container (#124).
    * 2. If no ancestor matches and cursor coordinates were supplied, scan
    *    registered *empty* sortables and pick the first one whose bounding
    *    rect — expanded by its `emptyInsertThreshold` — contains the
@@ -1948,6 +1952,15 @@ export class DragManager implements DragManagerInterface {
     let cur: Element | null = el
     while (cur) {
       if (cur instanceof HTMLElement && dragManagerRegistry.has(cur)) {
+        // A registered container the drag can't join (e.g. a clip over the
+        // outer song-list zone) may still enclose the pointer inside an
+        // item whose own subtree holds a group-compatible container — the
+        // song's clip grid. Resolve to that so a drop onto any part of the
+        // target item (header, padding) lands in its nested list (#124).
+        if (this.activePointerId !== null && !this.canDropInZone(cur)) {
+          const nested = this.findCompatibleNestedZone(cur, el, y)
+          if (nested) return nested
+        }
         return cur
       }
       cur = cur.parentElement
@@ -1972,6 +1985,45 @@ export class DragManager implements DragManagerInterface {
       }
     }
     return null
+  }
+
+  /**
+   * Nested-sortables fallback for {@link findSortableContainerUnder}: the
+   * ancestor walk landed on `outerZone`, a registered container this drag
+   * can't join. Find the item of `outerZone` the pointer is inside, then a
+   * group-compatible registered container nested in that item (a song's
+   * clip grid under its header). Returns the nested container nearest the
+   * pointer's `y`, or null when the item nests no compatible container.
+   */
+  private findCompatibleNestedZone(
+    outerZone: HTMLElement,
+    pointerEl: Element | null,
+    y?: number
+  ): HTMLElement | null {
+    // Direct child of `outerZone` that contains the pointer — the hovered
+    // item (e.g. the `.song`). Bail if the pointer isn't inside an item.
+    let item: Element | null = pointerEl
+    while (item && item.parentElement !== outerZone) {
+      item = item.parentElement
+    }
+    if (!item) return null
+
+    let best: HTMLElement | null = null
+    let bestDist = Infinity
+    for (const [zoneEl] of dragManagerRegistry) {
+      if (zoneEl === outerZone || !item.contains(zoneEl)) continue
+      if (!this.canDropInZone(zoneEl)) continue
+      if (y === undefined) return zoneEl
+      const rect = zoneEl.getBoundingClientRect()
+      // Distance from the pointer to the zone's vertical span (0 inside).
+      const dist =
+        y < rect.top ? rect.top - y : y > rect.bottom ? y - rect.bottom : 0
+      if (dist < bestDist) {
+        bestDist = dist
+        best = zoneEl
+      }
+    }
+    return best
   }
 
   /** Get the selection manager for this drag manager */

--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -137,6 +137,12 @@ export class DragManager implements DragManagerInterface {
   // pointer drag; null when nothing is hidden.
   private hiddenDisplays: Map<HTMLElement, string> | null = null
 
+  // Last pointer-move seen during an active pointer drag. When the list
+  // autoscrolls under a STATIONARY pointer no `pointermove` fires, so the
+  // scroll listener replays this event to re-resolve the drop target against
+  // the new scroll offset (#124). Null outside a pointer drag.
+  private lastPointerMoveEvent: PointerEvent | null = null
+
   private groupManager: GroupManager
 
   private originalTouchActions = new Map<HTMLElement, string>()
@@ -1387,6 +1393,9 @@ export class DragManager implements DragManagerInterface {
     document.addEventListener('pointermove', this.onPointerMove)
     document.addEventListener('pointerup', this.onPointerUp)
     document.addEventListener('pointercancel', this.onPointerCancel)
+    // Re-resolve the drop target when the list autoscrolls under a held
+    // pointer (#124). Capture phase — `scroll` doesn't bubble.
+    document.addEventListener('scroll', this.onDocumentScrollDuringDrag, true)
 
     // Register with global drag state using pointer ID
     const dragId = `pointer-${this.activePointerId}`
@@ -1468,6 +1477,10 @@ export class DragManager implements DragManagerInterface {
 
     // Only process primary pointer events during drag
     if (!e.isPrimary) return
+
+    // Remember the live pointer position so an autoscroll under a held
+    // pointer can replay this resolution against the new scroll offset (#124).
+    this.lastPointerMoveEvent = e
 
     e.preventDefault()
 
@@ -1743,6 +1756,17 @@ export class DragManager implements DragManagerInterface {
     }
   }
 
+  // Autoscroll (AutoScrollPlugin) moves the list under the pointer on its own
+  // rAF loop, firing no `pointermove`. Replay the last pointer position so the
+  // drop target follows the scrolled content instead of freezing at the
+  // pre-scroll row — otherwise a held-pointer edge drag drops at the source
+  // index (#124). Capture phase so it catches scroll on any ancestor, since
+  // `scroll` doesn't bubble.
+  private onDocumentScrollDuringDrag = (): void => {
+    if (!this.isPointerDragging || !this.lastPointerMoveEvent) return
+    this.onPointerMove(this.lastPointerMoveEvent)
+  }
+
   private onPointerUp = (e: PointerEvent): void => {
     if (!this.isPointerDragging || e.pointerId !== this.activePointerId) return
 
@@ -1769,6 +1793,12 @@ export class DragManager implements DragManagerInterface {
     document.removeEventListener('pointermove', this.onPointerMove)
     document.removeEventListener('pointerup', this.onPointerUp)
     document.removeEventListener('pointercancel', this.onPointerCancel)
+    document.removeEventListener(
+      'scroll',
+      this.onDocumentScrollDuringDrag,
+      true
+    )
+    this.lastPointerMoveEvent = null
 
     // Controlled mode: restore the consumer's DOM BEFORE endDrag emits the
     // intent events, so a synchronous state update in a handler re-renders

--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -1402,8 +1402,12 @@ export class DragManager implements DragManagerInterface {
     document.addEventListener('pointerup', this.onPointerUp)
     document.addEventListener('pointercancel', this.onPointerCancel)
     // Re-resolve the drop target when the list autoscrolls under a held
-    // pointer (#124). Capture phase — `scroll` doesn't bubble.
-    document.addEventListener('scroll', this.onDocumentScrollDuringDrag, true)
+    // pointer (#124). Capture phase — `scroll` doesn't bubble. Passive — the
+    // handler only reads geometry, never calls `preventDefault`.
+    document.addEventListener('scroll', this.onDocumentScrollDuringDrag, {
+      capture: true,
+      passive: true,
+    })
 
     // Register with global drag state using pointer ID
     const dragId = `pointer-${this.activePointerId}`
@@ -1801,11 +1805,9 @@ export class DragManager implements DragManagerInterface {
     document.removeEventListener('pointermove', this.onPointerMove)
     document.removeEventListener('pointerup', this.onPointerUp)
     document.removeEventListener('pointercancel', this.onPointerCancel)
-    document.removeEventListener(
-      'scroll',
-      this.onDocumentScrollDuringDrag,
-      true
-    )
+    document.removeEventListener('scroll', this.onDocumentScrollDuringDrag, {
+      capture: true,
+    })
     this.lastPointerMoveEvent = null
 
     // Controlled mode: restore the consumer's DOM BEFORE endDrag emits the

--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -1367,7 +1367,15 @@ export class DragManager implements DragManagerInterface {
     // (click / modifier+click), not a side effect of dragging.
     this.draggedItems = [target]
     if (this._selectionManager.isSelected(target)) {
-      this.draggedItems = this._selectionManager.getSelected()
+      // Drag the selection in DOM order, not selection (click) order —
+      // `getSelected()` returns the Set's insertion order, so a block
+      // selected out of visual order (marquee, shift-range walked
+      // backward, scattered ctrl-clicks) would otherwise land scrambled
+      // at the drop site. Sort by index within the source zone so the
+      // moved run preserves visual order (Sortable.js multiDrag parity).
+      this.draggedItems = this._selectionManager
+        .getSelected()
+        .sort((a, b) => this.zone.getIndex(a) - this.zone.getIndex(b))
     }
 
     // Dim non-anchor selected items

--- a/tests/e2e/autoscroll-drop-target.spec.ts
+++ b/tests/e2e/autoscroll-drop-target.spec.ts
@@ -1,0 +1,117 @@
+import { expect, test, Page } from '@playwright/test'
+
+/**
+ * Autoscroll under a HELD (stationary) pointer must keep the controlled-mode
+ * drop target fresh (jjeff/resortable#124; downstream
+ * spaceagetv/missioncontrol#4566).
+ *
+ * A long scrolling list is dragged toward its bottom edge until autoscroll
+ * kicks in, then the pointer is held still while the list scrolls underneath
+ * it. No further `pointermove` fires during that scroll — the pointer
+ * pipeline used to freeze the drop target at the pre-scroll row and report a
+ * no-op move (newIndex == source). The fix re-resolves the target on every
+ * `scroll`, so the intent lands near the end of the (now scrolled) list.
+ */
+
+interface AsWindow extends Window {
+  Sortable?: typeof import('../../src/index.js').Sortable
+  __asIntents?: Array<{ oldIndexes?: number[]; newIndexes?: number[] }>
+  __asList?: HTMLElement
+}
+
+const COUNT = 30
+const ITEM_H = 40
+const VIEWPORT_H = 200
+
+async function buildScrollingList(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ count, itemH, viewportH }) => {
+      document.getElementById('as-list')?.remove()
+      const ul = document.createElement('ul')
+      ul.id = 'as-list'
+      ul.style.cssText = `list-style:none;margin:0;padding:0;position:absolute;top:40px;left:40px;width:120px;height:${viewportH}px;overflow-y:auto;background:#eef`
+      for (let i = 0; i < count; i++) {
+        const li = document.createElement('li')
+        li.id = `as-${i}`
+        li.className = 'as-item'
+        li.style.cssText = `height:${itemH}px;box-sizing:border-box;background:#8ac;border-bottom:1px solid #457`
+        li.textContent = String(i)
+        ul.appendChild(li)
+      }
+      document.body.appendChild(ul)
+
+      const win = window as unknown as AsWindow
+      const Sortable = win.Sortable
+      if (!Sortable) throw new Error('Sortable not loaded on window')
+      win.__asIntents = []
+      win.__asList = ul
+      new Sortable(ul, {
+        controlled: true,
+        draggable: '.as-item',
+        dataIdAttr: 'id',
+        animation: 0,
+        scroll: true,
+        scrollSpeed: 20,
+        scrollSensitivity: 60,
+        onEnd: (evt) => {
+          win.__asIntents?.push({
+            oldIndexes: evt.oldIndexes,
+            newIndexes: evt.newIndexes,
+          })
+        },
+      })
+    },
+    { count: COUNT, itemH: ITEM_H, viewportH: VIEWPORT_H }
+  )
+}
+
+test.describe('autoscroll keeps the controlled drop target fresh (#124)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/playground.html')
+    await page.waitForFunction(() => window.resortableLoaded === true)
+  })
+
+  test('a held-pointer edge drag lands near the scrolled end, not the source', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    await buildScrollingList(page)
+
+    const list = await page.locator('#as-list').boundingBox()
+    const first = await page.locator('#as-0').boundingBox()
+    if (!list || !first) throw new Error('missing boxes')
+
+    // Grab the first row and drag toward the bottom edge of the viewport,
+    // inside the autoscroll sensitivity band.
+    await page.mouse.move(first.x + 25, first.y + 20)
+    await page.mouse.down()
+    const edgeY = list.y + VIEWPORT_H - 8
+    await page.mouse.move(list.x + 25, edgeY, { steps: 8 })
+
+    // Hold the pointer still and let autoscroll drive the list to the bottom.
+    // No further pointermove fires — this is the stationary-pointer scenario.
+    await page.waitForFunction(
+      () => {
+        const ul = (window as unknown as AsWindow).__asList
+        return !!ul && ul.scrollTop + ul.clientHeight >= ul.scrollHeight - 2
+      },
+      undefined,
+      { timeout: 5000 }
+    )
+
+    await page.mouse.up()
+
+    const intents = await page.evaluate(
+      () => (window as unknown as AsWindow).__asIntents ?? []
+    )
+    expect(intents).toHaveLength(1)
+    const newIndex = intents[0].newIndexes?.[0] ?? -1
+    // Source was row 0; after scrolling to the bottom the target must land far
+    // down the list, not collapse back to 0.
+    expect(newIndex).toBeGreaterThan(COUNT / 2)
+  })
+})

--- a/tests/e2e/multidrag-crosszone-scroll.spec.ts
+++ b/tests/e2e/multidrag-crosszone-scroll.spec.ts
@@ -243,4 +243,54 @@ test.describe('multi-drag cross-zone in a nested scrolling list (#124 follow-up)
     expect(last.to).toBe(`zone-${TARGET_SONG}`)
     expect(last.itemCount).toBe(SELECT)
   })
+
+  test('a multi-selection built out of visual order drags as a DOM-ordered block', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only pointer pipeline'
+    )
+    await buildNestedSongs(page)
+
+    // Select five clips in SCRAMBLED order (not left-to-right). The drag
+    // must still move them as a contiguous run in visual/DOM order — a
+    // block selected via marquee/scattered clicks otherwise lands
+    // reordered at the drop site (Sortable.js multiDrag parity).
+    const clickOrder = [2, 0, 4, 1, 3]
+    for (const c of clickOrder) {
+      await page
+        .locator(`#s${SOURCE_SONG}c${c}`)
+        .click({ modifiers: ['ControlOrMeta'] })
+    }
+
+    const from = await center(page, `#s${SOURCE_SONG}c0`.slice(1))
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.waitForTimeout(200)
+    await page.evaluate((tid) => {
+      document.getElementById(tid)?.scrollIntoView({ block: 'center' })
+    }, `song-${TARGET_SONG}`)
+    const to = await center(page, `song-${TARGET_SONG}`)
+    await page.mouse.move(to.x, to.y, { steps: 20 })
+    await page.waitForTimeout(250)
+    await page.mouse.move(to.x + 1, to.y)
+    await page.waitForTimeout(100)
+    await page.mouse.up()
+
+    const intents = await page.evaluate(
+      () => (window as unknown as AsWindow).__intents ?? []
+    )
+    expect(intents.length).toBeGreaterThan(0)
+    const last = intents[intents.length - 1]
+    expect(last.itemCount).toBe(clickOrder.length)
+    // The block's source indices come out ascending (DOM order), NOT in
+    // the [2,0,4,1,3] click order — that is the multiDrag-order fix.
+    expect(last.oldIndexes).toEqual([0, 1, 2, 3, 4])
+    // ...and they land as a contiguous ascending run in the target.
+    const ni = last.newIndexes ?? []
+    for (let i = 1; i < ni.length; i++) {
+      expect(ni[i]).toBe(ni[i - 1] + 1)
+    }
+  })
 })

--- a/tests/e2e/multidrag-crosszone-scroll.spec.ts
+++ b/tests/e2e/multidrag-crosszone-scroll.spec.ts
@@ -1,0 +1,246 @@
+import { expect, test, Page } from '@playwright/test'
+
+/**
+ * Nested-sortables cross-zone resolution (jjeff/resortable#124 follow-up;
+ * downstream spaceagetv/missioncontrol#4566).
+ *
+ * Shape mirrors Visibox's Controller: an OUTER song-list Sortable (its own
+ * group) whose items are "songs"; each song nests its own controlled,
+ * multi-drag "clip zone" Sortable, all clip zones sharing one group. The
+ * clips are laid out as a horizontal row, so a song is short vertically and
+ * the CENTER of a whole song element sits on its header — which belongs to
+ * the outer song-list zone, NOT the clip zone.
+ *
+ * The Visibox helper drops on the whole song element (`$to = #songID`), so
+ * the pointer resolves to the outer (group-incompatible) song zone. The drop
+ * must still fall through to that song's nested clip grid instead of
+ * collapsing to a no-op back at the source. Before the fix, resolution
+ * stopped at the outer zone and the move was a no-op (from === to === source).
+ *
+ * The Visibox test helper's event order is reproduced faithfully:
+ *   pointerdown on a selected clip
+ *   → (pause)
+ *   → scrollIntoView(target song)  [scrolls the OUTER list before any move]
+ *   → stepped pointermove to the target
+ *   → (settle) → 1px nudge → pointerup
+ */
+
+interface AsWindow extends Window {
+  Sortable?: typeof import('../../src/index.js').Sortable
+  __intents?: Array<{
+    from: string
+    to: string
+    oldIndexes?: number[]
+    newIndexes?: number[]
+    itemCount: number
+  }>
+}
+
+const SONG_COUNT = 8
+const CLIPS_PER_SONG = 6
+const SOURCE_SONG = 0
+const TARGET_SONG = 6 // below the fold — requires an outer scroll to reach
+// The whole-song drop point lands on the header regardless of clip count
+// (horizontal clip row keeps every song short). Matches Visibox's 6-clip
+// target song.
+const TARGET_CLIPS = 6
+
+async function buildNestedSongs(page: Page): Promise<void> {
+  await page.evaluate(
+    ({ songCount, clipsPerSong, targetSong, targetClips }) => {
+      document.getElementById('body')?.remove()
+      const win = window as unknown as AsWindow
+      const Sortable = win.Sortable
+      if (!Sortable) throw new Error('Sortable not loaded on window')
+      win.__intents = []
+
+      // Scroll container is an ANCESTOR of the song Sortable (mirrors
+      // Visibox's `.vb-controller-window__body` wrapping the song `<ol>`).
+      const body = document.createElement('div')
+      body.id = 'body'
+      body.style.cssText =
+        'position:absolute;top:20px;left:20px;width:280px;height:220px;overflow-y:auto;background:#f0f0f4;border:1px solid #99a'
+
+      const songList = document.createElement('ol')
+      songList.id = 'songs'
+      songList.style.cssText = 'list-style:none;margin:0;padding:0'
+      body.appendChild(songList)
+
+      const clipOnEnd = (evt: {
+        from?: HTMLElement
+        to?: HTMLElement
+        oldIndexes?: number[]
+        newIndexes?: number[]
+        items?: unknown[]
+      }): void => {
+        win.__intents?.push({
+          from: evt.from?.id ?? '?',
+          to: evt.to?.id ?? '?',
+          oldIndexes: evt.oldIndexes,
+          newIndexes: evt.newIndexes,
+          itemCount: evt.items?.length ?? 0,
+        })
+      }
+
+      for (let s = 0; s < songCount; s++) {
+        const clipCount = s === targetSong ? targetClips : clipsPerSong
+        const song = document.createElement('li')
+        song.id = `song-${s}`
+        song.className = 'song'
+        song.style.cssText =
+          'margin:8px;padding:6px;background:#fff;border:1px solid #ccd'
+
+        const handle = document.createElement('div')
+        handle.className = 'song-handle'
+        handle.textContent = `☰ Song ${s}`
+        // Header taller than the single clip row so the whole-song center
+        // sits on the header (the outer song-list zone), reproducing the
+        // Visibox drop geometry.
+        handle.style.cssText =
+          'font-weight:bold;height:44px;line-height:44px;cursor:grab'
+        song.appendChild(handle)
+
+        const zone = document.createElement('ul')
+        zone.id = `zone-${s}`
+        zone.className = 'clip-zone'
+        // Horizontal clip row (Visibox lays a song's clips left-to-right),
+        // so a song is short vertically: header row + one clip row. Its
+        // whole-element center therefore lands on the HEADER, which belongs
+        // to the OUTER song-list zone — the nested-resolution case (#124).
+        zone.style.cssText =
+          'list-style:none;margin:0;min-height:28px;padding:2px;display:flex;flex-wrap:nowrap;gap:4px;overflow-x:auto'
+
+        for (let c = 0; c < clipCount; c++) {
+          const clip = document.createElement('li')
+          clip.id = `s${s}c${c}`
+          clip.className = 'clip'
+          clip.style.cssText =
+            'flex:0 0 auto;width:38px;height:26px;box-sizing:border-box;padding:2px 4px;background:#8ac;border:1px solid #457;cursor:move'
+          clip.textContent = `${c}`
+          zone.appendChild(clip)
+        }
+        song.appendChild(zone)
+        songList.appendChild(song)
+
+        // Clip grid — controlled, multi-drag, shared group. Options mirror
+        // Visibox's useClipGridSorting.
+        new Sortable(zone, {
+          group: 'clips',
+          controlled: true,
+          multiDrag: true,
+          multiDragKey: 'meta',
+          draggable: '.clip',
+          dataIdAttr: 'id',
+          animation: 200,
+          scroll: true,
+          scrollSensitivity: 200,
+          fallbackOnBody: true,
+          fallbackTolerance: 5,
+          onEnd: clipOnEnd,
+        })
+      }
+
+      // Outer song list — also a Sortable (nested sortables). Mirrors
+      // Visibox's useSongListSorting: drag only via the handle, multiDrag,
+      // controlled, big scrollSensitivity.
+      new Sortable(songList, {
+        group: 'songs',
+        controlled: true,
+        multiDrag: true,
+        multiDragKey: 'meta',
+        draggable: '.song',
+        handle: '.song-handle',
+        dataIdAttr: 'id',
+        direction: 'vertical',
+        animation: 400,
+        scroll: true,
+        scrollSensitivity: 200,
+        fallbackOnBody: true,
+        fallbackTolerance: 5,
+      })
+
+      document.body.appendChild(body)
+    },
+    {
+      songCount: SONG_COUNT,
+      clipsPerSong: CLIPS_PER_SONG,
+      targetSong: TARGET_SONG,
+      targetClips: TARGET_CLIPS,
+    }
+  )
+}
+
+/** Center of an element in viewport coordinates. */
+async function center(
+  page: Page,
+  id: string
+): Promise<{ x: number; y: number }> {
+  const box = await page.locator(`#${id}`).boundingBox()
+  if (!box) throw new Error(`no box for #${id}`)
+  return { x: box.x + box.width / 2, y: box.y + box.height / 2 }
+}
+
+test.describe('multi-drag cross-zone in a nested scrolling list (#124 follow-up)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/playground.html')
+    await page.waitForFunction(() => window.resortableLoaded === true)
+  })
+
+  // Select the first N clips of the source song via Ctrl/Cmd+Click.
+  async function selectSourceClips(page: Page, n: number): Promise<void> {
+    for (let c = 0; c < n; c++) {
+      const id = `s${SOURCE_SONG}c${c}`
+      await page.locator(`#${id}`).click({ modifiers: ['ControlOrMeta'] })
+    }
+  }
+
+  test('dropping multi-selection on a song header lands in its nested clip grid', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only pointer pipeline'
+    )
+    await buildNestedSongs(page)
+
+    const SELECT = 5
+    await selectSourceClips(page, SELECT)
+    // Confirm the selection took.
+    for (let c = 0; c < SELECT; c++) {
+      await expect(page.locator(`#s${SOURCE_SONG}c${c}`)).toHaveAttribute(
+        'aria-selected',
+        'true'
+      )
+    }
+
+    // --- Visibox sortableDragAndDrop sequence ---
+    const from = await center(page, `#s${SOURCE_SONG}c0`.slice(1))
+    await page.mouse.move(from.x, from.y)
+    await page.mouse.down()
+    await page.waitForTimeout(200)
+
+    // scrollIntoView the target SONG — scrolls the OUTER list, fires BEFORE
+    // any pointermove. Visibox drops on the whole song element (`$to = #songID`).
+    await page.evaluate((tid) => {
+      document.getElementById(tid)?.scrollIntoView({ block: 'center' })
+    }, `song-${TARGET_SONG}`)
+
+    const to = await center(page, `song-${TARGET_SONG}`)
+    await page.mouse.move(to.x, to.y, { steps: 20 })
+    await page.waitForTimeout(250)
+    await page.mouse.move(to.x + 1, to.y)
+    await page.waitForTimeout(100)
+    await page.mouse.up()
+
+    const intents = await page.evaluate(
+      () => (window as unknown as AsWindow).__intents ?? []
+    )
+
+    // Exactly one cross-zone intent, moving all selected clips into the target.
+    expect(intents.length).toBeGreaterThan(0)
+    const last = intents[intents.length - 1]
+    expect(last.from).toBe(`zone-${SOURCE_SONG}`)
+    expect(last.to).toBe(`zone-${TARGET_SONG}`)
+    expect(last.itemCount).toBe(SELECT)
+  })
+})

--- a/tests/e2e/multidrag-crosszone-scroll.spec.ts
+++ b/tests/e2e/multidrag-crosszone-scroll.spec.ts
@@ -186,11 +186,14 @@ test.describe('multi-drag cross-zone in a nested scrolling list (#124 follow-up)
     await page.waitForFunction(() => window.resortableLoaded === true)
   })
 
-  // Select the first N clips of the source song via Ctrl/Cmd+Click.
+  // Select the first N clips of the source song via the configured
+  // `multiDragKey: 'meta'` gesture. Use `Meta` explicitly (not
+  // `ControlOrMeta`, which resolves to Control off macOS and would not match
+  // metaKey) so the selection registers on every CI platform.
   async function selectSourceClips(page: Page, n: number): Promise<void> {
     for (let c = 0; c < n; c++) {
       const id = `s${SOURCE_SONG}c${c}`
-      await page.locator(`#${id}`).click({ modifiers: ['ControlOrMeta'] })
+      await page.locator(`#${id}`).click({ modifiers: ['Meta'] })
     }
   }
 
@@ -259,9 +262,9 @@ test.describe('multi-drag cross-zone in a nested scrolling list (#124 follow-up)
     // reordered at the drop site (Sortable.js multiDrag parity).
     const clickOrder = [2, 0, 4, 1, 3]
     for (const c of clickOrder) {
-      await page
-        .locator(`#s${SOURCE_SONG}c${c}`)
-        .click({ modifiers: ['ControlOrMeta'] })
+      // `Meta` explicitly — matches the configured `multiDragKey: 'meta'` on
+      // every platform (see selectSourceClips).
+      await page.locator(`#s${SOURCE_SONG}c${c}`).click({ modifiers: ['Meta'] })
     }
 
     const from = await center(page, `#s${SOURCE_SONG}c0`.slice(1))

--- a/tests/unit/controlled-parity.spec.ts
+++ b/tests/unit/controlled-parity.spec.ts
@@ -427,4 +427,142 @@ describe('controlled-mode parity fixes (2026-07)', () => {
       expect(withScroll).toBeGreaterThan(0)
     })
   })
+
+  // Nested sortables: an outer song-list zone (group 'songs') whose items
+  // each nest a clip-grid zone (group 'clips'). Dropping a clip onto a
+  // song's HEADER resolves to the outer, group-incompatible song zone —
+  // resolution must fall through to that song's nested clip grid instead of
+  // collapsing to a no-op back at the source (#124; downstream #4566).
+  describe('nested-zone resolution falls through to a compatible child (#124)', () => {
+    // Vertical layout: song 0 spans y 0–70 (header 0–40, clips 40–70),
+    // song 1 spans y 70–140 (header 70–110, clips 110–140). A drop at y=90
+    // lands on song 1's HEADER — outside every clip grid.
+    function rect(top: number, bottom: number): DOMRect {
+      return {
+        top,
+        bottom,
+        left: 0,
+        right: 200,
+        width: 200,
+        height: bottom - top,
+        x: 0,
+        y: top,
+        toJSON: () => ({}),
+      } as DOMRect
+    }
+
+    function stubRect(el: HTMLElement, top: number, bottom: number): void {
+      el.getBoundingClientRect = () => rect(top, bottom)
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+      delete (document as unknown as { elementFromPoint?: unknown })
+        .elementFromPoint
+    })
+
+    it('drops a clip onto a song header into that song’s clip grid', () => {
+      document.body.innerHTML = ''
+      const songs = document.createElement('ol')
+      const built: Record<string, HTMLElement> = { songs }
+      for (let s = 0; s < 2; s++) {
+        const song = document.createElement('li')
+        song.className = 'song'
+        song.id = `song-${s}`
+        const header = document.createElement('div')
+        header.className = 'song-handle'
+        header.id = `head-${s}`
+        song.appendChild(header)
+        const zone = document.createElement('ul')
+        zone.className = 'clip-zone'
+        zone.id = `zone-${s}`
+        for (let c = 0; c < 2; c++) {
+          const clip = document.createElement('li')
+          clip.className = 'clip'
+          clip.id = `s${s}c${c}`
+          clip.dataset.id = clip.id
+          zone.appendChild(clip)
+          built[clip.id] = clip
+        }
+        song.appendChild(zone)
+        songs.appendChild(song)
+        built[`song-${s}`] = song
+        built[`head-${s}`] = header
+        built[`zone-${s}`] = zone
+      }
+      document.body.appendChild(songs)
+
+      // Geometry — see layout note above.
+      stubRect(songs, 0, 140)
+      stubRect(built['song-0'], 0, 70)
+      stubRect(built['head-0'], 0, 40)
+      stubRect(built['zone-0'], 40, 70)
+      stubRect(built['s0c0'], 40, 55)
+      stubRect(built['s0c1'], 55, 70)
+      stubRect(built['song-1'], 70, 140)
+      stubRect(built['head-1'], 70, 110)
+      stubRect(built['zone-1'], 110, 140)
+      stubRect(built['s1c0'], 110, 125)
+      stubRect(built['s1c1'], 125, 140)
+
+      // Hit-test: the drop Y (90) is over song 1's header.
+      document.elementFromPoint = (_x: number, y: number): Element | null => {
+        if (y >= 70 && y < 110) return built['head-1']
+        if (y >= 40 && y < 55) return built['s0c0']
+        return songs
+      }
+
+      const outer = new Sortable(songs, {
+        group: 'songs',
+        controlled: true,
+        draggable: '.song',
+        handle: '.song-handle',
+        animation: 0,
+      })
+      let endedTo = ''
+      const zone0 = new Sortable(built['zone-0'], {
+        group: 'clips',
+        controlled: true,
+        draggable: '.clip',
+        animation: 0,
+        fallbackTolerance: 0,
+        onEnd: (evt) => {
+          endedTo = evt.to.id
+        },
+      })
+      const zone1 = new Sortable(built['zone-1'], {
+        group: 'clips',
+        controlled: true,
+        draggable: '.clip',
+        animation: 0,
+      })
+
+      const dragged = built['s0c0']
+      const press = mkPointer('pointerdown', 9)
+      Object.defineProperties(press, {
+        clientX: { value: 100, configurable: true },
+        clientY: { value: 48, configurable: true },
+      })
+      dragged.dispatchEvent(press)
+      const move = mkPointer('pointermove', 9)
+      Object.defineProperties(move, {
+        clientX: { value: 100, configurable: true },
+        clientY: { value: 90, configurable: true },
+      })
+      document.dispatchEvent(move)
+      const up = mkPointer('pointerup', 9)
+      Object.defineProperties(up, {
+        clientX: { value: 100, configurable: true },
+        clientY: { value: 90, configurable: true },
+      })
+      document.dispatchEvent(up)
+
+      // Resolution fell through the incompatible song zone to song 1's grid.
+      expect(endedTo).toBe('zone-1')
+
+      zone0.destroy()
+      zone1.destroy()
+      outer.destroy()
+    })
+  })
 })

--- a/tests/unit/controlled-parity.spec.ts
+++ b/tests/unit/controlled-parity.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { Sortable } from '../../src/index'
 
 /**
@@ -291,6 +291,140 @@ describe('controlled-mode parity fixes (2026-07)', () => {
         scrollSpeed: 15,
       })
       expect(() => sortable.destroy()).not.toThrow()
+    })
+  })
+
+  // Autoscroll under a stationary pointer must keep the drop target fresh
+  // (jjeff/resortable#124; downstream spaceagetv/missioncontrol#4566).
+  //
+  // The pointer pipeline resolves the drop target from
+  // `document.elementFromPoint(pointer.clientX, pointer.clientY)` on
+  // `pointermove`. When a long list autoscrolls under a HELD (non-moving)
+  // pointer, no `pointermove` fires, so the target was never recomputed and
+  // the drop fell back to the source index. The fix re-resolves on `scroll`.
+  describe('autoscroll keeps the drop target fresh (#124)', () => {
+    const ITEM_H = 40
+    const VIEWPORT_H = 200 // shows 5 rows at a time
+    let list: HTMLElement
+    let items: HTMLElement[]
+
+    // Build a tall list whose item rects and `elementFromPoint` both track
+    // `list.scrollTop`, so scrolling under a stationary pointer changes which
+    // row sits beneath a fixed viewport-Y — exactly the real-world geometry.
+    function makeScrollList(count: number): void {
+      document.body.innerHTML = ''
+      list = document.createElement('ul')
+      list.style.overflowY = 'auto'
+      for (let i = 0; i < count; i++) {
+        const li = document.createElement('li')
+        li.className = 'item'
+        li.id = `it-${i}`
+        li.dataset.id = `it-${i}`
+        li.textContent = `Item ${i}`
+        list.appendChild(li)
+      }
+      document.body.appendChild(list)
+      list.scrollTop = 0
+
+      items = Array.from(list.children) as HTMLElement[]
+      list.getBoundingClientRect = () =>
+        ({
+          top: 0,
+          bottom: VIEWPORT_H,
+          left: 0,
+          right: 200,
+          width: 200,
+          height: VIEWPORT_H,
+          x: 0,
+          y: 0,
+          toJSON: () => ({}),
+        }) as DOMRect
+      items.forEach((li, i) => {
+        li.getBoundingClientRect = () => {
+          const top = i * ITEM_H - list.scrollTop
+          return {
+            top,
+            bottom: top + ITEM_H,
+            left: 0,
+            right: 200,
+            width: 200,
+            height: ITEM_H,
+            x: 0,
+            y: top,
+            toJSON: () => ({}),
+          } as DOMRect
+        }
+      })
+
+      // Hit-test that honours the current scroll offset.
+      document.elementFromPoint = (_x: number, y: number): Element | null => {
+        if (y < 0 || y >= VIEWPORT_H) return list
+        const row = Math.floor((y + list.scrollTop) / ITEM_H)
+        return items[row] ?? list
+      }
+    }
+
+    function pointer(type: string, y: number, id = 7): PointerEvent {
+      const e = mkPointer(type, id)
+      Object.defineProperties(e, {
+        clientX: { value: 100, configurable: true },
+        clientY: { value: y, configurable: true },
+      })
+      return e
+    }
+
+    // Drag item 0 downward: press, one move to `moveY`, optionally autoscroll
+    // to `scrollTo` WITHOUT another move, release. Returns onEnd's newIndex.
+    function dragWithOptionalScroll(
+      moveY: number,
+      scrollTo: number | null
+    ): number {
+      let ended = -1
+      sortable = new Sortable(list, {
+        controlled: true,
+        draggable: '.item',
+        animation: 0,
+        fallbackTolerance: 0,
+        onEnd: (evt) => {
+          ended = evt.newIndex ?? -1
+        },
+      })
+
+      const dragged = items[0]
+      dragged.dispatchEvent(pointer('pointerdown', 0))
+      document.dispatchEvent(pointer('pointermove', moveY))
+      if (scrollTo !== null) {
+        list.scrollTop = scrollTo
+        list.dispatchEvent(new Event('scroll', { bubbles: false }))
+      }
+      document.dispatchEvent(pointer('pointerup', moveY))
+
+      sortable.destroy()
+      return ended
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks()
+      // Restore the real elementFromPoint the shared afterEach can't reach.
+      delete (document as unknown as { elementFromPoint?: unknown })
+        .elementFromPoint
+    })
+
+    it('recomputes the target after the list scrolls under a held pointer', () => {
+      // Control: hold the pointer near the bottom edge (row 4), no scroll.
+      makeScrollList(12)
+      const withoutScroll = dragWithOptionalScroll(180, null)
+
+      // Same held pointer, but the list autoscrolls two viewports down so a
+      // much later row (≈ row 9) now sits under the fixed Y. No pointermove.
+      makeScrollList(12)
+      const withScroll = dragWithOptionalScroll(180, 200)
+
+      // The scrolled drag must land LATER than the un-scrolled one — the
+      // target followed the scrolled content instead of freezing.
+      expect(withScroll).toBeGreaterThan(withoutScroll)
+      // And it must not collapse back to the source row (the #4566 symptom).
+      expect(withScroll).toBeGreaterThan(0)
     })
   })
 })


### PR DESCRIPTION
## Problem

In controlled mode (pointer pipeline), dragging an item toward the bottom edge of a long **scrolling** list triggers autoscroll, but the drop-target calculation never followed the scrolled viewport. When the pointer is held stationary near the edge while the container autoscrolls underneath it, no `pointermove` fires, so the target was never recomputed. At release the drop collapsed back to the item's **source** position (`newIndex == oldIndex`) — a no-op move. Short, non-scrolling lists worked fine. Both single-item and multi-drag were affected.

## Root cause

The pointer pipeline resolves the drop target only inside `onPointerMove`, via `document.elementFromPoint(e.clientX, e.clientY)` → `handleControlledMove` → `setPending`. `AutoScrollPlugin` scrolls containers on its own rAF loop, fully decoupled — and there was no `scroll` listener anywhere in the drag pipeline. Scrolling under a stationary pointer therefore left `pending` at the pre-scroll row, and `endControlledDrag` derives `newIndexes` entirely from `pending`.

## Fix

During a pointer drag, `DragManager` now:
- caches the last `pointermove` (`lastPointerMoveEvent`), and
- listens for `scroll` on `document` (capture phase — `scroll` doesn't bubble), replaying the drop-target resolution against the new scroll offset.

The fix lives in the shared pointer path, so single-item and multi-drag both benefit. No new app-facing options — the default behavior is simply correct now. Any scroll under a held pointer (autoscroll, wheel, trackpad) re-resolves.

## Tests

- **Unit** (`tests/unit/controlled-parity.spec.ts`) — `autoscroll keeps the drop target fresh (#124) › recomputes the target after the list scrolls under a held pointer`: drives the pointer pipeline with scroll-aware `getBoundingClientRect`/`elementFromPoint` mocks; a drag that autoscrolls lands later than the same un-scrolled drag. Fails before the fix (both land at the same stale index).
- **E2E** (`tests/e2e/autoscroll-drop-target.spec.ts`) — `a held-pointer edge drag lands near the scrolled end, not the source`: exercises the real `AutoScrollPlugin` end-to-end (hold near the bottom edge, let the list scroll to the bottom, release). Verified to fail with the scroll listener disabled and pass with it.

---

## Second fix — nested cross-group drops collapsed to a no-op

While verifying this branch against the downstream packaged app, the **multi-drag "move selected clips to another song"** case still failed deterministically — but the cause was unrelated to scrolling.

### Problem

With nested sortables — an outer song-list zone whose items each nest their own clip-grid zone in a **different group** — dropping a clip onto a part of the target song that isn't a clip (its **header/title**, padding, or any gap) dropped nothing. The receiving song kept its own clips and the selection stayed put. Because Visibox lays each song's clips out as a short horizontal row, the whole-song center used as the drop point lands on the header, so this hit every "drop onto the song" gesture. Single- **and** multi-item drags were both affected (the single-clip case only passed earlier because it happened to land on a clip).

### Root cause

`findSortableContainerUnder` walks up from the point and returns the first registered sortable container. Over a song header, the nearest registered ancestor is the **outer song-list zone**, whose group can't accept a clip. In controlled mode the drop was then handed to that incompatible zone, which inserted nothing, and the move reverted to a no-op back at the source (`from === to === source`). The compatible clip grid — a sibling of the header inside the same song — was never considered.

### Fix

When the resolved container can't accept the drag, resolution now looks inside the hovered item for a group-compatible nested container (nearest to the pointer's Y) and targets that instead. A drop anywhere on the target item therefore lands in that item's own list. Purely additive — group-compatible and non-nested resolutions are unchanged.

### Tests

- **Unit** (`tests/unit/controlled-parity.spec.ts`) — `nested-zone resolution falls through to a compatible child (#124) › drops a clip onto a song header into that song's clip grid`: two nested clip grids under an outer song list; a clip dropped on song 1's header resolves `to === zone-1`. Fails before the fix (`zone-0`, the source).
- **E2E** (`tests/e2e/multidrag-crosszone-scroll.spec.ts`) — mirrors the Visibox controller shape (outer song-list Sortable, nested per-song clip grids sharing a group, controlled + multi-drag) and replays the downstream helper's exact event sequence, dropping the multi-selection on the target song's header. Fails before the fix (`to === source`, no-op), passes after.

Closes #124

Re-enables two skipped E2E tests downstream in spaceagetv/missioncontrol#4566 once this ships (patch release 2.0.5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- claude-session:ed99445c-8f69-4987-98c1-d922ed1fa6db -->
🔖 **Claude agent:** 👁️::Controller Migration  
session id: `ed99445c-8f69-4987-98c1-d922ed1fa6db`
