### PR TITLE
docs(types): correct swapThreshold default — unset disables the overlap gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@ new Sortable(element, {
   delayOnTouchOnly: 0,              // Touch-specific delay
   touchStartThreshold: 5,            // Pixels of movement before cancelling delay
   direction: 'vertical',             // 'vertical' | 'horizontal' list axis
-  // swapThreshold: undefined,        // Overlap fraction before an item swaps (unset = always swap)
+  // swapThreshold: 0.5,              // Min overlap fraction (0-1) before an item swaps;
+                                     // omit for the default (no overlap gate)
 
   // Drop targeting
   emptyInsertThreshold: 5,           // Px around an empty list that still counts as a drop

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ new Sortable(element, {
   delayOnTouchOnly: 0,              // Touch-specific delay
   touchStartThreshold: 5,            // Pixels of movement before cancelling delay
   direction: 'vertical',             // 'vertical' | 'horizontal' list axis
-  swapThreshold: 1,                  // Overlap fraction before an item swaps
+  // swapThreshold: undefined,        // Overlap fraction before an item swaps (unset = always swap)
 
   // Drop targeting
   emptyInsertThreshold: 5,           // Px around an empty list that still counts as a drop

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -374,13 +374,21 @@ export interface SortableOptions {
 
   /**
    * Threshold of the swap zone (0-1)
-   * @defaultValue 1
+   *
+   * When unset (the default), the overlap gate is disabled and any hover swaps.
+   * Setting this property enforces minimum overlap for a swap to occur.
    *
    * @example
    * ```typescript
    * // Swap when dragged element overlaps 50% with target
    * { swapThreshold: 0.5 }
    * ```
+   *
+   * @remarks
+   * **Legacy Sortable.js compatibility**: The original Sortable.js defaults to
+   * a swap threshold of 1 (100% overlap), making items much stickier. To replicate
+   * that behavior in Resortable, explicitly set `swapThreshold: 1`. Leaving unset
+   * enables the responsive default (any hover swaps).
    */
   swapThreshold?: number
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -375,8 +375,9 @@ export interface SortableOptions {
   /**
    * Threshold of the swap zone (0-1)
    *
-   * When unset (the default), the overlap gate is disabled and any hover swaps.
-   * Setting this property enforces minimum overlap for a swap to occur.
+   * When unset (the default), the overlap gate is disabled — swaps are not
+   * constrained by overlap amount. Setting this property enforces a minimum
+   * overlap for a swap to occur.
    *
    * @example
    * ```typescript
@@ -388,7 +389,7 @@ export interface SortableOptions {
    * **Legacy Sortable.js compatibility**: The original Sortable.js defaults to
    * a swap threshold of 1 (100% overlap), making items much stickier. To replicate
    * that behavior in Resortable, explicitly set `swapThreshold: 1`. Leaving unset
-   * enables the responsive default (any hover swaps).
+   * enables the responsive default (no minimum-overlap requirement).
    */
   swapThreshold?: number
 


### PR DESCRIPTION
Closes #132.

`swapThreshold` was documented with `@defaultValue 1`, but the implementation treats unset as "always swap" (behaviorally 0 — the opposite end of the range). A user explicitly writing the documented default got 100%-overlap stickiness instead of default behavior.

Doc-only fix, no runtime change:
- TSDoc now states unset = overlap gate disabled (any hover swaps), with a `@remarks` compat note: legacy Sortable.js defaults to 1, set it explicitly to replicate.
- README defaults example updated to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ND26MSiGy1BMPoh5o6eWmt

<!-- claude-session:70ee3204-014c-4824-8272-df3ca0d48c38 -->
🔖 **Claude agent:** resortable-9c  
session id: `70ee3204-014c-4824-8272-df3ca0d48c38`