### PR TITLE
feat(core): add `hitArea` option — non-empty zone claims drops in a surrounding region (#126)

### DIFF
--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -605,7 +605,14 @@ export class DragManager implements DragManagerInterface {
     visible: HTMLElement[]
   ): boolean {
     const pt = e as MouseEvent
-    if (typeof pt.clientX !== 'number') return false
+    // Same coordinate gate as `controlledInsertAfter`: need real coords, and
+    // treat (0,0) as "no usable coords" (synthetic events) — otherwise a
+    // vertical zone would read an undefined/0 `clientY` and misplace.
+    const hasCoords =
+      typeof pt.clientX === 'number' &&
+      typeof pt.clientY === 'number' &&
+      (pt.clientX !== 0 || pt.clientY !== 0)
+    if (!hasCoords) return false
     const rect = zoneEl.getBoundingClientRect()
     return this.detectHorizontalLayout(visible)
       ? pt.clientX < rect.left
@@ -1997,8 +2004,13 @@ export class DragManager implements DragManagerInterface {
     for (const [zoneEl, manager] of dragManagerRegistry) {
       if (!manager._hitArea) continue
       if (this.activePointerId !== null && !this.canDropInZone(zoneEl)) continue
-      const region = zoneEl.closest(manager._hitArea)
-      if (region && el && region.contains(el)) return zoneEl
+      try {
+        const region = zoneEl.closest(manager._hitArea)
+        if (region && el && region.contains(el)) return zoneEl
+      } catch {
+        // Invalid `hitArea` selector — fail closed (skip this zone) so a
+        // malformed selector can't abort drop-target resolution mid-drag.
+      }
     }
     return null
   }

--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -98,6 +98,10 @@ export class DragManager implements DragManagerInterface {
   // @ts-expect-error - kept on the instance so hide/show flow can read it later
   private _removeCloneOnHide: boolean
   private _emptyInsertThreshold: number
+  // CSS selector for a surrounding region whose drops this zone also claims,
+  // inserting at the nearest end (#126). Read cross-instance in
+  // `findSortableContainerUnder`, like `_emptyInsertThreshold`.
+  private _hitArea?: string
   private preventOnFilter: boolean
   // `_dataIdAttr` is the configured `data-*` attribute name used as the
   // identity column by toArray() / sort(). It is also forwarded to
@@ -181,6 +185,7 @@ export class DragManager implements DragManagerInterface {
       dropBubble?: boolean
       removeCloneOnHide?: boolean
       emptyInsertThreshold?: number
+      hitArea?: string
       preventOnFilter?: boolean
       dataIdAttr?: string
       ghostClass?: string
@@ -249,6 +254,7 @@ export class DragManager implements DragManagerInterface {
     this._dropBubble = options?.dropBubble ?? false
     this._removeCloneOnHide = options?.removeCloneOnHide ?? true
     this._emptyInsertThreshold = options?.emptyInsertThreshold ?? 5
+    this._hitArea = options?.hitArea
 
     // Initialize other options
     this.preventOnFilter = options?.preventOnFilter ?? true
@@ -585,6 +591,27 @@ export class DragManager implements DragManagerInterface {
     return this.direction === 'horizontal'
   }
 
+  /**
+   * Nearest-end anchor for a no-sibling zone entry (#126): true when the
+   * pointer sits before the zone's start edge (left for a row, top for a
+   * column) → insert at index 0; false → append. Only differs from a plain
+   * append when the pointer is OUTSIDE the zone's own rect, which is exactly
+   * the `hitArea`-resolved case — for an empty zone or a pointer inside the
+   * zone's own area both branches collapse to the same position.
+   */
+  private insertAtStartOfZone(
+    e: Event,
+    zoneEl: HTMLElement,
+    visible: HTMLElement[]
+  ): boolean {
+    const pt = e as MouseEvent
+    if (typeof pt.clientX !== 'number') return false
+    const rect = zoneEl.getBoundingClientRect()
+    return this.detectHorizontalLayout(visible)
+      ? pt.clientX < rect.left
+      : pt.clientY < rect.top
+  }
+
   private handleControlledMove(
     e: Event,
     over: HTMLElement | null,
@@ -625,6 +652,12 @@ export class DragManager implements DragManagerInterface {
       const hasSibling = overIsValid && over.parentElement === targetZoneElement
       const related: HTMLElement = hasSibling && over ? over : targetZoneElement
       const visible = targetZone.getVisibleItems(items)
+      // No hovered sibling: the pointer is in the zone's own empty area or was
+      // routed here from a surrounding `hitArea` region (#126). Insert at the
+      // nearest end — index 0 when the pointer is before the zone's start
+      // edge, else append (unchanged for the in-zone/empty cases).
+      const atStart =
+        !hasSibling && this.insertAtStartOfZone(e, targetZoneElement, visible)
       // Which side of the hovered sibling the cursor is on decides the
       // insert side; hovering empty container space appends at the end.
       const enterAfter =
@@ -632,7 +665,11 @@ export class DragManager implements DragManagerInterface {
           ? this.controlledInsertAfter(e, over, placeholder, visible)
           : false
       const overIdx =
-        hasSibling && over ? visible.indexOf(over) : visible.length
+        hasSibling && over
+          ? visible.indexOf(over)
+          : atStart
+            ? 0
+            : visible.length
       if (overIdx === -1) return
       const newIndex = overIdx + (enterAfter ? 1 : 0)
 
@@ -655,8 +692,8 @@ export class DragManager implements DragManagerInterface {
       // contract: 1 forces after, -1 forces before).
       const insertAfter =
         moveResult === 1 ? true : moveResult === -1 ? false : enterAfter
-      let insertRef: Node | null = null
-      let index = visible.length
+      let insertRef: Node | null = atStart && visible.length ? visible[0] : null
+      let index = atStart ? 0 : visible.length
       if (hasSibling && over) {
         insertRef = insertAfter ? over.nextSibling : over
         index = visible.indexOf(over) + (insertAfter ? 1 : 0)
@@ -1591,9 +1628,16 @@ export class DragManager implements DragManagerInterface {
 
           const targetZone = targetDragManager?.zone ?? this.zone
           const targetDraggables = targetZone.getItems()
+          // No sibling under the pointer: append, unless a `hitArea` region
+          // routed the drop here from before the zone's start edge (#126).
+          const atStart =
+            !hasSibling &&
+            this.insertAtStartOfZone(e, targetZoneElement, targetDraggables)
           const newIndex = hasSibling
             ? targetDraggables.indexOf(over)
-            : targetDraggables.length
+            : atStart
+              ? 0
+              : targetDraggables.length
           const oldIndex = Array.from(sourceParent.children).indexOf(
             this.dragElement
           )
@@ -1635,7 +1679,8 @@ export class DragManager implements DragManagerInterface {
           // one exists. With no sibling (related === container) the override
           // has no meaningful side, so we fall through to the natural
           // `insertBefore(item, null)` (≡ appendChild).
-          let insertReference: Node | null = over
+          let insertReference: Node | null =
+            over ?? (atStart ? (targetDraggables[0] ?? null) : null)
           if (hasSibling && moveResult === 1) {
             insertReference = over.nextSibling
           } else if (hasSibling && moveResult === -1) {
@@ -1940,6 +1985,20 @@ export class DragManager implements DragManagerInterface {
       ) {
         return zoneEl
       }
+    }
+
+    // Third pass, lowest priority (#126): a zone can opt into claiming drops
+    // that land anywhere inside a surrounding `hitArea` region but over no
+    // zone/item directly. Each zone's `closest(hitArea)` is its own region
+    // (e.g. the song row around a clip list), so a DOM `contains` test picks
+    // the right zone even with many rows. Skip regions whose group won't
+    // accept this drag so an incompatible region can't shadow a compatible
+    // one; final acceptance is still enforced in `handleControlledMove`.
+    for (const [zoneEl, manager] of dragManagerRegistry) {
+      if (!manager._hitArea) continue
+      if (this.activePointerId !== null && !this.canDropInZone(zoneEl)) continue
+      const region = zoneEl.closest(manager._hitArea)
+      if (region && el && region.contains(el)) return zoneEl
     }
     return null
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -462,6 +462,7 @@ export class Sortable {
       dropBubble: this.options.dropBubble,
       removeCloneOnHide: this.options.removeCloneOnHide,
       emptyInsertThreshold: this.options.emptyInsertThreshold,
+      hitArea: this.options.hitArea,
       preventOnFilter: this.options.preventOnFilter,
       dataIdAttr: this.options.dataIdAttr,
       ghostClass: this.options.ghostClass,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -501,6 +501,18 @@ export interface SortableOptions {
   emptyInsertThreshold?: number
 
   /**
+   * CSS selector for a surrounding region that also accepts drops for this
+   * zone. When a drop lands anywhere inside `zoneEl.closest(hitArea)` but
+   * outside the zone's own rect — and over no other zone/item — it resolves
+   * to this zone and inserts at the nearest end (index 0 when the pointer is
+   * before the zone's start edge, else append). Generalizes
+   * {@link emptyInsertThreshold} to a large, caller-defined region around a
+   * populated list (#126). Fallback only: a pointer directly over a zone or
+   * its items always wins, and group `put`/`pull` rules are still enforced.
+   */
+  hitArea?: string
+
+  /**
    * Call preventDefault when filter is triggered
    * @defaultValue true
    */

--- a/tests/e2e/fixtures/hit-area.html
+++ b/tests/e2e/fixtures/hit-area.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>hitArea Test (#126)</title>
+    <style>
+      body {
+        margin: 20px;
+        font-family: sans-serif;
+      }
+      /* A song row: a wide body area on the left, a content-sized clip list
+         pinned to the far right. Most of the row is NOT a drop zone. */
+      .song {
+        display: flex;
+        align-items: center;
+        width: 600px;
+        margin: 12px 0;
+        border: 1px solid #ccc;
+        background: #fafafa;
+      }
+      .body {
+        flex: 1 1 auto;
+        padding: 16px;
+      }
+      .clips {
+        flex: 0 0 auto;
+        display: flex;
+        gap: 4px;
+        padding: 8px;
+        min-width: 24px;
+        background: #eef;
+      }
+      .clip {
+        padding: 8px 12px;
+        background: #cce;
+        border: 1px solid #99c;
+        cursor: move;
+        white-space: nowrap;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>hitArea Test</h1>
+
+    <div class="song" id="song-a">
+      <div class="body">Song A body — drop clips here</div>
+      <ul class="clips" id="clips-a">
+        <li class="clip" data-id="a1">a1</li>
+        <li class="clip" data-id="a2">a2</li>
+      </ul>
+    </div>
+
+    <div class="song" id="song-b">
+      <div class="body">Song B body — drop clips here</div>
+      <ul class="clips" id="clips-b">
+        <li class="clip" data-id="b1">b1</li>
+      </ul>
+    </div>
+
+    <script type="module">
+      import { Sortable } from '/src/index.js'
+
+      const opts = {
+        group: 'clips',
+        draggable: '.clip',
+        direction: 'horizontal',
+        animation: 0,
+        hitArea: '.song',
+      }
+      new Sortable(document.getElementById('clips-a'), opts)
+      new Sortable(document.getElementById('clips-b'), opts)
+
+      window.resortableLoaded = true
+    </script>
+  </body>
+</html>

--- a/tests/e2e/hit-area.spec.ts
+++ b/tests/e2e/hit-area.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test, Page } from '@playwright/test'
+
+/**
+ * Coverage for #126 — `hitArea` lets a non-empty zone claim drops that land
+ * anywhere inside a surrounding region (`closest('.song')`) but outside the
+ * zone's own rect, inserting at the nearest end.
+ *
+ * The fixture's clip lists sit pinned to the far RIGHT of each 600px song row,
+ * so most of the row is "body" that is NOT a registered drop zone. Dragging a
+ * clip onto the body left of the list must land it at the start; dragging past
+ * the list must append.
+ */
+async function pointerDrag(
+  page: Page,
+  fromSelector: string,
+  toX: number,
+  toY: number
+): Promise<void> {
+  const fromBox = await page.locator(fromSelector).boundingBox()
+  if (!fromBox) throw new Error('missing source box')
+  const fromX = fromBox.x + fromBox.width / 2
+  const fromY = fromBox.y + fromBox.height / 2
+
+  await page.mouse.move(fromX, fromY)
+  await page.mouse.down()
+  await page.mouse.move(fromX, fromY, { steps: 5 })
+  await page.mouse.move(toX, toY, { steps: 10 })
+  await page.mouse.up()
+}
+
+const clipIds = (page: Page, listSel: string) =>
+  page
+    .locator(`${listSel} .clip`)
+    .evaluateAll((els) => els.map((el) => (el as HTMLElement).dataset.id))
+
+test.describe('hitArea (#126)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/tests/e2e/fixtures/hit-area.html')
+    await page.waitForFunction(() => window.resortableLoaded === true)
+  })
+
+  test('drop on the body left of the clip list inserts at the start', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only — touch geometry differs (Mobile Chrome tracked in #48)'
+    )
+
+    const songB = await page.locator('#song-b').boundingBox()
+    if (!songB) throw new Error('no song box')
+    // Aim at the left third of song B's body — well left of its clip list.
+    const targetX = songB.x + songB.width * 0.15
+    const targetY = songB.y + songB.height / 2
+
+    await pointerDrag(page, '#clips-a [data-id="a1"]', targetX, targetY)
+
+    // a1 moved to the FRONT of song B's clip list.
+    expect(await clipIds(page, '#clips-b')).toEqual(['a1', 'b1'])
+    expect(await clipIds(page, '#clips-a')).toEqual(['a2'])
+  })
+
+  test('drop past the clip list appends to the end', async ({
+    page,
+  }, testInfo) => {
+    test.skip(
+      /Mobile/.test(testInfo.project.name),
+      'Desktop-only — touch geometry differs (Mobile Chrome tracked in #48)'
+    )
+
+    const songB = await page.locator('#song-b').boundingBox()
+    if (!songB) throw new Error('no song box')
+    // Aim past the right edge of the clip list (the far right of the row).
+    const targetX = songB.x + songB.width - 4
+    const targetY = songB.y + songB.height / 2
+
+    await pointerDrag(page, '#clips-a [data-id="a1"]', targetX, targetY)
+
+    // a1 appended AFTER song B's existing clip.
+    expect(await clipIds(page, '#clips-b')).toEqual(['b1', 'a1'])
+    expect(await clipIds(page, '#clips-a')).toEqual(['a2'])
+  })
+})

--- a/tests/unit/hit-area.test.ts
+++ b/tests/unit/hit-area.test.ts
@@ -182,4 +182,71 @@ describe('hitArea option (#126)', () => {
     expect(end?.to).toBe(clipsA)
     expect(end?.newIndex).toBe(0)
   })
+
+  it('fails closed on a malformed hitArea selector (no throw, drag reverts)', () => {
+    const { clipsA, clipsB, bodyB } = buildSongs()
+    const opts = {
+      controlled: true,
+      draggable: '.clip',
+      direction: 'horizontal' as const,
+      animation: 0,
+      fallbackTolerance: 0,
+      group: 'clips',
+    }
+    let end: SortableEvent | undefined
+    const srcA = new Sortable(clipsA, {
+      ...opts,
+      hitArea: '.song',
+      onEnd: (e) => (end = e),
+    })
+    // `:::bad:::` throws in `closest()` — the pass must catch and skip it.
+    const srcB = new Sortable(clipsB, { ...opts, hitArea: ':::bad:::' })
+    srcs.push(srcA, srcB)
+
+    document.elementFromPoint = () => bodyB
+    const dragged = clipsA.querySelector<HTMLElement>('.clip')!
+    expect(() => {
+      dragged.dispatchEvent(mkPointer('pointerdown', 10))
+      document.dispatchEvent(mkPointer('pointermove', 10))
+      document.dispatchEvent(mkPointer('pointerup', 10))
+    }).not.toThrow()
+    // clipsB's bad selector is skipped → no resolution → reverts to source.
+    expect(end?.to).toBe(clipsA)
+  })
+
+  it('ignores (0,0) synthetic coords instead of forcing index 0', () => {
+    const { clipsA, clipsB, bodyB } = buildSongs()
+    // Vertical zone whose top edge is BELOW 0. Without the (0,0) coord gate,
+    // `clientY(0) < rect.top(50)` would wrongly route to index 0.
+    clipsB.getBoundingClientRect = () =>
+      ({ ...CLIPS_RECT, top: 50, bottom: 90, y: 50 }) as DOMRect
+    const opts = {
+      controlled: true,
+      draggable: '.clip',
+      direction: 'vertical' as const,
+      animation: 0,
+      fallbackTolerance: 0,
+      group: 'clips',
+      hitArea: '.song',
+    }
+    let end: SortableEvent | undefined
+    const srcA = new Sortable(clipsA, { ...opts, onEnd: (e) => (end = e) })
+    const srcB = new Sortable(clipsB, opts)
+    srcs.push(srcA, srcB)
+
+    // Events at true (0,0) — "no usable coords", must append not prepend.
+    const at00 = (type: string): PointerEvent => {
+      const e = mkPointer(type, 0)
+      Object.defineProperty(e, 'clientY', { value: 0, configurable: true })
+      return e
+    }
+    document.elementFromPoint = () => bodyB
+    const dragged = clipsA.querySelector<HTMLElement>('.clip')!
+    dragged.dispatchEvent(at00('pointerdown'))
+    document.dispatchEvent(at00('pointermove'))
+    document.dispatchEvent(at00('pointerup'))
+
+    expect(end?.to).toBe(clipsB)
+    expect(end?.newIndex).toBe(1)
+  })
 })

--- a/tests/unit/hit-area.test.ts
+++ b/tests/unit/hit-area.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { Sortable } from '../../src/index'
+import type { SortableEvent } from '../../src/types/index'
+
+/**
+ * `hitArea` (#126): a non-empty zone claims drops that land anywhere inside a
+ * surrounding region (`zoneEl.closest(hitArea)`) but over no zone/item, and
+ * inserts at the nearest end.
+ *
+ * Driven through the POINTER pipeline (where `findSortableContainerUnder`
+ * lives) with `document.elementFromPoint` + `getBoundingClientRect` mocked —
+ * the same technique the autoscroll parity suite uses. Real geometry is
+ * covered in e2e.
+ */
+
+const CLIPS_RECT = {
+  left: 100,
+  right: 160,
+  top: 0,
+  bottom: 40,
+  width: 60,
+  height: 40,
+  x: 100,
+  y: 0,
+  toJSON: () => ({}),
+} as DOMRect
+
+function mkPointer(type: string, clientX: number, id = 3): PointerEvent {
+  let e: PointerEvent
+  try {
+    e = new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      pointerId: id,
+      isPrimary: true,
+      button: 0,
+    })
+  } catch {
+    e = new MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    }) as unknown as PointerEvent
+    Object.defineProperties(e, {
+      pointerId: { value: id },
+      isPrimary: { value: true },
+    })
+  }
+  Object.defineProperties(e, {
+    clientX: { value: clientX, configurable: true },
+    clientY: { value: 20, configurable: true },
+  })
+  return e
+}
+
+/**
+ * Two horizontal song rows. Each song's clip list (`ul.clips`) is a zone whose
+ * `hitArea` is the surrounding `.song`. The clip list sits at x∈[100,160]; the
+ * song body (title) is to its left, outside the zone rect.
+ */
+function buildSongs(): {
+  clipsA: HTMLElement
+  clipsB: HTMLElement
+  bodyB: HTMLElement
+} {
+  document.body.innerHTML = ''
+  const make = (id: string): { song: HTMLElement; clips: HTMLElement } => {
+    const song = document.createElement('li')
+    song.className = 'song'
+    const body = document.createElement('span')
+    body.className = 'body'
+    body.textContent = `title ${id}`
+    const clips = document.createElement('ul')
+    clips.className = 'clips'
+    const clip = document.createElement('li')
+    clip.className = 'clip'
+    clip.dataset.id = `${id}1`
+    clip.textContent = `${id}1`
+    clips.appendChild(clip)
+    song.append(body, clips)
+    document.body.appendChild(song)
+    clips.getBoundingClientRect = () => CLIPS_RECT
+    return { song, clips }
+  }
+  const a = make('a')
+  const b = make('b')
+  return {
+    clipsA: a.clips,
+    clipsB: b.clips,
+    bodyB: b.song.querySelector<HTMLElement>('.body')!,
+  }
+}
+
+/** Drag clip a1 out of clipsA, hover over `hoverEl` at x=`clientX`, release. */
+function dragToBody(
+  clipsA: HTMLElement,
+  clipsB: HTMLElement,
+  hoverEl: HTMLElement,
+  clientX: number,
+  group = 'clips'
+): { srcA: Sortable; srcB: Sortable; end?: SortableEvent } {
+  let end: SortableEvent | undefined
+  const opts = {
+    controlled: true,
+    draggable: '.clip',
+    direction: 'horizontal' as const,
+    animation: 0,
+    fallbackTolerance: 0,
+    group,
+    hitArea: '.song',
+  }
+  const srcA = new Sortable(clipsA, { ...opts, onEnd: (e) => (end = e) })
+  const srcB = new Sortable(clipsB, opts)
+
+  document.elementFromPoint = () => hoverEl
+  const dragged = clipsA.querySelector<HTMLElement>('.clip')!
+  dragged.dispatchEvent(mkPointer('pointerdown', clientX))
+  document.dispatchEvent(mkPointer('pointermove', clientX))
+  document.dispatchEvent(mkPointer('pointerup', clientX))
+  return { srcA, srcB, end }
+}
+
+describe('hitArea option (#126)', () => {
+  let srcs: Sortable[] = []
+  const track = <T extends { srcA: Sortable; srcB: Sortable }>(r: T): T => {
+    srcs.push(r.srcA, r.srcB)
+    return r
+  }
+
+  afterEach(() => {
+    srcs.forEach((s) => s.destroy())
+    srcs = []
+    vi.restoreAllMocks()
+    delete (document as unknown as { elementFromPoint?: unknown })
+      .elementFromPoint
+  })
+
+  it('a drop on the song body left of the clip list inserts at index 0', () => {
+    const { clipsA, clipsB, bodyB } = buildSongs()
+    // clientX=10 is left of clipsB (left=100) → nearest end is the start.
+    const { end } = track(dragToBody(clipsA, clipsB, bodyB, 10))
+    expect(end?.to).toBe(clipsB)
+    expect(end?.newIndex).toBe(0)
+  })
+
+  it('a drop past the clip list appends (nearest end = end)', () => {
+    const { clipsA, clipsB, bodyB } = buildSongs()
+    // clientX=500 is right of clipsB → append after its 1 existing clip.
+    const { end } = track(dragToBody(clipsA, clipsB, bodyB, 500))
+    expect(end?.to).toBe(clipsB)
+    expect(end?.newIndex).toBe(1)
+  })
+
+  it('does not claim the drop when group rules reject it (no hitArea resolve)', () => {
+    const { clipsA, clipsB, bodyB } = buildSongs()
+    // Give clipsB an incompatible group so canDropInZone fails: the hitArea
+    // pass skips it and the drag reverts to the source list unchanged.
+    const opts = {
+      controlled: true,
+      draggable: '.clip',
+      direction: 'horizontal' as const,
+      animation: 0,
+      fallbackTolerance: 0,
+      hitArea: '.song',
+    }
+    let end: SortableEvent | undefined
+    const srcA = new Sortable(clipsA, {
+      ...opts,
+      group: 'clips',
+      onEnd: (e) => (end = e),
+    })
+    const srcB = new Sortable(clipsB, { ...opts, group: 'other' })
+    srcs.push(srcA, srcB)
+
+    document.elementFromPoint = () => bodyB
+    const dragged = clipsA.querySelector<HTMLElement>('.clip')!
+    dragged.dispatchEvent(mkPointer('pointerdown', 10))
+    document.dispatchEvent(mkPointer('pointermove', 10))
+    document.dispatchEvent(mkPointer('pointerup', 10))
+
+    // Rejected target → stays in source list (to === from, index unchanged).
+    expect(end?.to).toBe(clipsA)
+    expect(end?.newIndex).toBe(0)
+  })
+})


### PR DESCRIPTION
Closes #126.

## What

Adds a per-zone `hitArea` option (CSS selector). A **non-empty** sortable with `hitArea: 'X'` claims drops that land anywhere inside its `closest('X')` region but **outside the zone's own rect** and over no other zone/item — inserting the dragged item at the **nearest end** (index `0` when the pointer is before the zone's start edge, else append), honoring `direction`.

Generalizes the existing `emptyInsertThreshold` "close enough to count" behavior to a large, caller-defined region around a populated list. Motivating case: a clip list pinned to the right of a wide song row, where users drop clips onto the song body (not a registered zone).

```ts
useSortable({ group: 'clips', draggable: '.clip', hitArea: '.song' })
```

## How

- **Resolution:** new lowest-priority pass in `findSortableContainerUnder` (after the ancestor walk and the empty-zone `emptyInsertThreshold` scan). Uses DOM `region.contains(el)` — not a rect test — so arbitrarily shaped / multi-row regions resolve to the right zone. Group `put`/`pull` acceptance is enforced in the pass (incompatible regions are skipped so they can't shadow a compatible one) and again downstream in `handleControlledMove`.
- **Nearest-end index:** `insertAtStartOfZone` helper, wired into both the controlled and uncontrolled zone-entry branches. **No side-channel flag** — nearest-end only diverges from plain append when the pointer is *outside* the zone rect, which is exactly the hitArea case (empty zones make start==append; the ancestor walk always resolves with the pointer inside). So the geometry self-selects the case.
- **Fallback only:** a pointer directly over a zone or its items wins unchanged. Produces a normal cross-zone `SortIntent` (`to`/`toId`/`newIndexes`), so the React adapter needs no changes.

## Non-regression

- No behavior change when the pointer is over a zone or its items.
- Group acceptance still enforced for hitArea-resolved targets.
- Works for `horizontal` and `vertical` zones (axis via `detectHorizontalLayout`).

## Tests

- **Unit** (`tests/unit/hit-area.test.ts`): pointer-pipeline resolution, index-0 vs append, and group-reject — via mocked `elementFromPoint`/rects (the repo's existing technique).
- **e2e** (`tests/e2e/hit-area.spec.ts` + fixture): real-geometry drops onto a non-empty list's body → begin/end placement.
- Full unit suite green (297); lint + type-check clean.

Branched off `main` (independent of the autoscroll fix in #125).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDjeiaqVvJquyyx6M6igQG

<!-- claude-session:56373524-a35b-49d6-9859-b52e9aa34d18 -->
🔖 **Claude agent:** resortable-e1  
session id: `56373524-a35b-49d6-9859-b52e9aa34d18`