### PR TITLE
fix(core): gate HTML5 dragover swaps on a rect synthesized from the drag cursor

### DIFF
--- a/src/core/DragManager.ts
+++ b/src/core/DragManager.ts
@@ -54,6 +54,14 @@ export class DragManager implements DragManagerInterface {
   private swapThreshold?: number
   private invertSwap: boolean
   private invertedSwapThreshold?: number
+  // Grab offset + item size captured at HTML5 dragstart, used to synthesize
+  // the moving rect for the swap-threshold gate — see `html5DragRect` (#130).
+  private html5GrabOrigin: {
+    grabX: number
+    grabY: number
+    width: number
+    height: number
+  } | null = null
   private direction: 'vertical' | 'horizontal'
   // Fallback system properties.
   //
@@ -428,6 +436,26 @@ export class DragManager implements DragManagerInterface {
 
     this.startIndex = this.zone.getIndex(target)
 
+    // Where within the item the user grabbed it, plus the item's size at
+    // dragstart (its live rect later reflects cross-zone parking). Feeds the
+    // synthesized moving rect in `html5DragRect` (#130). Only capture from
+    // usable coordinates — a coordless dragstart (plain `Event`, or the
+    // (0, 0) synthetic convention) would poison the origin with NaN and
+    // freeze the gate for the whole drag; leaving it null makes the gate
+    // fall back to the item-rect measurement instead.
+    const startRect = target.getBoundingClientRect()
+    this.html5GrabOrigin =
+      Number.isFinite(e.clientX) &&
+      Number.isFinite(e.clientY) &&
+      (e.clientX !== 0 || e.clientY !== 0)
+        ? {
+            grabX: e.clientX - startRect.left,
+            grabY: e.clientY - startRect.top,
+            width: startRect.width,
+            height: startRect.height,
+          }
+        : null
+
     // Register with global drag state using HTML5 drag API as ID
     const dragId = 'html5-drag'
     globalDragState.startDrag(
@@ -536,6 +564,45 @@ export class DragManager implements DragManagerInterface {
 
     // Normal mode: swap when overlap exceeds threshold
     return overlap >= threshold
+  }
+
+  /**
+   * Moving rect for the swap-threshold gate during a native HTML5 drag
+   * (#130). The dragged item keeps its original DOM slot until drop, so its
+   * own rect never overlaps a sibling (adjacent rects touch; the rest clamp
+   * to 0) — any `swapThreshold > 0` would fail the gate on every dragover,
+   * and `invertSwap` would swap on every hover. The ghost is no substitute:
+   * `onDragStart` sets it `display: none` (the browser draws its own drag
+   * image) and `updateGhostPosition` never runs on this pipeline, so its
+   * rect is zero-size and frozen. Instead, synthesize the rect the ghost
+   * would have: position = the event's clientX/Y minus the grab offset
+   * captured at dragstart, size = the item's rect at dragstart.
+   *
+   * Returns null (caller falls back to the old measurement) when the active
+   * drag isn't the HTML5 one or the event has no usable coordinates —
+   * (0, 0) means "synthetic event", same convention as
+   * `controlledInsertAfter`.
+   */
+  private html5DragRect(e: Event, activeDrag: ActiveDrag): DOMRect | null {
+    if (activeDrag.id !== 'html5-drag') return null
+    // TS private access across instances of the same class is permitted by
+    // design; the origin lives on the SOURCE manager, `this` may be a target.
+    const origin = (activeDrag.fromDragManager as DragManager).html5GrabOrigin
+    if (!origin) return null
+    const pt = e as MouseEvent
+    if (
+      !Number.isFinite(pt.clientX) ||
+      !Number.isFinite(pt.clientY) ||
+      (pt.clientX === 0 && pt.clientY === 0)
+    ) {
+      return null
+    }
+    return new DOMRect(
+      pt.clientX - origin.grabX,
+      pt.clientY - origin.grabY,
+      origin.width,
+      origin.height
+    )
   }
 
   /**
@@ -761,10 +828,15 @@ export class DragManager implements DragManagerInterface {
     if (overIdx === -1) return
     const oldIdx = targetZone.getControlledIndex(placeholder, items)
 
-    // Overlap gate: the ghost is the moving visual in controlled mode.
-    const movingRect = (
-      sourceManager.ghostManager.getGhostElement() ?? placeholder
-    ).getBoundingClientRect()
+    // Overlap gate. Pointer pipeline: the cursor-following ghost is the
+    // moving visual. HTML5 pipeline: that ghost is `display: none` (browser
+    // draws its own drag image) and never repositioned, so measure the rect
+    // synthesized from the drag cursor instead (#130).
+    const movingRect =
+      this.html5DragRect(e, activeDrag) ??
+      (
+        sourceManager.ghostManager.getGhostElement() ?? placeholder
+      ).getBoundingClientRect()
     const overRect = over.getBoundingClientRect()
     const naturalAfter = this.controlledInsertAfter(
       e,
@@ -990,28 +1062,13 @@ export class DragManager implements DragManagerInterface {
     const dragIndex = this.zone.getIndex(dragItem)
     if (overIndex === dragIndex) return
 
-    // Check swap threshold if configured.
-    //
-    // KNOWN GAP — `swapThreshold` does not merely misbehave here, it disables
-    // same-zone sorting outright. Within a zone `dragItem` keeps its original
-    // slot for the whole drag (the reorder is committed on drop — see the
-    // commented-out `zone.move` below), so against a sibling `over` the
-    // overlap is 0: adjacent rects touch, non-adjacent ones clamp to 0. Every
-    // `swapThreshold > 0` therefore fails this gate on every dragover, the
-    // placeholder never moves, and sort/update/change never fire. `invertSwap`
-    // has the mirror bug — `0 < threshold` is always true, so the threshold is
-    // bypassed entirely. (`dragItem` IS moved on cross-zone entry above, but
-    // it lands as a parked sibling in the new zone, so the overlap is still 0.)
-    //
-    // The pointer pipeline had the same bug and fixed it by measuring the
-    // cursor-following ghost (#121). That is NOT available here: `onDragStart`
-    // sets the ghost to `display: none` because the browser draws its own drag
-    // image, and `updateGhostPosition` is only ever called from the pointer
-    // path — so its rect is both zero-size and frozen. The placeholder is no
-    // use either; it is only repositioned AFTER this gate passes. A real fix
-    // needs a rect synthesized from the DragEvent's clientX/clientY. Do NOT
-    // "restore parity" by copying the pointer pipeline's ghost lookup here.
-    const dragRect = dragItem.getBoundingClientRect()
+    // Swap-threshold gate (#130). `dragItem` keeps its DOM slot until drop,
+    // so its own rect never overlaps a sibling — gate on a rect synthesized
+    // from the drag cursor instead (see `html5DragRect`). The item-rect
+    // fallback only applies to synthetic events without coordinates, where
+    // the gate degrades to its pre-fix behavior.
+    const dragRect =
+      this.html5DragRect(e, activeDrag) ?? dragItem.getBoundingClientRect()
     const targetRect = over.getBoundingClientRect()
 
     if (!this.shouldSwap(dragRect, targetRect, this.zone.getItems())) {
@@ -1190,6 +1247,7 @@ export class DragManager implements DragManagerInterface {
 
     globalDragState.endDrag(dragId)
     this.startIndex = -1
+    this.html5GrabOrigin = null
   }
 
   private onDragEnter = (e: DragEvent): void => {

--- a/tests/unit/swap-threshold-html5.spec.ts
+++ b/tests/unit/swap-threshold-html5.spec.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import { Sortable } from '../../src/index'
+
+/**
+ * Unit coverage for #130 — `swapThreshold` on the native HTML5 pipeline.
+ *
+ * The dragged item keeps its DOM slot until drop, so its own rect never
+ * overlaps a sibling: any `swapThreshold > 0` used to fail the dragover gate
+ * unconditionally (sorting frozen), and `invertSwap` had the mirror bug
+ * (every hover swapped). The fix gates on a rect synthesized from the drag
+ * cursor: position = clientX/Y minus the grab offset captured at dragstart,
+ * size = the item's rect at dragstart.
+ *
+ * Driven through HTML5 `dragstart` / `dragover` — jsdom dispatches them
+ * synchronously (same technique as `on-move.spec.ts`; Playwright's synthetic
+ * mouse can only reach the pointer pipeline). jsdom's layout reports
+ * zero-size boxes, so `getBoundingClientRect` is stubbed on the items.
+ */
+
+function stubRect(
+  el: HTMLElement,
+  { top = 0, left = 0, width = 100, height = 60 } = {}
+): void {
+  el.getBoundingClientRect = () =>
+    ({
+      top,
+      left,
+      width,
+      height,
+      right: left + width,
+      bottom: top + height,
+      x: left,
+      y: top,
+      toJSON: () => ({}),
+    }) as DOMRect
+}
+
+interface Layout {
+  horizontal?: boolean
+}
+
+const lists: HTMLElement[] = []
+const sortables: Sortable[] = []
+
+function track(s: Sortable): Sortable {
+  sortables.push(s)
+  return s
+}
+
+/** 4 items, stacked vertically (60px tall) or in a row (100px wide). */
+function makeList({ horizontal = false }: Layout = {}): {
+  container: HTMLElement
+  items: HTMLElement[]
+} {
+  const container = document.createElement('div')
+  const items: HTMLElement[] = []
+  for (let i = 0; i < 4; i++) {
+    const el = document.createElement('div')
+    el.className = 'sortable-item'
+    el.dataset.id = `item-${i}`
+    el.textContent = `Item ${i}`
+    if (horizontal) {
+      stubRect(el, { left: i * 100, top: 0 })
+    } else {
+      stubRect(el, { top: i * 60, left: 0 })
+    }
+    container.appendChild(el)
+    items.push(el)
+  }
+  document.body.appendChild(container)
+  lists.push(container)
+  return { container, items }
+}
+
+// Some jsdom builds lack the DragEvent constructor — fall back to a plain
+// MouseEvent cast (same pattern as on-move.spec.ts). MouseEvent carries the
+// clientX/clientY the synthesized-rect gate consumes.
+function makeDragEvent(
+  type: string,
+  clientX: number,
+  clientY: number
+): DragEvent {
+  const init = { bubbles: true, cancelable: true, clientX, clientY }
+  try {
+    return new DragEvent(type, init)
+  } catch {
+    return new MouseEvent(type, init) as unknown as DragEvent
+  }
+}
+
+function drag(el: HTMLElement, clientX: number, clientY: number): void {
+  el.dispatchEvent(makeDragEvent('dragstart', clientX, clientY))
+}
+
+function over(el: HTMLElement, clientX: number, clientY: number): void {
+  el.dispatchEvent(makeDragEvent('dragover', clientX, clientY))
+}
+
+describe('swapThreshold on the HTML5 drag pipeline (#130)', () => {
+  afterEach(() => {
+    // Finish any in-flight drag so globalDragState doesn't carry a stale
+    // 'html5-drag' entry into the next test (dragend bubbles to the zone).
+    for (const list of lists) {
+      list.dispatchEvent(
+        new Event('dragend', { bubbles: true, cancelable: true })
+      )
+    }
+    lists.length = 0
+    for (const s of sortables) s.destroy()
+    sortables.length = 0
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  // Vertical geometry, dragging item-0 (grabbed at its center: 50, 30, so
+  // the synthesized rect is [clientY - 30, clientY + 30] on the y-axis)
+  // over item-2 which spans y 120..180.
+
+  it('threshold 0.5: pointer well inside the target allows the swap', () => {
+    const { container, items } = makeList()
+    const onSort = vi.fn()
+    const onUpdate = vi.fn()
+    track(
+      new Sortable(container, {
+        animation: 0,
+        swapThreshold: 0.5,
+        onSort,
+        onUpdate,
+      })
+    )
+
+    drag(items[0], 50, 30)
+    // Synthesized rect [120, 180] — overlap with item-2 is 1.0 >= 0.5.
+    over(items[2], 50, 150)
+
+    expect(onSort).toHaveBeenCalledTimes(1)
+    expect(onUpdate).toHaveBeenCalledTimes(1)
+  })
+
+  it('threshold 0.5: pointer barely overlapping the target blocks the swap', () => {
+    const { container, items } = makeList()
+    const onSort = vi.fn()
+    track(new Sortable(container, { animation: 0, swapThreshold: 0.5, onSort }))
+
+    drag(items[0], 50, 30)
+    // Synthesized rect [70, 130] — overlap with item-2 is 10/60 ≈ 0.17 < 0.5.
+    over(items[2], 50, 100)
+
+    expect(onSort).not.toHaveBeenCalled()
+  })
+
+  it('threshold unset: always swaps (unchanged legacy behavior)', () => {
+    const { container, items } = makeList()
+    const onSort = vi.fn()
+    track(new Sortable(container, { animation: 0, onSort }))
+
+    drag(items[0], 50, 30)
+    // Barely-overlapping cursor position — irrelevant without a threshold.
+    over(items[2], 50, 100)
+
+    expect(onSort).toHaveBeenCalledTimes(1)
+  })
+
+  it('invertSwap: swaps only when overlap is BELOW the threshold', () => {
+    const { container, items } = makeList()
+    const onSort = vi.fn()
+    track(
+      new Sortable(container, {
+        animation: 0,
+        swapThreshold: 0.5,
+        invertSwap: true,
+        onSort,
+      })
+    )
+
+    drag(items[0], 50, 30)
+
+    // Fully over the target (overlap 1.0 >= 0.5) — inverted mode blocks.
+    // Before the fix the measured overlap was always 0, so EVERY hover
+    // swapped in inverted mode; this asserts the mirror bug is gone.
+    over(items[2], 50, 150)
+    expect(onSort).not.toHaveBeenCalled()
+
+    // Barely overlapping (0.17 < 0.5) — inverted mode swaps.
+    over(items[2], 50, 100)
+    expect(onSort).toHaveBeenCalledTimes(1)
+  })
+
+  it('threshold 0.5 on a horizontal layout gates along the x-axis', () => {
+    const { container, items } = makeList({ horizontal: true })
+    const onSort = vi.fn()
+    track(
+      new Sortable(container, {
+        animation: 0,
+        direction: 'horizontal',
+        swapThreshold: 0.5,
+        onSort,
+      })
+    )
+
+    // Grab item-0 at its center (50, 30); item-2 spans x 200..300.
+    drag(items[0], 50, 30)
+
+    // Synthesized rect [120, 220] — overlap 20/100 = 0.2 < 0.5 → blocked.
+    over(items[2], 170, 30)
+    expect(onSort).not.toHaveBeenCalled()
+
+    // Synthesized rect [200, 300] — overlap 1.0 >= 0.5 → allowed.
+    over(items[2], 250, 30)
+    expect(onSort).toHaveBeenCalledTimes(1)
+  })
+
+  it('coordless dragstart leaves the origin unset — gate falls back, never NaN-freezes', () => {
+    const { container, items } = makeList()
+    const onSort = vi.fn()
+    track(
+      new Sortable(container, {
+        animation: 0,
+        swapThreshold: 0.5,
+        invertSwap: true,
+        onSort,
+      })
+    )
+
+    // Plain Event: no MouseEvent init, so clientX/clientY are undefined. An
+    // unguarded capture would store a NaN grab origin, making every later
+    // overlap NaN — NaN fails BOTH `>=` and `<`, freezing even inverted
+    // mode despite the dragovers carrying good coordinates. Guarded, the
+    // origin stays null and the gate falls back to the parked item's rect
+    // (overlap 0), so inverted mode still swaps — the pre-fix fallback
+    // behavior, not a NaN freeze.
+    items[0].dispatchEvent(
+      new Event('dragstart', { bubbles: true, cancelable: true })
+    )
+    over(items[2], 50, 150)
+
+    expect(onSort).toHaveBeenCalledTimes(1)
+  })
+
+  it('controlled mode: the synthesized rect drives the handleControlledMove gate', () => {
+    const { container, items } = makeList()
+    const onSort = vi.fn()
+    track(
+      new Sortable(container, {
+        animation: 0,
+        controlled: true,
+        swapThreshold: 0.5,
+        onSort,
+      })
+    )
+
+    drag(items[0], 50, 30)
+
+    // Barely overlapping item-2 (0.17 < 0.5) — blocked, no reorder.
+    over(items[2], 50, 100)
+    expect(onSort).not.toHaveBeenCalled()
+
+    // Fully over item-2 (overlap 1.0 >= 0.5) — the controlled gate passes
+    // and the placeholder reorder emits sort. Before the fix this path
+    // measured the browser-hidden ghost (zero-size rect → overlap 0).
+    over(items[2], 50, 150)
+    expect(onSort).toHaveBeenCalledTimes(1)
+  })
+
+  it('cross-zone: target zone reads the grab origin from the source manager', () => {
+    const { container: a, items: aItems } = makeList()
+    const { container: b, items: bItems } = makeList()
+    const onSort = vi.fn()
+    track(new Sortable(a, { animation: 0, group: 'shared' }))
+    track(
+      new Sortable(b, {
+        animation: 0,
+        group: 'shared',
+        swapThreshold: 0.5,
+        onSort,
+      })
+    )
+
+    // Grab a's item-0 at its center; b's item-1 spans y 60..120. The origin
+    // is captured on a's manager; b's dragover listener must reach it via
+    // activeDrag.fromDragManager for its own threshold gate.
+    drag(aItems[0], 50, 30)
+
+    // First dragover parks the item in b (cross-zone entry — not gated),
+    // but the barely-overlapping cursor (rect [10, 70], overlap 10/60)
+    // blocks the same-zone reorder, so no sort fires.
+    over(bItems[1], 50, 40)
+    expect(onSort).not.toHaveBeenCalled()
+
+    // Cursor centered on b's item-1 (overlap 1.0 >= 0.5) — gate passes.
+    over(bItems[1], 50, 90)
+    expect(onSort).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
Closes #130. Completes for the native HTML5 pipeline what #129 did for the pointer pipeline.

In native HTML5 mode the dragged item keeps its DOM slot until drop, so its own rect never overlaps a sibling — any `swapThreshold > 0` failed the dragover gate on **every** event (same-zone sorting completely frozen: placeholder never moves, `sort`/`update`/`change` never fire), and `invertSwap` had the mirror bug (threshold bypassed, every hover swaps). The ghost can't be measured either: it's `display: none` in this mode (browser draws its own drag image) and never repositioned — the KNOWN GAP comment documented all this.

Fix:
- `onDragStart` captures the grab offset and item size (only from finite, non-(0,0) coordinates — a coordless synthetic `dragstart` leaves it null rather than poisoning the drag with NaN).
- New `html5DragRect()` synthesizes the moving rect from the dragover's `clientX/clientY` minus the grab offset; both the uncontrolled `onDragOver` gate and the controlled `handleControlledMove` gate (which measured the hidden ghost — same defect) prefer it, falling back to the old measurement for non-HTML5 drags or coordless events. Pointer pipeline untouched (guarded on the active drag id).
- Origin cleared in `onDragEnd`.

Tests: new `swap-threshold-html5.spec.ts` (8 tests) driving real `dragstart`/`dragover` with stubbed rects — threshold blocks/allows by pointer position, unset unchanged, `invertSwap` fixed, horizontal axis, coordless-dragstart fallback, controlled-mode gate, cross-zone origin read through the source manager. Key tests mutation-checked (each fails with its hunk reverted). Playwright can't drive native HTML5 drag (documented in `on-move.spec.ts`), hence unit-level coverage. Full unit suite 428/428; `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ND26MSiGy1BMPoh5o6eWmt

<!-- claude-session:70ee3204-014c-4824-8272-df3ca0d48c38 -->
🔖 **Claude agent:** resortable-9c  
session id: `70ee3204-014c-4824-8272-df3ca0d48c38`