### PR TITLE
chore(worktree): automate per-worktree dev environment setup

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,24 @@
+{
+  "enabledPlugins": {
+    "feature-dev@claude-plugins-official": true,
+    "playwright@claude-plugins-official": true,
+    "serena@claude-plugins-official": true,
+    "pr-review-toolkit@claude-plugins-official": true,
+    "explanatory-output-style@claude-plugins-official": true,
+    "playground@claude-plugins-official": true,
+    "typescript-lsp@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR/scripts/worktree-setup.sh\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,29 @@ npm run check
 
 If it reports any errors, fix them before committing. **NO EXCEPTIONS.**
 
-### Worktree gotcha
+## Working in git worktrees
 
-`npm` walks up the directory tree to find `node_modules`, so a fresh worktree can lint against the parent repo's stale dependencies and falsely pass while CI fails on the same code. **In a new worktree, run `npm ci` once before the first `npm run check`** to guarantee dependencies match `package-lock.json`.
+`npm` walks up the directory tree to find `node_modules`, so a worktree without its own
+would lint against the parent repo's stale dependencies — passing locally while CI fails
+on the same code. `scripts/worktree-setup.sh` prevents that, and Claude Code runs it
+automatically via the `SessionStart` hook in `.claude/settings.json`. It:
+
+- symlinks `node_modules` to the main checkout when the two `package-lock.json` files are
+  byte-identical, and runs a real `npm ci` when they differ;
+- assigns the worktree a unique `PW_PORT` (5200–5299) in its gitignored
+  `.claude/settings.local.json`, so parallel vite/playwright runs don't collide on 5173.
+
+It is idempotent and a no-op in the main checkout. After creating a worktree outside a
+Claude Code session, run it yourself before the first `npm run check`:
+
+```
+git worktree add .worktrees/my-feature -b feat/my-feature
+cd .worktrees/my-feature && npm run worktree:setup
+```
+
+**If a branch changes dependencies**, the shared `node_modules` symlink is no longer valid —
+delete it and run `npm ci` in the worktree. Never run `npm install` through the symlink; it
+writes through to the main checkout.
 
 ## Project Overview
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "docs:serve": "npx http-server docs -p 8080",
     "docs:clean": "rimraf docs/api",
     "size": "size-limit",
-    "size:build": "npm run build && npm run size"
+    "size:build": "npm run build && npm run size",
+    "worktree:setup": "bash scripts/worktree-setup.sh"
   },
   "size-limit": [
     {

--- a/scripts/worktree-setup.sh
+++ b/scripts/worktree-setup.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+#
+# Prepare a git worktree for development:
+#   1. give it a node_modules (symlinked from the main checkout when the lockfiles match)
+#   2. give it its own dev-server port, so parallel worktrees don't fight over 5173
+#
+# Idempotent and cheap to re-run — Claude Code runs it on every SessionStart.
+# Run it by hand after `git worktree add` with: npm run worktree:setup
+set -euo pipefail
+
+cd "${1:-$PWD}"
+
+git_dir=$(git rev-parse --absolute-git-dir)
+common_dir=$(cd "$(git rev-parse --git-common-dir)" && pwd)
+
+# Main checkout, not a worktree: nothing to set up.
+[ "$git_dir" = "$common_dir" ] && exit 0
+
+main_repo=$(dirname "$common_dir")
+
+if [ ! -e node_modules ]; then
+  # Test for the install receipt, not just the directory — a stale `.vite-temp/` is enough
+  # to make an otherwise-empty node_modules look installed, and linking to that produces a
+  # worktree where every binary is missing.
+  if [ -f "$main_repo/node_modules/.package-lock.json" ] && cmp -s package-lock.json "$main_repo/package-lock.json"; then
+    # ponytail: shared node_modules, not a copy. Valid only while the lockfiles are
+    # byte-identical — which is why the cmp guard above exists. Running `npm install`
+    # in this worktree writes through to the main checkout; run `npm ci` here instead
+    # (deletes the symlink, installs a real tree) if this branch changes dependencies.
+    ln -s "$main_repo/node_modules" node_modules
+    echo "worktree-setup: linked node_modules -> $main_repo/node_modules"
+  else
+    echo "worktree-setup: lockfile differs from main checkout, installing deps..."
+    npm ci
+  fi
+fi
+
+# Unique dev-server port, derived from the worktree path so a worktree recreated at
+# the same path gets the same port back. Read by vite.config.ts and playwright.config.ts.
+# ponytail: 100-port space, collisions unhandled. Widen the range if that ever bites.
+port=$((5200 + $(printf '%s' "$PWD" | cksum | cut -d' ' -f1) % 100))
+
+PW_PORT="$port" node -e '
+  const fs = require("fs");
+  const path = ".claude/settings.local.json";
+  const settings = fs.existsSync(path) ? JSON.parse(fs.readFileSync(path, "utf8")) : {};
+  if (settings.env?.PW_PORT) process.exit(0);
+  settings.env = { ...settings.env, PW_PORT: process.env.PW_PORT };
+  fs.mkdirSync(".claude", { recursive: true });
+  fs.writeFileSync(path, JSON.stringify(settings, null, 2) + "\n");
+  console.log(`worktree-setup: PW_PORT=${process.env.PW_PORT}`);
+'


### PR DESCRIPTION
## Problem

A git worktree does not inherit gitignored files, so a fresh one starts with no `node_modules`. npm then walks up the directory tree, finds the main checkout's dependencies, and lints against them — passing locally while CI fails on the same code. This gotcha was documented in `CLAUDE.md` as "remember to run `npm ci`"; this automates it instead.

Two of the four existing worktrees in this repo had been left with an empty `node_modules` (just a stale `.vite/` cache), and one had a dangling symlink — exactly the failure mode the manual instruction was supposed to prevent.

## Changes

- **`scripts/worktree-setup.sh`** — idempotent, exits immediately in the main checkout:
  - symlinks `node_modules` to the main checkout when both `package-lock.json` files are byte-identical; falls back to a real `npm ci` when they differ, or when the main checkout has no `.package-lock.json` install receipt;
  - assigns each worktree a unique `PW_PORT` (5200–5299, derived from its path so a worktree recreated at the same path gets the same port) in its gitignored `.claude/settings.local.json`. `vite.config.ts` and `playwright.config.ts` already read this variable.
- **`.claude/settings.json`** — now tracked, so worktree sessions inherit the project's plugin set. Adds a `SessionStart` hook running the script, which covers worktrees created from inside a Claude Code session. Drops the disabled `superpowers` entry.
- **`npm run worktree:setup`** — for worktrees created outside a session.
- **`CLAUDE.md`** — replaces the manual instruction, and documents the symlink's one sharp edge: never run `npm install` through it, since that writes to the main checkout.

## Verification

- `npm run check`: 0 errors (45 pre-existing warnings, all non-null assertions in test files).
- Fresh worktree gets a working symlink; `npx eslint --version` resolves through it; re-running the script is a silent no-op.
- Confirmed `git worktree remove --force` unlinks the symlink rather than deleting through it, so removing a worktree cannot destroy the shared dependencies.
- Applied to all four existing worktrees; each now resolves eslint v9.34.0.

No library or test code is touched, so there is nothing here for the e2e suite to regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KV2kiwbspDpZi83UKKq8yC

<!-- claude-session:8fa24901-9884-436a-9da0-0c18fa34d75c -->
🔖 **Claude agent:** resortable-12  
session id: `8fa24901-9884-436a-9da0-0c18fa34d75c`