### PR TITLE
perf(core): coalesce autoscroll scroll-replay to one onPointerMove per frame

### DIFF
--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -147,6 +147,14 @@ export class DragManager implements DragManagerInterface {
   // the new scroll offset (#124). Null outside a pointer drag.
   private lastPointerMoveEvent: PointerEvent | null = null
 
+  // rAF handle for a pending scroll-replay (#134). Autoscroll's rAF loop
+  // fires `scrollBy` every frame, so the `scroll` listener below would
+  // otherwise pay a full `onPointerMove` (hit-test + rect math) per frame.
+  // Coalescing to one replay per animation frame is enough to keep the drop
+  // target fresh without redoing that work on every scroll tick. Null when
+  // no replay is scheduled.
+  private scrollReplayFrame: number | null = null
+
   private groupManager: GroupManager
 
   private originalTouchActions = new Map<HTMLElement, string>()
@@ -1923,7 +1931,12 @@ export class DragManager implements DragManagerInterface {
   // `scroll` doesn't bubble.
   private onDocumentScrollDuringDrag = (): void => {
     if (!this.isPointerDragging || !this.lastPointerMoveEvent) return
-    this.onPointerMove(this.lastPointerMoveEvent)
+    if (this.scrollReplayFrame !== null) return
+    this.scrollReplayFrame = window.requestAnimationFrame(() => {
+      this.scrollReplayFrame = null
+      if (!this.isPointerDragging || !this.lastPointerMoveEvent) return
+      this.onPointerMove(this.lastPointerMoveEvent)
+    })
   }
 
   private onPointerUp = (e: PointerEvent): void => {
@@ -1939,6 +1952,23 @@ export class DragManager implements DragManagerInterface {
   }
 
   private cleanupPointerDrag(revert = false): void {
+    // A pointerup/pointercancel can land in the same frame as the last
+    // autoscroll scroll tick, before the deferred scroll-replay (#134) has
+    // run. Flush it synchronously here, before any other teardown, while
+    // drag state is still fully live — identical timing to the old
+    // synchronous replay. Otherwise the drop resolves against a placeholder
+    // that's one scroll tick stale, resurrecting #124. Skipped on revert:
+    // a cancelled drag doesn't need its last target re-resolved.
+    if (
+      !revert &&
+      this.scrollReplayFrame !== null &&
+      this.lastPointerMoveEvent
+    ) {
+      window.cancelAnimationFrame(this.scrollReplayFrame)
+      this.scrollReplayFrame = null
+      this.onPointerMove(this.lastPointerMoveEvent)
+    }
+
     // Remove multi-drag-source class from all items
     this.draggedItems.forEach((item) => {
       item.classList.remove('sortable-multi-drag-source')
@@ -1955,6 +1985,10 @@ export class DragManager implements DragManagerInterface {
     document.removeEventListener('scroll', this.onDocumentScrollDuringDrag, {
       capture: true,
     })
+    if (this.scrollReplayFrame !== null) {
+      window.cancelAnimationFrame(this.scrollReplayFrame)
+      this.scrollReplayFrame = null
+    }
     this.lastPointerMoveEvent = null
 
     // Controlled mode: restore the consumer's DOM BEFORE endDrag emits the

--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -377,6 +377,13 @@ export class DragManager implements DragManagerInterface {
     // Cleanup is non-reverting on purpose: it unbinds and clears state without
     // moving DOM, so teardown stays behaviourally neutral.
     if (this.isPointerDragging) {
+      // Drop any pending scroll-replay frame (#134) BEFORE cleanup: the
+      // flush in cleanupPointerDrag re-resolves the drop target and moves
+      // DOM, which teardown must not do.
+      if (this.scrollReplayFrame !== null) {
+        window.cancelAnimationFrame(this.scrollReplayFrame)
+        this.scrollReplayFrame = null
+      }
       this.cleanupPointerDrag()
     }
 

--- a/tests/unit/drag-manager.test.ts
+++ b/tests/unit/drag-manager.test.ts
@@ -681,4 +681,37 @@ describe('scroll-replay coalescing during autoscroll (#134)', () => {
     vi.advanceTimersByTime(16)
     expect(replay).toHaveBeenCalledTimes(2)
   })
+
+  it('detach mid-drag drops a pending replay instead of flushing it', () => {
+    // `detach()` (React unmount, `option()` rebuild) documents itself as
+    // behaviourally neutral: it must not move DOM. The drop-time flush in
+    // cleanupPointerDrag would re-resolve the drop target, so detach cancels
+    // the pending frame first and no replay ever fires.
+    vi.useFakeTimers()
+    const list = makeList('list')
+    const sortable = mount(list, { animation: 0 })
+    const internals = sortable.dragManager as unknown as {
+      onPointerMove(e: PointerEvent): void
+      detach(): void
+    }
+    const replay = vi.spyOn(internals, 'onPointerMove')
+
+    const item1 = list.children[0] as HTMLElement
+    hover(list.children[2] as HTMLElement)
+    item1.dispatchEvent(pointer('pointerdown'))
+
+    document.dispatchEvent(pointer('pointermove', { y: 20 }))
+    expect(replay).toHaveBeenCalledTimes(1)
+
+    // Schedules a replay frame that hasn't fired yet…
+    document.dispatchEvent(new Event('scroll'))
+
+    // …and the manager is torn down before it does. No synchronous flush.
+    internals.detach()
+    expect(replay).toHaveBeenCalledTimes(1)
+
+    // And no deferred one either.
+    vi.advanceTimersByTime(16)
+    expect(replay).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/unit/drag-manager.test.ts
+++ b/tests/unit/drag-manager.test.ts
@@ -606,3 +606,79 @@ describe('detach during an active pointer drag', () => {
     expect(ids(second)).toEqual(secondBefore)
   })
 })
+
+describe('scroll-replay coalescing during autoscroll (#134)', () => {
+  // Autoscroll's rAF loop fires `scrollBy` every frame, and each `scroll`
+  // event used to replay the last pointermove synchronously — a full
+  // hit-test + rect pass per frame. The replay is now coalesced to at most
+  // one `onPointerMove` call per animation frame (`tests/setup.ts` maps
+  // `requestAnimationFrame` to a 16ms `setTimeout`, so fake timers drive it).
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('N scroll events within one frame produce exactly one replay', () => {
+    vi.useFakeTimers()
+    const list = makeList('list')
+    const sortable = mount(list, { animation: 0 })
+    const internals = sortable.dragManager as unknown as {
+      onPointerMove(e: PointerEvent): void
+    }
+    const replay = vi.spyOn(internals, 'onPointerMove')
+
+    const item1 = list.children[0] as HTMLElement
+    hover(list.children[2] as HTMLElement)
+    item1.dispatchEvent(pointer('pointerdown'))
+
+    // Seed `lastPointerMoveEvent` — the scroll listener replays this.
+    document.dispatchEvent(pointer('pointermove', { y: 20 }))
+    expect(replay).toHaveBeenCalledTimes(1)
+
+    // Several scroll ticks land before the animation frame flushes.
+    document.dispatchEvent(new Event('scroll'))
+    document.dispatchEvent(new Event('scroll'))
+    document.dispatchEvent(new Event('scroll'))
+    expect(replay).toHaveBeenCalledTimes(1) // still just the seed call
+
+    vi.advanceTimersByTime(16)
+
+    // One replay for the whole batch, not one per scroll event.
+    expect(replay).toHaveBeenCalledTimes(2)
+  })
+
+  it('flushes a pending replay synchronously at drop, then cancels the frame', () => {
+    // Race: pointerup lands in the same frame as the last autoscroll scroll
+    // tick, before the deferred replay has fired. The old synchronous
+    // replay never lost that last tick, so dropping here must not resolve
+    // against a one-tick-stale target (#124) — cleanupPointerDrag flushes
+    // the pending replay itself before tearing anything else down.
+    vi.useFakeTimers()
+    const list = makeList('list')
+    const sortable = mount(list, { animation: 0 })
+    const internals = sortable.dragManager as unknown as {
+      onPointerMove(e: PointerEvent): void
+    }
+    const replay = vi.spyOn(internals, 'onPointerMove')
+
+    const item1 = list.children[0] as HTMLElement
+    hover(list.children[2] as HTMLElement)
+    item1.dispatchEvent(pointer('pointerdown'))
+
+    document.dispatchEvent(pointer('pointermove', { y: 20 }))
+    expect(replay).toHaveBeenCalledTimes(1)
+
+    // Schedules a replay frame that hasn't fired yet.
+    document.dispatchEvent(new Event('scroll'))
+
+    // Pointer released before the frame flushes — the drop must still see
+    // the post-scroll target: one flushed replay, right here, synchronously.
+    document.dispatchEvent(pointer('pointerup'))
+    expect(replay).toHaveBeenCalledTimes(2)
+
+    // No further callback once the frame would otherwise have fired —
+    // teardown already cancelled it.
+    vi.advanceTimersByTime(16)
+    expect(replay).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION
Closes #134.

`onDocumentScrollDuringDrag` replayed the last pointermove synchronously on **every** scroll event during a drag, so autoscroll's rAF loop paid a full `onPointerMove` (hit-test with ghost hide/show, drop-target resolution, placeholder move, rect math) per frame — and browser-coalesced scroll bursts could exceed one per frame. WebKit on the hosted-Windows runner spent 6.8–9.4s on `autoscroll-drop-target.spec.ts` largely on this.

Changes:
- Replay is coalesced to at most one `onPointerMove` per animation frame via `requestAnimationFrame`.
- A pending replay is **flushed synchronously at drop** (top of `cleanupPointerDrag`, drag state still live) so a pointerup landing in the same frame as the last scroll tick never resolves against a one-tick-stale target — the original #124 test (scroll then immediate release, unmodified) pins exactly that race and fails without the flush.
- On revert/cancel the pending frame is cancelled without replay.

Tests: 2 new unit tests (N scroll events in one frame → one replay; pending replay flushed once at drop, none after teardown), both mutation-checked against the unthrottled/cancel-only variants. Full unit suite 422/422; `npm run check` clean.

Follow-up per issue acceptance criteria: once CI confirms the WebKit runtime drop, the 20s stopgap timeout in `autoscroll-drop-target.spec.ts` can come back down (left untouched here deliberately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ND26MSiGy1BMPoh5o6eWmt

<!-- claude-session:70ee3204-014c-4824-8272-df3ca0d48c38 -->
🔖 **Claude agent:** resortable-9c  
session id: `70ee3204-014c-4824-8272-df3ca0d48c38`