### PR TITLE
fix(core): guard drop-animation cleanup against destroying a newer drag's ghost

### DIFF
--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -2153,15 +2153,23 @@ export class DragManager implements DragManagerInterface {
         const timer: { id?: number } = {}
         const cleanup = () => {
           window.clearTimeout(timer.id)
+          // The SAME element re-grabbed within the animation window owns its
+          // state classes again — whether the new drag has committed
+          // (dragElement) or is still in the fallback-tolerance capture
+          // phase (pointerCaptureTarget), which applies chosenClass at tap
+          // start before dragElement is set. Its own cleanup removes them.
+          const regrabbed =
+            this.dragElement === dragEl || this.pointerCaptureTarget === dragEl
           if (this.ghostManager.getGhostElement() === ghost) {
-            this.ghostManager.destroy(dragEl)
-          } else if (this.dragElement !== dragEl) {
+            // Still this drop's ghost (a capture-phase re-grab creates no
+            // new ghost, so it lands here too): settle is done, destroy it.
+            // Passing dragEl also strips its state classes, so omit it on
+            // a re-grab.
+            this.ghostManager.destroy(regrabbed ? undefined : dragEl)
+          } else if (!regrabbed) {
             // A newer drag owns the current ghost/placeholder — leave them
             // intact, but this drag's element still sheds its state classes
             // (nothing else removes them once this cleanup is skipped).
-            // Skipped when the SAME element was re-grabbed within the
-            // animation window: the new drag just re-applied these classes
-            // and its own cleanup will remove them.
             dragEl.classList.remove(this.ghostManager.getChosenClass())
             dragEl.classList.remove(this.ghostManager.getDragClass())
           }

--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -2146,13 +2146,29 @@ export class DragManager implements DragManagerInterface {
         ghost.style.transition = 'transform 150ms cubic-bezier(0.2, 0, 0, 1)'
         ghost.style.transform = `translate(${deltaX}px, ${deltaY}px)`
 
-        // After animation, clean up
+        // After animation, clean up. Guarded by identity: if a new drag has
+        // started within the animation window, `getGhostElement()` will be
+        // that new ghost, not `ghost` — so this no-ops instead of destroying
+        // the wrong drag's ghost/placeholder (#131).
+        const timer: { id?: number } = {}
         const cleanup = () => {
-          this.ghostManager.destroy(dragEl)
+          window.clearTimeout(timer.id)
+          if (this.ghostManager.getGhostElement() === ghost) {
+            this.ghostManager.destroy(dragEl)
+          } else if (this.dragElement !== dragEl) {
+            // A newer drag owns the current ghost/placeholder — leave them
+            // intact, but this drag's element still sheds its state classes
+            // (nothing else removes them once this cleanup is skipped).
+            // Skipped when the SAME element was re-grabbed within the
+            // animation window: the new drag just re-applied these classes
+            // and its own cleanup will remove them.
+            dragEl.classList.remove(this.ghostManager.getChosenClass())
+            dragEl.classList.remove(this.ghostManager.getDragClass())
+          }
         }
         ghost.addEventListener('transitionend', cleanup, { once: true })
         // Fallback timeout in case transitionend doesn't fire
-        window.setTimeout(cleanup, 200)
+        timer.id = window.setTimeout(cleanup, 200)
       } else {
         this.ghostManager.destroy(dragEl)
       }

--- a/tests/unit/drag-manager.test.ts
+++ b/tests/unit/drag-manager.test.ts
@@ -715,3 +715,147 @@ describe('scroll-replay coalescing during autoscroll (#134)', () => {
     expect(replay).toHaveBeenCalledTimes(1)
   })
 })
+
+describe('stale drop-animation timer (#131)', () => {
+  // The ghost drop-settle cleanup in `cleanupPointerDrag` only defers to a
+  // transitionend/timeout pair when the ghost and the drag element disagree
+  // on position by more than 2px — otherwise it destroys synchronously and
+  // there is no timer to go stale. Force that gap so both tests exercise the
+  // deferred path.
+  function forceDropAnimation(ghost: HTMLElement, dragEl: HTMLElement): void {
+    vi.spyOn(ghost, 'getBoundingClientRect').mockReturnValue(
+      new DOMRect(0, 0, 50, 20)
+    )
+    vi.spyOn(dragEl, 'getBoundingClientRect').mockReturnValue(
+      new DOMRect(100, 100, 50, 20)
+    )
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("a stale fallback timer does not destroy a newer drag's ghost/placeholder", () => {
+    const list = makeList('list', 4)
+    const sortable = mount(list, { animation: 0 })
+    // ghostManager is private; reached the same way `canDropInZone` is above.
+    const internals = sortable.dragManager as unknown as {
+      ghostManager: {
+        getGhostElement(): HTMLElement | null
+        getPlaceholderElement(): HTMLElement | null
+        getChosenClass(): string
+        getDragClass(): string
+      }
+    }
+
+    const item1 = list.children[0] as HTMLElement
+    const item3 = list.children[2] as HTMLElement
+    const item4 = byId(list, 'list-4')
+
+    // First drag drops far enough from its ghost to schedule the 200ms
+    // fallback timer instead of destroying synchronously.
+    hover(item3)
+    item1.dispatchEvent(pointer('pointerdown', { id: 1 }))
+    const staleGhost = internals.ghostManager.getGhostElement()
+    if (!staleGhost) throw new Error('expected a ghost element')
+    forceDropAnimation(staleGhost, item1)
+    document.dispatchEvent(pointer('pointerup', { id: 1 }))
+    // Still mid drop-animation — not destroyed yet.
+    expect(document.body.contains(staleGhost)).toBe(true)
+
+    // A second drag starts within the 200ms window, before the stale timer
+    // fires, and gets its own ghost and placeholder.
+    hover(item3)
+    item4.dispatchEvent(pointer('pointerdown', { id: 1 }))
+    const freshGhost = internals.ghostManager.getGhostElement()
+    const freshPlaceholder = internals.ghostManager.getPlaceholderElement()
+    expect(freshGhost).not.toBeNull()
+    expect(freshGhost).not.toBe(staleGhost)
+    expect(freshPlaceholder).not.toBeNull()
+
+    // The stale timer from the FIRST drop fires now. Unguarded, it would
+    // destroy the CURRENT (second drag's) ghost and placeholder, leaving the
+    // new drag with no ghost for the rest of its lifetime.
+    vi.advanceTimersByTime(200)
+
+    expect(internals.ghostManager.getGhostElement()).toBe(freshGhost)
+    expect(internals.ghostManager.getPlaceholderElement()).toBe(
+      freshPlaceholder
+    )
+    // The guarded cleanup still clears the FIRST drag element's state
+    // classes — skipping the destroy must not leave item1 styled as
+    // chosen/dragging forever.
+    expect(
+      item1.classList.contains(internals.ghostManager.getChosenClass())
+    ).toBe(false)
+    expect(
+      item1.classList.contains(internals.ghostManager.getDragClass())
+    ).toBe(false)
+  })
+
+  it('re-grabbing the SAME element within the window keeps its drag classes', () => {
+    const list = makeList('list', 4)
+    const sortable = mount(list, { animation: 0 })
+    const internals = sortable.dragManager as unknown as {
+      ghostManager: {
+        getGhostElement(): HTMLElement | null
+        getChosenClass(): string
+      }
+    }
+
+    const item1 = list.children[0] as HTMLElement
+    const item3 = list.children[2] as HTMLElement
+
+    // Drop item1 with a settle animation pending…
+    hover(item3)
+    item1.dispatchEvent(pointer('pointerdown', { id: 1 }))
+    const staleGhost = internals.ghostManager.getGhostElement()
+    if (!staleGhost) throw new Error('expected a ghost element')
+    forceDropAnimation(staleGhost, item1)
+    document.dispatchEvent(pointer('pointerup', { id: 1 }))
+
+    // …then re-grab the SAME item before the stale timer fires. The new
+    // drag re-applies the chosen class; the stale cleanup must not strip
+    // it off a drag that is still running.
+    hover(item3)
+    item1.dispatchEvent(pointer('pointerdown', { id: 1 }))
+    const chosenClass = internals.ghostManager.getChosenClass()
+    expect(item1.classList.contains(chosenClass)).toBe(true)
+
+    vi.advanceTimersByTime(200)
+
+    expect(item1.classList.contains(chosenClass)).toBe(true)
+    // And the second drag's ghost survives, as in the cross-element case.
+    expect(internals.ghostManager.getGhostElement()).not.toBeNull()
+  })
+
+  it('transitionend cancels the fallback timer — cleanup runs once', () => {
+    const list = makeList('list', 4)
+    mount(list, { animation: 0 })
+
+    const item1 = list.children[0] as HTMLElement
+    const item3 = list.children[2] as HTMLElement
+
+    const destroySpy = vi.spyOn(GhostManager.prototype, 'destroy')
+
+    hover(item3)
+    item1.dispatchEvent(pointer('pointerdown', { id: 1 }))
+    const ghost = document.querySelector(
+      '[data-resortable-ghost]'
+    ) as HTMLElement
+    forceDropAnimation(ghost, item1)
+    document.dispatchEvent(pointer('pointerup', { id: 1 }))
+
+    ghost.dispatchEvent(new Event('transitionend'))
+    expect(destroySpy).toHaveBeenCalledTimes(1)
+
+    // The fallback timeout must have been cleared by transitionend — it
+    // must not fire a second cleanup.
+    vi.advanceTimersByTime(200)
+    expect(destroySpy).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/drag-manager.test.ts
+++ b/tests/unit/drag-manager.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, afterEach, vi } from 'vitest'
+import { describe, it, expect, afterEach, beforeEach, vi } from 'vitest'
 import { Sortable } from '../../src/index'
+import { GhostManager } from '../../src/core/GhostManager'
 import type { SortableEvent, SortableOptions } from '../../src/types/index'
 
 /**
@@ -831,6 +832,44 @@ describe('stale drop-animation timer (#131)', () => {
     expect(item1.classList.contains(chosenClass)).toBe(true)
     // And the second drag's ghost survives, as in the cross-element case.
     expect(internals.ghostManager.getGhostElement()).not.toBeNull()
+  })
+
+  it('re-grab still in fallback-tolerance capture phase keeps chosenClass', () => {
+    // With `fallbackTolerance > 0` a pointerdown applies chosenClass at tap
+    // start but leaves `dragElement` null until the pointer travels the
+    // tolerance distance. A stale timer firing in that window must not
+    // strip the class off the in-flight capture phase.
+    const list = makeList('list', 4)
+    const sortable = mount(list, { animation: 0, fallbackTolerance: 5 })
+    const internals = sortable.dragManager as unknown as {
+      ghostManager: {
+        getGhostElement(): HTMLElement | null
+        getChosenClass(): string
+      }
+    }
+
+    const item1 = list.children[0] as HTMLElement
+    const item3 = list.children[2] as HTMLElement
+    const chosenClass = internals.ghostManager.getChosenClass()
+
+    // First drag: commit past the tolerance, then drop with a settle
+    // animation pending.
+    hover(item3)
+    item1.dispatchEvent(pointer('pointerdown', { id: 1 }))
+    document.dispatchEvent(pointer('pointermove', { id: 1, y: 30 }))
+    const staleGhost = internals.ghostManager.getGhostElement()
+    if (!staleGhost) throw new Error('expected a ghost element')
+    forceDropAnimation(staleGhost, item1)
+    document.dispatchEvent(pointer('pointerup', { id: 1 }))
+
+    // Re-grab the SAME item: capture phase only — no movement, so the drag
+    // has not committed and `dragElement` is still null.
+    item1.dispatchEvent(pointer('pointerdown', { id: 1 }))
+    expect(item1.classList.contains(chosenClass)).toBe(true)
+
+    vi.advanceTimersByTime(200)
+
+    expect(item1.classList.contains(chosenClass)).toBe(true)
   })
 
   it('transitionend cancels the fallback timer — cleanup runs once', () => {


### PR DESCRIPTION
Closes #131.

The drop-settle animation scheduled a 200ms fallback `setTimeout` that (a) was never cleared when `transitionend` fired and (b) ran an unguarded cleanup that destroys GhostManager's *current* ghost/placeholder. Any drag started within 200ms of a previous drop had its ghost (and placeholder) destroyed mid-drag by the stale timer — `getGhostElement()` null for the rest of that drag.

Changes:
- `transitionend` now clears the fallback timer; cleanup only destroys when the current ghost is still the exact element the animation was scheduled for.
- When the guard no-ops (a newer drag owns the ghost), the old drag element still sheds its `chosenClass`/`dragClass` — nothing else removes them — *except* when the same element was re-grabbed within the window, where the new drag owns those classes (adversarial review catch).

Tests: 3 new unit tests — stale timer spares the newer drag's ghost/placeholder and clears the old element's classes; transitionend cancels the fallback (cleanup once); same-element re-grab keeps its classes. Each mutation-checked against the buggy variant. Full unit suite green; `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ND26MSiGy1BMPoh5o6eWmt

<!-- claude-session:70ee3204-014c-4824-8272-df3ca0d48c38 -->
🔖 **Claude agent:** resortable-9c  
session id: `70ee3204-014c-4824-8272-df3ca0d48c38`