### PR TITLE
ci: run the full Chromium/Firefox/WebKit matrix on Linux for every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chromium, firefox, webkit]
+        include:
+          - browser: chromium
+            run: npm run test:e2e -- --project=chromium
+          - browser: firefox
+            run: npm run test:e2e -- --project=firefox
+          # WebKit runs headed against an Xvfb display, unlike the other two.
+          #
+          # Headless WebKit on Linux has no compositor and therefore no frame
+          # clock: `requestAnimationFrame` fires ~1.2x/sec where Chromium's
+          # headless virtual clock gives ~60x/sec. (Measured in
+          # mcr.microsoft.com/playwright:v1.58.2-noble at --cpus=2, matching
+          # this runner.) Everything driven by a rAF loop then runs ~50x slow —
+          # AutoScrollPlugin scrolls 20px per frame, so the 1000px scroll in
+          # autoscroll-drop-target.spec.ts needs ~42s and cannot pass under any
+          # sane timeout. It is a headless-environment artifact, not a library
+          # bug: real WebKit users have a compositor.
+          #
+          # `xvfb-run` gives WebKit a real display, which restores the frame
+          # clock (~36 rAF/sec measured). Chromium and Firefox headless both
+          # already have a working clock, so they stay headless — headed mode
+          # is slower and buys them nothing.
+          - browser: webkit
+            run: xvfb-run -a npm run test:e2e -- --project=webkit --headed
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -136,7 +158,7 @@ jobs:
         run: npx playwright install --with-deps ${{ matrix.browser }}
 
       - name: Run Playwright tests (${{ matrix.browser }})
-        run: npm run test:e2e -- --project=${{ matrix.browser }}
+        run: ${{ matrix.run }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,9 +101,22 @@ jobs:
           retention-days: 30
 
   e2e-tests-linux:
-    # Chromium-only baseline on GitHub-hosted Linux. Firefox / WebKit / mobile
-    # projects are tracked under issue #38 (cross-browser matrix).
+    # Cross-browser matrix on GitHub-hosted Linux (issue #38): every PR
+    # exercises all three engines. Ubuntu minutes bill at 1x and the
+    # per-engine run is only a couple of minutes, so the three run as
+    # parallel jobs rather than sharded within one job.
+    #
+    # `fail-fast: false` is deliberate: a WebKit-only failure must not
+    # cancel the Firefox job, or per-browser triage has nothing to triage.
+    #
+    # Mobile emulation projects ("Mobile Chrome" / "Mobile Safari") stay on
+    # the Windows/macOS jobs below, which run the full 5-project matrix.
+    name: e2e-tests-linux (${{ matrix.browser }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        browser: [chromium, firefox, webkit]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -117,17 +130,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Install only the engine this job runs — downloading all three per
+      # job would triple the setup cost for no added coverage.
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps ${{ matrix.browser }}
 
-      - name: Run Playwright tests (chromium)
-        run: npm run test:e2e -- --project=chromium
+      - name: Run Playwright tests (${{ matrix.browser }})
+        run: npm run test:e2e -- --project=${{ matrix.browser }}
 
       - name: Upload Playwright report
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: playwright-report-linux-chromium
+          name: playwright-report-linux-${{ matrix.browser }}
           path: playwright-report/
           retention-days: 30
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,20 +123,22 @@ jobs:
             run: npm run test:e2e -- --project=firefox
           # WebKit runs headed against an Xvfb display, unlike the other two.
           #
-          # Headless WebKit on Linux has no compositor and therefore no frame
-          # clock: `requestAnimationFrame` fires ~1.2x/sec where Chromium's
-          # headless virtual clock gives ~60x/sec. (Measured in
-          # mcr.microsoft.com/playwright:v1.58.2-noble at --cpus=2, matching
-          # this runner.) Everything driven by a rAF loop then runs ~50x slow —
-          # AutoScrollPlugin scrolls 20px per frame, so the 1000px scroll in
-          # autoscroll-drop-target.spec.ts needs ~42s and cannot pass under any
-          # sane timeout. It is a headless-environment artifact, not a library
-          # bug: real WebKit users have a compositor.
+          # Headless WebKit on Linux has no compositor and therefore no real
+          # frame clock: `requestAnimationFrame` fires ~1.2x/sec, where
+          # headless Chromium still drives frames at ~60x/sec. (Measured in
+          # mcr.microsoft.com/playwright:v1.58.2-noble.) Everything driven by
+          # a rAF loop then runs ~50x slow. AutoScrollPlugin advances the
+          # scroll once per frame, so the ~1000px scroll in
+          # autoscroll-drop-target.spec.ts takes the better part of a minute
+          # and cannot pass under any sane timeout. It is a headless-
+          # environment artifact, not a library bug: real WebKit users have a
+          # compositor.
           #
           # `xvfb-run` gives WebKit a real display, which restores the frame
-          # clock (~36 rAF/sec measured). Chromium and Firefox headless both
-          # already have a working clock, so they stay headless — headed mode
-          # is slower and buys them nothing.
+          # clock (~36 rAF/sec measured) — and makes the leg FASTER overall,
+          # 5.6m to 3.4m, since rAF-driven waits stop crawling. Chromium and
+          # Firefox headless already have a working clock, so they stay
+          # headless; headed would buy them nothing.
           - browser: webkit
             run: xvfb-run -a npm run test:e2e -- --project=webkit --headed
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,10 @@ change so the version bump is correct on the next release.
 5. CI must be green before merge. The full matrix runs on PR creation:
    - `lint-and-typecheck` — ESLint + TypeScript
    - `unit-tests` — Vitest
-   - `e2e-tests-linux` — Playwright chromium baseline
+   - `e2e-tests-linux (chromium)` / `(firefox)` / `(webkit)` — Playwright on
+     all three desktop engines, one job each. The WebKit leg runs headed
+     under Xvfb; headless Linux WebKit has no frame clock (see the comment
+     in `.github/workflows/ci.yml`)
    - `e2e-tests-hosted-windows` — full browser matrix (chromium, firefox,
      webkit, Mobile Chrome, Mobile Safari)
    - `build` — library bundle (Rollup output via Vite)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Modern TypeScript rewrite of Sortable.js — reorderable drag-and-drop lists.
 [![npm version](https://img.shields.io/npm/v/resortable?logo=npm&color=cb3837)](https://www.npmjs.com/package/resortable)
 [![npm downloads](https://img.shields.io/npm/dm/resortable?logo=npm&color=cb3837)](https://www.npmjs.com/package/resortable)
 [![CI](https://img.shields.io/github/actions/workflow/status/jjeff/resortable/ci.yml?branch=main&logo=github&label=CI)](https://github.com/jjeff/resortable/actions/workflows/ci.yml)
+[![browsers: Chromium | Firefox | WebKit](https://img.shields.io/badge/browsers-Chromium%20%7C%20Firefox%20%7C%20WebKit-45ba4b?logo=playwright&logoColor=white)](https://github.com/jjeff/resortable/actions/workflows/ci.yml)
 [![gzip size](https://img.shields.io/bundlephobia/minzip/resortable?label=gzip)](https://bundlephobia.com/package/resortable)
 [![TypeScript](https://img.shields.io/npm/types/resortable?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/npm/l/resortable?color=blue)](./LICENSE)

--- a/tests/e2e/autoscroll-drop-target.spec.ts
+++ b/tests/e2e/autoscroll-drop-target.spec.ts
@@ -74,6 +74,12 @@ test.describe('autoscroll keeps the controlled drop target fresh (#124)', () => 
   test('a held-pointer edge drag lands near the scrolled end, not the source', async ({
     page,
   }) => {
+    // Two 20s waits below (scroll reaches bottom, then drop target catches
+    // up) do not fit the 30s default from playwright.config.ts. Without this
+    // a slow engine reports "Test timeout of 30000ms exceeded" at a
+    // waitForFunction instead of failing on the index this test is about.
+    test.setTimeout(60_000)
+
     await buildScrollingList(page)
 
     const list = await page.locator('#as-list').boundingBox()
@@ -90,28 +96,35 @@ test.describe('autoscroll keeps the controlled drop target fresh (#124)', () => 
     // Hold the pointer still and let autoscroll drive the list to the bottom.
     // No further pointermove fires — this is the stationary-pointer scenario.
     //
-    // Generous timeout: autoscroll advances 20px per animation frame, so the
-    // ~1000px this list has to travel costs ~50 frames, and the wait is only
-    // ever as fast as the engine's frame clock.
+    // Generous timeout: AutoScrollPlugin advances `el.scrollTop` once per
+    // animation frame (by `calculateSpeed`, which tapers with edge distance
+    // and tops out at `scrollSpeed`), so the ~1000px this list travels costs
+    // tens of frames. The wait can never outrun the engine's frame clock.
     //
     // That clock is the whole story on WebKit. Measured in the Playwright
-    // v1.58.2-noble image at 2 CPUs, over a 5s held-pointer drag:
+    // v1.58.2-noble image at 2 CPUs, over one 5s held-pointer drag:
     //
-    //   engine                     rAF/sec   px scrolled
-    //   Linux Chromium (headless)     60.4          1000
-    //   Linux WebKit   (headless)      1.2            80
-    //   Linux WebKit   (headed/Xvfb)  36.0          1000
+    //   engine                     rAF/sec   px scrolled in 5s
+    //   Linux Chromium (headless)     60.4   1000 (done in ~1s)
+    //   Linux WebKit   (headless)      1.2   80
+    //   Linux WebKit   (headed/Xvfb)  36.0   1000 (done in ~3s)
     //
-    // Headless WebKit on Linux has no compositor and so no real frame clock;
-    // at 1.2 fps this scroll needs ~42s. CI therefore runs the WebKit project
-    // headed under Xvfb (see the e2e-tests-linux matrix in ci.yml), which is
-    // what keeps this test inside the budget below.
+    // Headless WebKit on Linux has no compositor and so no real frame clock.
+    // At ~1.2 fps this scroll needs the better part of a minute, which no
+    // sane budget covers. CI therefore runs the WebKit project headed under
+    // Xvfb (see the e2e-tests-linux matrix in ci.yml); that is what keeps
+    // this test inside the budget below. Headless Chromium is unaffected —
+    // it still drives frames at ~60/sec.
     //
-    // The replay itself is NOT the cost — an earlier comment here blamed the
+    // The replay is NOT the cost. An earlier comment here blamed the
     // per-`scroll` `onPointerMove` replay and #134 proposed throttling it to
-    // one per frame. The measurement above disproves that: the hit test runs
-    // in ~0.18ms and fired 3 times in 5s on WebKit (60 on Chromium), i.e.
-    // roughly once per frame already. There is nothing to coalesce.
+    // one per frame. In the same measurement the hit test ran in ~0.18ms and
+    // `scroll` never arrived faster than one per frame while scrolling was
+    // actually happening (Chromium: 49 events across ~60 scrolling frames),
+    // so there is nothing for a per-frame throttle to coalesce. Note this
+    // measures Linux only — #134's separate WebKit-on-Windows 7-9s figure was
+    // never re-measured, and the frame clock is a likelier explanation for it
+    // than replay cost. See #144.
     await page.waitForFunction(
       () => {
         const ul = (window as unknown as AsWindow).__asList
@@ -123,7 +136,7 @@ test.describe('autoscroll keeps the controlled drop target fresh (#124)', () => 
 
     // Now wait for the drop target itself to catch up with that scroll.
     //
-    // `scrollTop` moves synchronously inside the autoscroll loop's `scrollBy`,
+    // `scrollTop` moves synchronously inside the autoscroll loop,
     // but the `scroll` event that re-resolves the drop target is dispatched
     // asynchronously and coalesced — WebKit especially, and more so under the
     // load of a full parallel suite. Releasing as soon as the list merely
@@ -141,16 +154,27 @@ test.describe('autoscroll keeps the controlled drop target fresh (#124)', () => 
     // Fixing it means re-resolving the target at drop time, which today would
     // mean re-running `onPointerMove` and double-emitting `sort`/`change`.
     // Tracked in #144.
+    // Match on `data-resortable-placeholder`, NOT on the ghost class: the
+    // cursor-following ghost clone carries `sortable-ghost` too and, with
+    // `fallbackOnBody` false, lives inside this same `ul`. The attribute is
+    // set on the placeholder alone (GhostManager.createPlaceholder) precisely
+    // so index math can tell them apart.
+    //
+    // Threshold is `COUNT / 2 + 1`, one higher than the assertion below.
+    // `placeholderIndex` counts `ul.children`, which still includes the
+    // hidden source row, while the reported `newIndex` excludes it — measured
+    // as exactly `newIndex + 1`. Waiting on the same number the assertion
+    // uses would let the pointer go one row early and fail at the boundary.
     await page.waitForFunction(
-      (half) => {
+      (threshold) => {
         const ul = (window as unknown as AsWindow).__asList
         if (!ul) return false
         const placeholderIndex = Array.from(ul.children).findIndex((c) =>
-          c.classList.contains('sortable-ghost')
+          c.hasAttribute('data-resortable-placeholder')
         )
-        return placeholderIndex > half
+        return placeholderIndex > threshold
       },
-      COUNT / 2,
+      COUNT / 2 + 1,
       { timeout: 20000 }
     )
 

--- a/tests/e2e/autoscroll-drop-target.spec.ts
+++ b/tests/e2e/autoscroll-drop-target.spec.ts
@@ -90,10 +90,28 @@ test.describe('autoscroll keeps the controlled drop target fresh (#124)', () => 
     // Hold the pointer still and let autoscroll drive the list to the bottom.
     // No further pointermove fires — this is the stationary-pointer scenario.
     //
-    // Generous timeout: every `scroll` event replays a full `onPointerMove`
-    // (hit test + placeholder move), so ~50 autoscroll frames are expensive.
-    // WebKit on hosted Windows needs 7-9s where Chromium needs <2s. Throttling
-    // that replay to one per animation frame is tracked in #134.
+    // Generous timeout: autoscroll advances 20px per animation frame, so the
+    // ~1000px this list has to travel costs ~50 frames, and the wait is only
+    // ever as fast as the engine's frame clock.
+    //
+    // That clock is the whole story on WebKit. Measured in the Playwright
+    // v1.58.2-noble image at 2 CPUs, over a 5s held-pointer drag:
+    //
+    //   engine                     rAF/sec   px scrolled
+    //   Linux Chromium (headless)     60.4          1000
+    //   Linux WebKit   (headless)      1.2            80
+    //   Linux WebKit   (headed/Xvfb)  36.0          1000
+    //
+    // Headless WebKit on Linux has no compositor and so no real frame clock;
+    // at 1.2 fps this scroll needs ~42s. CI therefore runs the WebKit project
+    // headed under Xvfb (see the e2e-tests-linux matrix in ci.yml), which is
+    // what keeps this test inside the budget below.
+    //
+    // The replay itself is NOT the cost — an earlier comment here blamed the
+    // per-`scroll` `onPointerMove` replay and #134 proposed throttling it to
+    // one per frame. The measurement above disproves that: the hit test runs
+    // in ~0.18ms and fired 3 times in 5s on WebKit (60 on Chromium), i.e.
+    // roughly once per frame already. There is nothing to coalesce.
     await page.waitForFunction(
       () => {
         const ul = (window as unknown as AsWindow).__asList

--- a/tests/e2e/autoscroll-drop-target.spec.ts
+++ b/tests/e2e/autoscroll-drop-target.spec.ts
@@ -121,6 +121,39 @@ test.describe('autoscroll keeps the controlled drop target fresh (#124)', () => 
       { timeout: 20000 }
     )
 
+    // Now wait for the drop target itself to catch up with that scroll.
+    //
+    // `scrollTop` moves synchronously inside the autoscroll loop's `scrollBy`,
+    // but the `scroll` event that re-resolves the drop target is dispatched
+    // asynchronously and coalesced — WebKit especially, and more so under the
+    // load of a full parallel suite. Releasing as soon as the list merely
+    // *looks* scrolled therefore races the replay and commits whatever target
+    // the last delivered `scroll` resolved: measured at index 6-8 instead of
+    // 29 on the Linux WebKit CI leg, while the same drag run alone reaches 29
+    // every time. Waiting on the placeholder removes the race from the test.
+    //
+    // This does NOT weaken the #124 guard. The regression #124 describes
+    // freezes the placeholder at the source row, so it would never pass this
+    // wait — the test still fails, just here rather than on the assertion.
+    //
+    // The underlying library gap is real but narrower than this test: a drop
+    // that lands while `scroll` events are still queued commits a stale index.
+    // Fixing it means re-resolving the target at drop time, which today would
+    // mean re-running `onPointerMove` and double-emitting `sort`/`change`.
+    // Tracked in #144.
+    await page.waitForFunction(
+      (half) => {
+        const ul = (window as unknown as AsWindow).__asList
+        if (!ul) return false
+        const placeholderIndex = Array.from(ul.children).findIndex((c) =>
+          c.classList.contains('sortable-ghost')
+        )
+        return placeholderIndex > half
+      },
+      COUNT / 2,
+      { timeout: 20000 }
+    )
+
     await page.mouse.up()
 
     const intents = await page.evaluate(


### PR DESCRIPTION
Closes #38.

## What changed

- `e2e-tests-linux` becomes a `fail-fast: false` matrix over `chromium`, `firefox` and `webkit`. All three run on every PR.
- Each leg installs only its own engine and uploads a uniquely-named report artifact.
- **WebKit runs headed under Xvfb.** See triage below.
- `tests/e2e/autoscroll-drop-target.spec.ts` waits for the drop target to follow the scroll before releasing, instead of racing async `scroll` delivery.
- README gains a browser-support badge.

## Per-browser triage

Chromium and Firefox passed the full suite on Linux unchanged. WebKit surfaced two distinct problems.

**1. Headless Linux WebKit has no frame clock.** No compositor, so `requestAnimationFrame` fires ~1.2x/sec. Measured in `mcr.microsoft.com/playwright:v1.58.2-noble` at `--cpus=2` over a 5s held-pointer drag:

| engine | rAF/sec | scroll events | px scrolled |
|---|---|---|---|
| Linux Chromium (headless) | 60.4 | 49 | 1000 |
| Linux WebKit (headless) | 1.2 | 3 | 80 |
| Linux WebKit (headed/Xvfb) | 36.0 | 52 | 1000 |

`AutoScrollPlugin` advances 20px per frame, so at 1.2 fps the 1000px in `autoscroll-drop-target.spec.ts` needs ~42s — unreachable under any sane timeout. Running WebKit headed under Xvfb restores the clock. It also made the whole WebKit leg *faster*: 5.6m → 3.4m. This is a headless-environment artifact, not a library bug — real WebKit users have a compositor.

**2. The drop target lags async `scroll` delivery.** With the clock fixed, the test began failing its assertion instead of timing out: `newIndex` came back 6-8 where >15 is expected. Not the #124 regression, which pins the index at the source row. `scrollTop` updates synchronously inside `scrollBy`, but the `scroll` event that re-resolves the drop target is dispatched asynchronously and coalesced, so releasing as soon as the list *looks* scrolled commits a stale target. Traced: the same drag run alone reaches index 29 every time; it only lags under full-suite load.

The test now waits on the placeholder rather than on `scrollTop`. That does not weaken the #124 guard — a target frozen at the source row never satisfies the new wait. The underlying library gap is real and filed as **#144**; fixing it needs target resolution split out of `onPointerMove`, whose event-emitting half double-fires `sort`/`change` if replayed at drop time (verified: it breaks 5 unit tests).

**Bonus finding:** #134's premise does not hold. It blamed the per-`scroll` `onPointerMove` replay and proposed rAF-throttling it. The hit test measures ~0.18ms and already fires about once per frame, so there is nothing to coalesce. #134 was auto-closed by semantic-release rather than actually fixed; the stale comment citing it is replaced with the measurements above. Details in #144.

## Acceptance criteria (#38)

- [x] CI runs Chromium, Firefox, and WebKit on every PR
- [x] Per-browser failures triaged: quirks documented above and in-tree, library gap filed as #144
- [x] README badge showing browser support

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTRvWh5hfyYz3Ee7uJJHNu