### PR TITLE
fix(core): give the pointer pipeline event/behavior parity with HTML5 (#121)

### DIFF
--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -472,26 +472,42 @@ export class DragManager implements DragManagerInterface {
   }
 
   /**
-   * Calculate if swap should occur based on overlap (only if threshold is set)
+   * Calculate if swap should occur based on overlap (only if threshold is set).
+   *
+   * `visible` is the item list used to MEASURE the layout axis. Trusting the
+   * `direction` option alone doesn't work: it defaults to `'vertical'` and is
+   * never auto-detected, so on a row or grid every item shares the same
+   * top/bottom and vertical overlap is always ~1.0 — which makes
+   * `swapThreshold` a no-op and, with `invertSwap`, blocks every reorder for
+   * the whole drag. `detectHorizontalLayout` measures the real axis and falls
+   * back to the `direction` option only when it can't (zero-size rects).
+   *
+   * Returns `true` (fail OPEN) when the target has no measurable extent along
+   * the axis — a threshold that can't be evaluated must not silently behave
+   * like a threshold that wasn't met, which would freeze the drag with no
+   * signal. Reachable with unlaid-out or `display: none` elements, and in
+   * jsdom, where every rect is zero-size.
    */
   private shouldSwap(
     dragRect: DOMRect,
     targetRect: DOMRect,
-    _dragDirection: 'forward' | 'backward'
+    visible: HTMLElement[]
   ): boolean {
     // If no threshold is set, always allow swap (legacy behavior)
     if (this.swapThreshold === undefined) {
       return true
     }
 
-    // Calculate overlap percentage based on direction
+    // Calculate overlap percentage along the measured layout axis
     let overlap: number
-    if (this.direction === 'vertical') {
+    if (!this.detectHorizontalLayout(visible)) {
+      if (targetRect.height <= 0) return true
       const overlapHeight =
         Math.min(dragRect.bottom, targetRect.bottom) -
         Math.max(dragRect.top, targetRect.top)
       overlap = Math.max(0, overlapHeight) / targetRect.height
     } else {
+      if (targetRect.width <= 0) return true
       const overlapWidth =
         Math.min(dragRect.right, targetRect.right) -
         Math.max(dragRect.left, targetRect.left)
@@ -532,11 +548,9 @@ export class DragManager implements DragManagerInterface {
    * and pointer move). Only the placeholder travels; consumer-owned nodes
    * are never structurally moved. `onMove` cancellation/override semantics
    * are preserved (dispatched on the SOURCE sortable's options, legacy
-   * parity). Per-pipeline differences:
+   * parity). Both pipelines emit the same sort/update/change set (#121).
+   * The one remaining per-pipeline difference:
    *
-   * - `emitHtml5Events` — the HTML5 pipeline emits sort/update/change on
-   *   same-list reorders; the pointer pipeline only emits update (parity
-   *   with the uncontrolled paths).
    * - `commitPending`  — the pointer pipeline commits pending live
    *   (pointerup IS the drop); the HTML5 pipeline commits only in onDrop
    *   so a cancelled drag (dragend without drop) reports a no-op.
@@ -630,7 +644,7 @@ export class DragManager implements DragManagerInterface {
     over: HTMLElement | null,
     targetManager: DragManager,
     activeDrag: ActiveDrag,
-    opts: { emitHtml5Events: boolean; commitPending: boolean }
+    opts: { commitPending: boolean }
   ): void {
     const sourceManager = activeDrag.fromDragManager as DragManager
     const placeholder = sourceManager.ghostManager.getPlaceholderElement()
@@ -746,13 +760,7 @@ export class DragManager implements DragManagerInterface {
       placeholder,
       visible
     )
-    if (
-      !this.shouldSwap(
-        movingRect,
-        overRect,
-        naturalAfter ? 'forward' : 'backward'
-      )
-    ) {
+    if (!this.shouldSwap(movingRect, overRect, visible)) {
       return
     }
 
@@ -795,17 +803,11 @@ export class DragManager implements DragManagerInterface {
       oldIndex: oldIdx,
       newIndex,
     }
-    const isSourceList = activeDrag.fromZone === targetZoneElement
-    if (opts.emitHtml5Events) {
-      // HTML5-pipeline parity: sort always, update/change on the source list.
-      targetManager.events.emit('sort', evt)
-      if (isSourceList) {
-        targetManager.events.emit('update', evt)
-        targetManager.events.emit('change', evt)
-      }
-    } else if (isSourceList) {
-      // Pointer-pipeline parity: update only.
+    // Both pipelines: sort always, update/change on the source list (#121).
+    targetManager.events.emit('sort', evt)
+    if (activeDrag.fromZone === targetZoneElement) {
       targetManager.events.emit('update', evt)
+      targetManager.events.emit('change', evt)
     }
   }
 
@@ -853,10 +855,9 @@ export class DragManager implements DragManagerInterface {
 
     if (this.controlled) {
       // Controlled mode: only the placeholder travels. Mid-drag events fire
-      // (HTML5 parity: sort/update/change) but pending is only committed in
-      // onDrop — a dragend without a drop must not commit intent.
+      // (sort/update/change) but pending is only committed in onDrop — a
+      // dragend without a drop must not commit intent.
       this.handleControlledMove(e, over, this, activeDrag, {
-        emitHtml5Events: true,
         commitPending: false,
       })
       return
@@ -977,12 +978,31 @@ export class DragManager implements DragManagerInterface {
     const dragIndex = this.zone.getIndex(dragItem)
     if (overIndex === dragIndex) return
 
-    // Check swap threshold if configured
+    // Check swap threshold if configured.
+    //
+    // KNOWN GAP — `swapThreshold` does not merely misbehave here, it disables
+    // same-zone sorting outright. Within a zone `dragItem` keeps its original
+    // slot for the whole drag (the reorder is committed on drop — see the
+    // commented-out `zone.move` below), so against a sibling `over` the
+    // overlap is 0: adjacent rects touch, non-adjacent ones clamp to 0. Every
+    // `swapThreshold > 0` therefore fails this gate on every dragover, the
+    // placeholder never moves, and sort/update/change never fire. `invertSwap`
+    // has the mirror bug — `0 < threshold` is always true, so the threshold is
+    // bypassed entirely. (`dragItem` IS moved on cross-zone entry above, but
+    // it lands as a parked sibling in the new zone, so the overlap is still 0.)
+    //
+    // The pointer pipeline had the same bug and fixed it by measuring the
+    // cursor-following ghost (#121). That is NOT available here: `onDragStart`
+    // sets the ghost to `display: none` because the browser draws its own drag
+    // image, and `updateGhostPosition` is only ever called from the pointer
+    // path — so its rect is both zero-size and frozen. The placeholder is no
+    // use either; it is only repositioned AFTER this gate passes. A real fix
+    // needs a rect synthesized from the DragEvent's clientX/clientY. Do NOT
+    // "restore parity" by copying the pointer pipeline's ghost lookup here.
     const dragRect = dragItem.getBoundingClientRect()
     const targetRect = over.getBoundingClientRect()
-    const dragDirection = dragIndex < overIndex ? 'forward' : 'backward'
 
-    if (!this.shouldSwap(dragRect, targetRect, dragDirection)) {
+    if (!this.shouldSwap(dragRect, targetRect, this.zone.getItems())) {
       return // Don't swap if threshold not met
     }
 
@@ -1586,10 +1606,9 @@ export class DragManager implements DragManagerInterface {
     if (this.controlled) {
       const targetManager = this.findDragManagerForZone(targetZoneElement)
       if (targetManager) {
-        // Pointer parity: only `update` fires mid-drag (gated on the source
-        // list); pending updates live because pointerup IS the commit.
+        // Same mid-drag event set as HTML5 (#121); pending updates live
+        // because pointerup IS the commit.
         this.handleControlledMove(e, over, targetManager, activeDrag, {
-          emitHtml5Events: false,
           commitPending: true,
         })
       }
@@ -1762,10 +1781,47 @@ export class DragManager implements DragManagerInterface {
           overIndex !== -1 &&
           currentIndex !== overIndex
         ) {
+          const naturalAfter = currentIndex < overIndex
+          const draggedRect = movingElement.getBoundingClientRect()
+          const targetRect = over.getBoundingClientRect()
+
+          // Swap-threshold gate — `swapThreshold` / `invertSwap` used to be
+          // ignored entirely on this path, so touch and fallback mode
+          // reordered on any hover (#121).
+          //
+          // Measure the GHOST, not `movingElement`: nothing moves the real
+          // item until a swap actually commits, so its rect stays parked in
+          // its original slot for the whole hover. Adjacent items touch with
+          // zero gap, so `movingElement` vs `over` overlaps by exactly 0 no
+          // matter how far the cursor travels — any threshold > 0 would
+          // freeze the drag outright, and `invertSwap` would fire
+          // unconditionally. The cursor-following ghost is the moving visual,
+          // which is why `handleControlledMove` measures it too.
+          //
+          // No ghost means nothing tracks the cursor, so there is no honest
+          // rect to gate on: skip the gate rather than substitute
+          // `movingElement`, whose rect is exactly the "no overlap" value
+          // described above and would silently freeze the drag. Failing open
+          // degrades to pre-#121 behavior (reorder on hover) instead.
+          //
+          // The threshold config is read from the manager owning the zone
+          // being reordered — not always `this` — matching the `sort: false`
+          // check above.
+          const ghostForSwap = this.ghostManager.getGhostElement()
+          if (
+            ghostForSwap &&
+            !(targetDragManager ?? this).shouldSwap(
+              ghostForSwap.getBoundingClientRect(),
+              targetRect,
+              currentItems
+            )
+          ) {
+            return
+          }
+
           // Dispatch move BEFORE mutating the DOM so cancellation is a true
           // no-op for this tick (#33). Pointer pipeline uses the live
           // `PointerEvent` as `originalEvent`.
-          const naturalAfter = currentIndex < overIndex
           const moveEvent: MoveEvent = {
             item: this.dragElement,
             items:
@@ -1778,8 +1834,8 @@ export class DragManager implements DragManagerInterface {
             newIndex: overIndex,
             related: over,
             willInsertAfter: naturalAfter,
-            draggedRect: movingElement.getBoundingClientRect(),
-            targetRect: over.getBoundingClientRect(),
+            draggedRect,
+            targetRect,
           }
           const moveResult = this.dispatchMove(moveEvent, e)
           if (moveResult === false) {
@@ -1794,6 +1850,12 @@ export class DragManager implements DragManagerInterface {
           else if (moveResult === -1 && naturalAfter)
             targetIndex = overIndex - 1
 
+          // An `onMove` override can collapse the target back onto the
+          // current index, leaving nothing to do. `handleControlledMove`
+          // guards the same case — without this, a no-op move would still
+          // emit a full sort/update/change round.
+          if (targetIndex === currentIndex) return
+
           // Use the DropZone's move method to get animations
           if (this.draggedItems.length > 1) {
             targetZone.moveMultiple(this.draggedItems, targetIndex)
@@ -1801,19 +1863,40 @@ export class DragManager implements DragManagerInterface {
             targetZone.move(movingElement, targetIndex)
           }
 
-          // Only emit update if it's within the original zone
-          if (activeDrag.fromZone === targetZoneElement) {
-            this.events.emit('update', {
-              item: this.dragElement,
-              items:
-                this.draggedItems.length > 0
-                  ? this.draggedItems
-                  : [this.dragElement],
-              from: targetZoneElement,
-              to: targetZoneElement,
-              oldIndex: this.startIndex,
-              newIndex: targetIndex,
-            })
+          const isSourceList = activeDrag.fromZone === targetZoneElement
+
+          // HTML5-pipeline parity (#121): `sort` fires on every reorder,
+          // `update` + `change` only when reordering the list the drag
+          // started in.
+          //
+          // `oldIndex` must index the list named by `from`/`to`. Once the
+          // item has been dragged into another zone, `startIndex` is an index
+          // into the ORIGINAL zone and is meaningless for a reorder happening
+          // inside the destination — use the live index there. (Same-zone
+          // keeps `startIndex`: the item never left, so it matches what the
+          // HTML5 path reports.)
+          const evt = {
+            item: this.dragElement,
+            items:
+              this.draggedItems.length > 0
+                ? this.draggedItems
+                : [this.dragElement],
+            from: targetZoneElement,
+            to: targetZoneElement,
+            oldIndex: isSourceList ? this.startIndex : currentIndex,
+            newIndex: targetIndex,
+          }
+
+          // Each emit gets its own copy — the payload is handed to consumer
+          // code, and a handler that mutates it must not corrupt the events
+          // that follow. `sort` goes to the manager owning the reordered
+          // zone (the HTML5 path gets that for free from its per-zone
+          // `dragover` listener); `update`/`change` stay on the drag owner,
+          // which is where they have always been emitted.
+          ;(targetDragManager ?? this).events.emit('sort', { ...evt })
+          if (isSourceList) {
+            this.events.emit('update', { ...evt })
+            this.events.emit('change', { ...evt })
           }
         }
       }

--- a/tests/e2e/advanced-events.spec.ts
+++ b/tests/e2e/advanced-events.spec.ts
@@ -85,24 +85,7 @@ test.describe('Advanced Event Callbacks', () => {
     await page.mouse.up()
   })
 
-  // Not a test-timing issue: the pointer pipeline's same-zone reorder branch
-  // (DragManager.onPointerMove, ~line 1635) only emits `'update'` — `'sort'`
-  // and `'change'` are only emitted by the HTML5-native `onDragOver` handler
-  // (DragManager.ts:970 and :991). No amount of stepped page.mouse.move
-  // driving will make onSort fire through this pipeline; it's a real gap
-  // between the two drag pipelines, not exercised by this rewrite's mandate
-  // (pure test-infra). tests/e2e/fallback-mode.spec.ts's pointer-driven
-  // `onSort` wiring hits the same gap — see its comment around line 707
-  // ("we don't lock down the exact set"), which deliberately avoids
-  // asserting `sort` fires. Confirmed via direct instrumentation of
-  // DragManager.onPointerMove: with the correct `Sortable.get()` teardown
-  // (see below), `dispatchMove` and `onMove` both fire correctly, but
-  // `'sort'` is never emitted for this same-zone pointer drag. Tracked
-  // under #73 as a follow-up (DragManager pointer/HTML5 parity), not fixed
-  // here.
-  test.skip('should fire onSort event when sorting changes', async ({
-    page,
-  }) => {
+  test('should fire onSort event when sorting changes', async ({ page }) => {
     await page.evaluate(() => {
       const basicList = document.getElementById('basic-list')
       if (!basicList || !window.Sortable) return
@@ -141,13 +124,7 @@ test.describe('Advanced Event Callbacks', () => {
     expect(eventLog.some((e: any) => e.type === 'sort')).toBeTruthy()
   })
 
-  // Same root cause as onSort above: DragManager.onPointerMove's same-zone
-  // branch only emits `'update'` (DragManager.ts:1706) — `'change'` is only
-  // emitted by the HTML5-native `onDragOver` handler (DragManager.ts:991).
-  // The pointer pipeline structurally never fires `'change'`; this isn't
-  // fixable by adjusting how the mouse is driven. Tracked under #73 as a
-  // follow-up (DragManager pointer/HTML5 parity), not fixed here.
-  test.skip('should fire onChange event when order changes within same list', async ({
+  test('should fire onChange event when order changes within same list', async ({
     page,
   }) => {
     await page.evaluate(() => {

--- a/tests/e2e/autoscroll-drop-target.spec.ts
+++ b/tests/e2e/autoscroll-drop-target.spec.ts
@@ -94,13 +94,18 @@ test.describe('autoscroll keeps the controlled drop target fresh (#124)', () => 
 
     // Hold the pointer still and let autoscroll drive the list to the bottom.
     // No further pointermove fires — this is the stationary-pointer scenario.
+    //
+    // Generous timeout: every `scroll` event replays a full `onPointerMove`
+    // (hit test + placeholder move), so ~50 autoscroll frames are expensive.
+    // WebKit on hosted Windows needs 7-9s where Chromium needs <2s. Throttling
+    // that replay to one per animation frame is tracked in #134.
     await page.waitForFunction(
       () => {
         const ul = (window as unknown as AsWindow).__asList
         return !!ul && ul.scrollTop + ul.clientHeight >= ul.scrollHeight - 2
       },
       undefined,
-      { timeout: 5000 }
+      { timeout: 20000 }
     )
 
     await page.mouse.up()

--- a/tests/e2e/fallback-mode.spec.ts
+++ b/tests/e2e/fallback-mode.spec.ts
@@ -704,14 +704,16 @@ test.describe('fallback cross-option sweep (#29 PR4)', () => {
     expect(finalOrder).toContain('pr4-1')
     expect(finalOrder).toHaveLength(4)
 
-    // Lifecycle events fired in order. We don't lock down the exact set —
-    // animation timing and pointer pipeline both vary across runs — but at
-    // minimum `choose` + `start` must precede `end`.
+    // Lifecycle events fired in order. `choose` + `start` + `sort` must all
+    // precede `end` — `sort` fires on every same-zone reorder through the
+    // pointer pipeline as of #121, and the drag above (asserted via
+    // `finalOrder` above) is a genuine reorder, so it's no longer loose here.
     const finalEvents = await page.evaluate(() =>
       (window as unknown as { __pr4Events: string[] }).__pr4Events.slice()
     )
     expect(finalEvents).toContain('choose')
     expect(finalEvents).toContain('start')
+    expect(finalEvents).toContain('sort')
     expect(finalEvents).toContain('end')
     expect(finalEvents.indexOf('choose')).toBeLessThan(
       finalEvents.indexOf('end')
@@ -719,5 +721,6 @@ test.describe('fallback cross-option sweep (#29 PR4)', () => {
     expect(finalEvents.indexOf('start')).toBeLessThan(
       finalEvents.indexOf('end')
     )
+    expect(finalEvents.indexOf('sort')).toBeLessThan(finalEvents.indexOf('end'))
   })
 })

--- a/tests/e2e/swap-behavior.spec.ts
+++ b/tests/e2e/swap-behavior.spec.ts
@@ -2,31 +2,32 @@ import { test, expect, Page } from '@playwright/test'
 
 /**
  * Coverage for `swapThreshold` / `invertSwap` / `invertedSwapThreshold` /
- * `direction` (#77). Previously skipped: the inline fixtures built plain
- * `document.createElement` markup with no explicit sizing, so
- * `getBoundingClientRect()` overlap math (the whole point of these options)
- * was unpredictable.
+ * `direction` (#77). The inline fixtures build `position: absolute`
+ * markup with explicit item width/height (mirrors `fallback-mode.spec.ts`)
+ * so every rect is known in advance and overlap fractions are computable
+ * exactly.
  *
- * Two things had to be fixed, not just fixture CSS:
+ * **Two pipelines reach `shouldSwap()`, historically via one entry point
+ * each; now the pointer path has two.** Before #121, the *uncontrolled*
+ * pointer path's same-zone branch reordered immediately on
+ * `over !== movingElement` — it never consulted `swapThreshold` at all —
+ * so `controlled: true` (routing through `handleControlledMove`, the same
+ * gate the native HTML5 `dragover` handler uses) was the only way to
+ * exercise the threshold gate via `page.mouse` (native HTML5
+ * `dragstart`/`dragover` can't be triggered by Playwright's synthetic mouse
+ * input either — same constraint documented in `on-move.spec.ts`). The
+ * fixtures below still use `controlled: true` and still read the
+ * placeholder's position (`data-resortable-placeholder`, same signal
+ * `controlled-pointer.spec.ts` uses) instead of real DOM item order, since
+ * controlled mode never structurally moves the real items mid-drag — that
+ * coverage remains valid on its own terms and stays as-is.
  *
- * 1. **Geometry** — mirrors `fallback-mode.spec.ts`: `position: absolute`
- *    fixtures with explicit item width/height so every rect is known in
- *    advance and overlap fractions are computable exactly.
- *
- * 2. **Which pipeline `shouldSwap()` is even wired into.** `DragManager`
- *    has exactly two call sites for the threshold gate: the native HTML5
- *    `dragover` handler, and `handleControlledMove` (shared by both
- *    pipelines when `controlled: true`). The *uncontrolled* pointer path
- *    that `page.mouse` normally drives (see `on-move.spec.ts`) reorders
- *    immediately on `over !== movingElement` — it never consults
- *    `swapThreshold` at all. Native HTML5 `dragstart`/`dragover` can't be
- *    triggered by Playwright's synthetic mouse input here either (same
- *    constraint documented in `on-move.spec.ts`). So `controlled: true` is
- *    the only way to exercise the threshold gate via `page.mouse` — the
- *    fixtures below all use it, and assertions read the placeholder's
- *    position (`data-resortable-placeholder`, same signal
- *    `controlled-pointer.spec.ts` uses) instead of real DOM item order,
- *    since controlled mode never structurally moves the real items mid-drag.
+ * #121 wired `shouldSwap()` into the uncontrolled path too, so as of this
+ * PR `controlled: true` is no longer required to reach the gate — see the
+ * 'uncontrolled pointer pipeline (#121)' describe block below, which drives
+ * the same options through plain `page.mouse` with no `controlled` option
+ * set and asserts real DOM reordering directly (see the comment on that
+ * block for why the gate measures the ghost's rect, not the parked item's).
  */
 
 /**
@@ -87,15 +88,16 @@ async function childLabels(page: Page, containerId: string): Promise<string[]> {
   }, containerId)
 }
 
+/** Shared by both describe blocks below. */
+function skipMobile(testInfo: { project: { name: string } }): boolean {
+  return /Mobile/.test(testInfo.project.name)
+}
+
 test.describe('Swap Behavior Options (#77)', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/playground.html')
     await page.waitForFunction(() => window.resortableLoaded === true)
   })
-
-  function skipMobile(testInfo: { project: { name: string } }): boolean {
-    return /Mobile/.test(testInfo.project.name)
-  }
 
   test('should respect swapThreshold option', async ({ page }, testInfo) => {
     test.skip(
@@ -460,6 +462,199 @@ test.describe('Swap Behavior Options (#77)', () => {
       'ivt-2',
       'PH',
       'ivt-3',
+      'GHOST',
+    ])
+
+    await page.mouse.up()
+  })
+})
+
+/**
+ * Uncontrolled pointer pipeline coverage for #121: `shouldSwap()` is now
+ * reachable from `page.mouse` with no `controlled` option set (previously
+ * only `controlled: true` reached it — see the file header). Unlike the
+ * controlled-mode fixtures above, the dragged item is never hidden or
+ * replaced by a placeholder here — it's the real DOM node, so assertions
+ * read real item order via `childLabels()` (no `'PH'` ever appears).
+ *
+ * The gate is fed the GHOST's rect, not `movingElement`'s: nothing moves
+ * the real dragged item until a swap actually commits, so its rect stays
+ * parked in its original slot for the whole hover — measuring it would make
+ * overlap compute to 0 no matter how far the cursor has traveled into the
+ * target (any `swapThreshold > 0` would freeze the drag outright, and
+ * `invertSwap` would fire unconditionally, since 0 overlap is always below
+ * any positive threshold — this was caught by an earlier `test.fail()` pin
+ * on these two cases before the ghost-rect fix landed). The cursor-following
+ * ghost is the actual moving visual, which is why `handleControlledMove`
+ * measures it too (`sourceManager.ghostManager.getGhostElement() ??
+ * placeholder`, DragManager.ts:737-739) — the uncontrolled branch now does
+ * the same (DragManager.ts, `onPointerMove`'s same-zone branch).
+ */
+test.describe('Swap Behavior Options (#77) — uncontrolled pointer pipeline (#121)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/playground.html')
+    await page.waitForFunction(() => window.resortableLoaded === true)
+  })
+
+  test('should respect swapThreshold option', async ({ page }, testInfo) => {
+    test.skip(
+      skipMobile(testInfo),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    const LIST = '#swap-threshold-list-uncontrolled'
+    const ITEM_HEIGHT = 60
+
+    await page.evaluate(() => {
+      document.getElementById('swap-threshold-list-uncontrolled')?.remove()
+      const container = document.createElement('div')
+      container.id = 'swap-threshold-list-uncontrolled'
+      container.style.cssText =
+        'position:absolute;top:40px;left:40px;width:220px;background:#eef'
+      container.innerHTML = `
+        <div class="sortable-item" data-id="st-1" style="width:220px;height:60px;background:#ccc;">Item 1</div>
+        <div class="sortable-item" data-id="st-2" style="width:220px;height:60px;background:#ddd;">Item 2</div>
+        <div class="sortable-item" data-id="st-3" style="width:220px;height:60px;background:#ccc;">Item 3</div>
+        <div class="sortable-item" data-id="st-4" style="width:220px;height:60px;background:#ddd;">Item 4</div>
+      `
+      document.body.appendChild(container)
+
+      interface WindowWithSortable extends Window {
+        Sortable?: typeof import('../../src/index.js').Sortable
+      }
+      const win = window as WindowWithSortable
+      const Sortable = win.Sortable
+      if (!Sortable) throw new Error('Sortable not loaded on window')
+      new Sortable(container, {
+        swapThreshold: 0.5,
+        animation: 0,
+      })
+    })
+
+    const item1Box = await page
+      .locator(`${LIST} [data-id="st-1"]`)
+      .boundingBox()
+    const item2Box = await page
+      .locator(`${LIST} [data-id="st-2"]`)
+      .boundingBox()
+    if (!item1Box || !item2Box) throw new Error('missing item boxes')
+
+    // Same GRAB_OFFSET / overlap math as the controlled-mode
+    // swapThreshold test above — see {@link overlapY}.
+    const GRAB_OFFSET = 15
+    const grabX = item1Box.x + item1Box.width / 2
+    const grabY = item1Box.y + GRAB_OFFSET
+
+    await page.mouse.move(grabX, grabY)
+    await page.mouse.down()
+
+    // 30% overlap — below the 0.5 threshold, must NOT swap.
+    await page.mouse.move(
+      grabX,
+      overlapY(item2Box.y, ITEM_HEIGHT, 0.3, GRAB_OFFSET),
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-threshold-list-uncontrolled')).toEqual(
+      ['st-1', 'st-2', 'st-3', 'st-4', 'GHOST']
+    )
+
+    // 60% overlap — above the 0.5 threshold, must swap.
+    await page.mouse.move(
+      grabX,
+      overlapY(item2Box.y, ITEM_HEIGHT, 0.6, GRAB_OFFSET),
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-threshold-list-uncontrolled')).toEqual(
+      ['st-2', 'st-1', 'st-3', 'st-4', 'GHOST']
+    )
+
+    await page.mouse.up()
+  })
+
+  test('should handle invertSwap option', async ({ page }, testInfo) => {
+    test.skip(
+      skipMobile(testInfo),
+      'Desktop-only — touch emulation differs (Mobile Chrome tracked in #48)'
+    )
+
+    const LIST = '#swap-invert-list-uncontrolled'
+    const ITEM_HEIGHT = 60
+
+    await page.evaluate(() => {
+      document.getElementById('swap-invert-list-uncontrolled')?.remove()
+      const container = document.createElement('div')
+      container.id = 'swap-invert-list-uncontrolled'
+      container.style.cssText =
+        'position:absolute;top:40px;left:40px;width:220px;background:#efe'
+      container.innerHTML = `
+        <div class="sortable-item" data-id="iv-a" style="width:220px;height:60px;background:#cdc;">Item A</div>
+        <div class="sortable-item" data-id="iv-b" style="width:220px;height:60px;background:#dcd;">Item B</div>
+        <div class="sortable-item" data-id="iv-c" style="width:220px;height:60px;background:#cdc;">Item C</div>
+      `
+      document.body.appendChild(container)
+
+      interface WindowWithSortable extends Window {
+        Sortable?: typeof import('../../src/index.js').Sortable
+      }
+      const win = window as WindowWithSortable
+      const Sortable = win.Sortable
+      if (!Sortable) throw new Error('Sortable not loaded on window')
+      new Sortable(container, {
+        invertSwap: true,
+        swapThreshold: 0.5,
+        animation: 0,
+      })
+    })
+
+    const itemABox = await page
+      .locator(`${LIST} [data-id="iv-a"]`)
+      .boundingBox()
+    const itemBBox = await page
+      .locator(`${LIST} [data-id="iv-b"]`)
+      .boundingBox()
+    if (!itemABox || !itemBBox) throw new Error('missing item boxes')
+
+    // Same GRAB_OFFSET / overlap math as the controlled-mode invertSwap
+    // test above — see {@link overlapY}.
+    const GRAB_OFFSET = 5
+    const grabX = itemABox.x + itemABox.width / 2
+    const grabY = itemABox.y + GRAB_OFFSET
+
+    await page.mouse.move(grabX, grabY)
+    await page.mouse.down()
+
+    // 80% overlap — inverted rule swaps only when overlap < threshold, so
+    // a LARGE overlap must NOT swap.
+    await page.mouse.move(
+      grabX,
+      overlapY(itemBBox.y, ITEM_HEIGHT, 0.8, GRAB_OFFSET),
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-invert-list-uncontrolled')).toEqual([
+      'iv-a',
+      'iv-b',
+      'iv-c',
+      'GHOST',
+    ])
+
+    // 20% overlap — below the 0.5 threshold, inverted rule swaps.
+    await page.mouse.move(
+      grabX,
+      overlapY(itemBBox.y, ITEM_HEIGHT, 0.2, GRAB_OFFSET),
+      {
+        steps: 1,
+      }
+    )
+    expect(await childLabels(page, 'swap-invert-list-uncontrolled')).toEqual([
+      'iv-b',
+      'iv-a',
+      'iv-c',
       'GHOST',
     ])
 

--- a/tests/unit/pointer-html5-parity.spec.ts
+++ b/tests/unit/pointer-html5-parity.spec.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { Sortable } from '../../src/index'
+
+/**
+ * Unit coverage for #121 — the pointer/PointerEvent drag pipeline had
+ * drifted out of parity with the HTML5-native pipeline in two ways:
+ *
+ * 1. Uncontrolled same-zone reorder only emitted `update`. It now emits
+ *    `sort` on every reorder, plus `update` + `change` when the reorder
+ *    stays within the drag's source zone — matching the HTML5 `dragover`
+ *    handler.
+ * 2. The uncontrolled pipeline never consulted `swapThreshold` /
+ *    `invertSwap` — it reordered on any hover. It now runs the same
+ *    `shouldSwap` overlap gate the HTML5 `dragover` handler uses.
+ *
+ * Controlled mode's `handleControlledMove` also lost the `emitHtml5Events`
+ * flag that used to make controlled-pointer emit `update` only while
+ * controlled-HTML5 emitted the full `sort`/`update`/`change` set; both
+ * pipelines now emit the same set unconditionally.
+ *
+ * Driven through the POINTER pipeline with `document.elementFromPoint`
+ * stubbed to hit-test a fixed target element — same technique as
+ * `hit-area.test.ts` and the autoscroll suite in `controlled-parity.spec.ts`.
+ * `swapThreshold`'s overlap math additionally needs real
+ * `getBoundingClientRect` rects, stubbed directly on the dragged/target
+ * elements (jsdom's own layout always reports zero-size boxes).
+ */
+
+function makeList(count = 4): HTMLElement {
+  const ul = document.createElement('ul')
+  for (let i = 0; i < count; i++) {
+    const li = document.createElement('li')
+    li.className = 'item'
+    li.dataset.id = `it-${i}`
+    li.textContent = `Item ${i}`
+    ul.appendChild(li)
+  }
+  document.body.appendChild(ul)
+  return ul
+}
+
+// jsdom lacks the PointerEvent constructor in some CI configurations — fall
+// back to a plain MouseEvent cast, same pattern as controlled-parity.spec.ts.
+function mkPointer(type: string, pointerId = 1): PointerEvent {
+  try {
+    return new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      pointerId,
+      isPrimary: true,
+      button: 0,
+    })
+  } catch {
+    const ev = new MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+    }) as unknown as PointerEvent
+    // MouseEvent's own props are getter-only — define, don't assign.
+    Object.defineProperties(ev, {
+      pointerId: { value: pointerId },
+      isPrimary: { value: true },
+    })
+    return ev
+  }
+}
+
+function rect(top: number, bottom: number): DOMRect {
+  return {
+    top,
+    bottom,
+    left: 0,
+    right: 100,
+    width: 100,
+    height: bottom - top,
+    x: 0,
+    y: top,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+// A 100x60 box in a row — every item shares the same top/bottom, which is
+// what makes the layout horizontal and what the vertical-axis math misreads.
+function hRect(left: number): DOMRect {
+  return {
+    top: 0,
+    bottom: 60,
+    left,
+    right: left + 100,
+    width: 100,
+    height: 60,
+    x: left,
+    y: 0,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+describe('pointer/HTML5 event parity (#121)', () => {
+  let sortable: Sortable | undefined
+
+  afterEach(() => {
+    sortable?.destroy()
+    sortable = undefined
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+    delete (document as unknown as { elementFromPoint?: unknown })
+      .elementFromPoint
+  })
+
+  it('uncontrolled same-zone reorder fires sort, update, AND change', () => {
+    const ul = makeList()
+    const sortSpy = vi.fn()
+    const updateSpy = vi.fn()
+    const changeSpy = vi.fn()
+    sortable = new Sortable(ul, {
+      draggable: '.item',
+      animation: 0,
+      fallbackTolerance: 0,
+      onSort: sortSpy,
+      onUpdate: updateSpy,
+      onChange: changeSpy,
+    })
+
+    const dragged = ul.children[0] as HTMLElement
+    const target = ul.children[2] as HTMLElement
+    document.elementFromPoint = () => target
+
+    dragged.dispatchEvent(mkPointer('pointerdown', 1))
+    document.dispatchEvent(mkPointer('pointermove', 1))
+    document.dispatchEvent(mkPointer('pointerup', 1))
+
+    expect(sortSpy).toHaveBeenCalledTimes(1)
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+    expect(changeSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('uncontrolled same-zone reorder respects swapThreshold', () => {
+    const ul = makeList()
+    const sortSpy = vi.fn()
+    sortable = new Sortable(ul, {
+      draggable: '.item',
+      animation: 0,
+      fallbackTolerance: 0,
+      swapThreshold: 0.9,
+      onSort: sortSpy,
+    })
+
+    const dragged = ul.children[0] as HTMLElement
+    const target = ul.children[2] as HTMLElement
+    target.getBoundingClientRect = () => rect(80, 120)
+    document.elementFromPoint = () => target
+
+    dragged.dispatchEvent(mkPointer('pointerdown', 2))
+
+    // The gate measures the GHOST, not the still-parked dragged item —
+    // nothing moves `dragged` until a swap commits, so its rect stays put
+    // for the whole hover. The ghost is the cursor-following visual, so
+    // it's the only element whose rect actually changes as the drag
+    // progresses (matches `data-resortable-ghost`, see GhostManager).
+    const ghost = document.querySelector<HTMLElement>('[data-resortable-ghost]')
+    expect(ghost).not.toBeNull()
+
+    // Barely overlapping the target row (1px of 40px = 2.5%) — well under
+    // the 0.9 threshold. No reorder, no events.
+    ghost!.getBoundingClientRect = () => rect(119, 159)
+    document.dispatchEvent(mkPointer('pointermove', 2))
+    expect(sortSpy).not.toHaveBeenCalled()
+    expect(ul.children[0]).toBe(dragged)
+
+    // Full overlap with the target row — clears the 0.9 threshold.
+    ghost!.getBoundingClientRect = () => rect(80, 120)
+    document.dispatchEvent(mkPointer('pointermove', 2))
+    expect(sortSpy).toHaveBeenCalledTimes(1)
+
+    document.dispatchEvent(mkPointer('pointerup', 2))
+  })
+
+  it('measures the real layout axis, so a horizontal row + invertSwap still reorders', () => {
+    // Regression: `shouldSwap` used to branch on the `direction` OPTION,
+    // which defaults to 'vertical' and is never auto-detected. On a row every
+    // item shares a top and bottom, so vertical overlap computes to ~1.0 —
+    // `invertSwap` then evaluates `1.0 < threshold` as false on every move
+    // and the list freezes for the entire drag. The axis is now measured.
+    const ul = makeList()
+    const sortSpy = vi.fn()
+    sortable = new Sortable(ul, {
+      draggable: '.item',
+      animation: 0,
+      fallbackTolerance: 0,
+      swapThreshold: 0.5,
+      invertSwap: true,
+      onSort: sortSpy,
+      // `direction` deliberately left at its default — that IS the bug.
+    })
+
+    // Lay the items out as a row: shared top/bottom, side-by-side columns.
+    Array.from(ul.children).forEach((el, i) => {
+      ;(el as HTMLElement).getBoundingClientRect = () => hRect(i * 100)
+    })
+
+    const dragged = ul.children[0] as HTMLElement
+    const target = ul.children[2] as HTMLElement
+    document.elementFromPoint = () => target
+
+    dragged.dispatchEvent(mkPointer('pointerdown', 4))
+    const ghost = document.querySelector<HTMLElement>('[data-resortable-ghost]')
+    expect(ghost).not.toBeNull()
+
+    // Ghost overlaps the target column by 10% — under the 0.5 inverted
+    // threshold, so an inverted swap SHOULD fire. Read on the wrong axis this
+    // is ~100% overlap and nothing happens at all.
+    ghost!.getBoundingClientRect = () => hRect(290)
+    document.dispatchEvent(mkPointer('pointermove', 4))
+
+    expect(sortSpy).toHaveBeenCalledTimes(1)
+    document.dispatchEvent(mkPointer('pointerup', 4))
+  })
+
+  it('reports oldIndex against the destination list when reordering after a cross-zone move', () => {
+    // Regression: `sort` now fires for reorders inside a DESTINATION zone,
+    // where `startIndex` is an index into the ORIGINAL zone — so the payload
+    // claimed `from`/`to` were zone B while `oldIndex` indexed zone A.
+    const from = makeList(3)
+    const to = makeList(3)
+    Array.from(to.children).forEach((el, i) => {
+      ;(el as HTMLElement).dataset.id = `to-${i}`
+    })
+    const sortSpy = vi.fn()
+    const opts = { draggable: '.item', animation: 0, fallbackTolerance: 0 }
+    sortable = new Sortable(from, { ...opts, group: 'shared' })
+    const toSortable = new Sortable(to, {
+      ...opts,
+      group: 'shared',
+      onSort: sortSpy,
+    })
+
+    try {
+      // Index 2 in the SOURCE list, so that its index in the destination
+      // (0, see below) differs — otherwise the buggy and correct values
+      // coincide and the test proves nothing.
+      const dragged = from.children[2] as HTMLElement
+      let hit = to.children[0] as HTMLElement
+      document.elementFromPoint = () => hit
+
+      // Enter zone B — inserts before B's first item, so it lands at index 0.
+      dragged.dispatchEvent(mkPointer('pointerdown', 5))
+      document.dispatchEvent(mkPointer('pointermove', 5))
+      expect(dragged.parentElement).toBe(to)
+      expect(Array.from(to.children).indexOf(dragged)).toBe(0)
+
+      // Now reorder WITHIN B, hovering B's last item.
+      hit = to.children[to.children.length - 1] as HTMLElement
+      document.dispatchEvent(mkPointer('pointermove', 5))
+      document.dispatchEvent(mkPointer('pointerup', 5))
+
+      expect(sortSpy).toHaveBeenCalled()
+      const payload = sortSpy.mock.calls[0][0] as {
+        from: HTMLElement
+        to: HTMLElement
+        oldIndex: number
+      }
+      expect(payload.from).toBe(to)
+      expect(payload.to).toBe(to)
+      // The item's live index in B — NOT its index back in the source list.
+      expect(payload.oldIndex).toBe(0)
+    } finally {
+      toSortable.destroy()
+    }
+  })
+
+  it('controlled pointer mode fires sort AND change too', () => {
+    const ul = makeList()
+    const sortSpy = vi.fn()
+    const changeSpy = vi.fn()
+    sortable = new Sortable(ul, {
+      controlled: true,
+      draggable: '.item',
+      animation: 0,
+      fallbackTolerance: 0,
+      onSort: sortSpy,
+      onChange: changeSpy,
+    })
+
+    const dragged = ul.children[0] as HTMLElement
+    const target = ul.children[2] as HTMLElement
+    document.elementFromPoint = () => target
+
+    dragged.dispatchEvent(mkPointer('pointerdown', 3))
+    document.dispatchEvent(mkPointer('pointermove', 3))
+    document.dispatchEvent(mkPointer('pointerup', 3))
+
+    expect(sortSpy).toHaveBeenCalledTimes(1)
+    expect(changeSpy).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Closes #121.

## What was wrong

The pointer/PointerEvent pipeline had drifted from the HTML5-native one. Both gaps hit touch input and fallback mode:

1. **`sort` / `change` never fired.** `onPointerMove`'s same-zone branch emitted only `update`; `sort` and `change` were emitted exclusively by `onDragOver`.
2. **`swapThreshold` / `invertSwap` were ignored.** `shouldSwap()` was only reachable from the HTML5 `dragover` handler and from controlled mode; the uncontrolled pointer path reordered on any hover.

`handleControlledMove`'s `emitHtml5Events` flag is deleted — a per-pipeline event-set switch inside a shared function is what encoded the drift. Both pipelines now emit the same set.

## Two latent bugs this surfaced

Fixed here, because the parity work is what makes them reachable:

- **Horizontal and grid lists froze completely.** `shouldSwap` branched on the `direction` *option*, which defaults to `'vertical'` and is never auto-detected. On a row, every item shares a top/bottom, so vertical overlap is always ~1.0 — `swapThreshold` became a no-op and `invertSwap` blocked every reorder for the whole drag. It now measures the real axis via the existing `detectHorizontalLayout`, falling back to the option only when rects aren't measurable.
- **Cross-zone `sort` reported `oldIndex` from the wrong list.** `sort` now fires for reorders inside a *destination* zone, but `startIndex` indexes the *original* zone — so the payload claimed `from`/`to` were zone B while `oldIndex` indexed zone A.

## Why the gate measures the ghost

Nothing moves the real dragged item until a swap commits, so its rect stays parked in its original slot and overlaps the target by **exactly 0** no matter how far the cursor travels. Measuring it would make any `swapThreshold > 0` freeze the drag outright. The cursor-following ghost is the actual moving visual — which is why `handleControlledMove` already measured it.

The gate **fails open** when there's no ghost, and `shouldSwap` returns `true` when the target has no measurable extent along the axis — a threshold that *can't be evaluated* must not silently behave like one that wasn't met.

## Known gap left in place

Native HTML5 mode has the same parked-rect bug, and it's worse than #121 described: `swapThreshold > 0` there disables same-zone sorting entirely. The ghost fix can't be reused — the browser draws its own drag image, so the ghost is `display: none` and its rect is zero-size and frozen. It needs a rect synthesized from the `DragEvent` coordinates. Documented in-code with an explicit "do NOT restore parity by copying the pointer pipeline's ghost lookup" warning, and filed separately.

## Testing

- Un-skips the two `advanced-events` tests blocked on this; tightens `fallback-mode` to actually assert `sort` fires
- Adds uncontrolled-pipeline `swapThreshold` / `invertSwap` e2e coverage (the suite previously needed `controlled: true` to reach the gate at all)
- Adds unit coverage for the emissions, the threshold gate, the measured axis, and the cross-zone `oldIndex`
- Both new regression tests are **mutation-verified** — each fails when its corresponding fix is reverted

`npm run check` clean (0 errors) · 306/306 unit · 44/44 and 66/66 on the touched e2e specs with repeats, no flake.

**Note on the full e2e suite:** it's nondeterministic on my machine — a clean `main` baseline produced *13* failures to this branch's *10*, with overlapping, non-subset sets (all 6 `animation-visual` failures are `beforeEach` page-load timeouts on both). Leaving the full-suite verdict to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017ao27EZwAPvgYEnPH8fbbH

<!-- claude-session:35f418e5-3d9c-49b0-8739-7e7f3d2b24ef -->
🔖 **Claude agent:** resortable-9b  
session id: `35f418e5-3d9c-49b0-8739-7e7f3d2b24ef`