### PR TITLE
fix: report pullMode on the end event so duplicate drops reach onEnd consumers

### DIFF
--- a/src/core/GlobalDragState.ts
+++ b/src/core/GlobalDragState.ts
@@ -301,6 +301,18 @@ class GlobalDragStateManager {
         )
       : -1
 
+    // Same outcome-reporting contract as the controlled path: `end` carries
+    // `pullMode` so a consumer wired only to onEnd can tell a duplicate/clone
+    // drop from a move without also subscribing to clone/remove.
+    const endPullMode =
+      isDifferentZone && putTarget
+        ? activeDrag.pullMode === 'clone'
+          ? ('clone' as const)
+          : activeDrag.pullMode || true
+        : activeDrag.duplicate && activeDrag.clones?.[0]
+          ? ('clone' as const)
+          : undefined
+
     activeDrag.eventSystem.emit('end', {
       item: activeDrag.items[0],
       items: activeDrag.items,
@@ -308,6 +320,7 @@ class GlobalDragStateManager {
       to: putTarget?.zone || activeDrag.fromZone,
       oldIndex: activeDrag.startIndices[0],
       newIndex: finalIndex,
+      ...(endPullMode !== undefined && { pullMode: endPullMode }),
     })
 
     this.activeDrags.delete(dragId)
@@ -345,18 +358,25 @@ class GlobalDragStateManager {
       newIndexes,
     }
 
+    // `end` must report the drag's OUTCOME (`pullMode`, and for a same-zone
+    // duplicate the offset-adjusted indexes) — it is the one event the React
+    // adapter builds its SortIntent from, so a bare `base` here silently
+    // downgraded every controlled duplicate to a move.
+    let endEvent: typeof base & { pullMode?: boolean | 'clone' | 'move' } = base
+
     if (isDifferentZone) {
       const isClone =
         activeDrag.pullMode === 'clone' || activeDrag.duplicate === true
       const pullMode = isClone
         ? ('clone' as const)
         : activeDrag.pullMode || true
+      endEvent = { ...base, pullMode }
       if (isClone) {
         // No clone node exists in controlled mode — the event reports the
         // intent and the consumer's state insert IS the clone.
-        activeDrag.eventSystem.emit('clone', { ...base, pullMode })
+        activeDrag.eventSystem.emit('clone', endEvent)
       } else {
-        activeDrag.eventSystem.emit('remove', { ...base, pullMode })
+        activeDrag.eventSystem.emit('remove', endEvent)
       }
       // Fire add on the target's event system (skip if the placeholder
       // ended somewhere we never registered — shouldn't happen, but don't
@@ -366,7 +386,7 @@ class GlobalDragStateManager {
           ? putTarget.dragManager.events
           : null
       if (targetEvents && targetEvents !== activeDrag.eventSystem) {
-        targetEvents.emit('add', { ...base, pullMode })
+        targetEvents.emit('add', endEvent)
       }
     } else if (activeDrag.duplicate && pending) {
       // Same-zone controlled duplicate: no DOM to read from, so the copy's
@@ -392,6 +412,7 @@ class GlobalDragStateManager {
         newIndexes: duplicateNewIndexes,
         pullMode: 'clone' as const,
       }
+      endEvent = duplicateBase
       // No clone node exists in controlled mode.
       activeDrag.eventSystem.emit('clone', duplicateBase)
       activeDrag.eventSystem.emit('sort', duplicateBase)
@@ -400,7 +421,7 @@ class GlobalDragStateManager {
     }
 
     activeDrag.eventSystem.emit('unchoose', { ...base, newIndex: -1 })
-    activeDrag.eventSystem.emit('end', base)
+    activeDrag.eventSystem.emit('end', endEvent)
   }
 
   /** Check if a specific drag can be accepted by a group */

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -789,6 +789,10 @@ export interface SortableEvent {
    *
    * On a `clone` event fired by `duplicateKey`, `to === from` marks an
    * in-place (same-list) duplicate rather than a cross-zone copy.
+   *
+   * The `end` event reports the drag's outcome here too: `'clone'` for any
+   * duplicate/clone drop (same-list or cross-zone), the source's pull mode
+   * for a cross-zone move, and undefined for a plain same-list reorder.
    */
   pullMode?: boolean | 'clone' | 'move'
 

--- a/tests/unit/duplicate-key.spec.ts
+++ b/tests/unit/duplicate-key.spec.ts
@@ -103,12 +103,14 @@ describe('duplicateKey', () => {
   it('same-zone alt-drag duplicates: original stays put, copy lands at the drop slot', () => {
     const ul = makeList(4)
     const cloneSpy = vi.fn()
+    const endSpy = vi.fn()
     sortable = new Sortable(ul, {
       draggable: '.item',
       animation: 0,
       fallbackTolerance: 0,
       duplicateKey: 'alt',
       onClone: cloneSpy,
+      onEnd: endSpy,
     })
 
     const dragged = ul.children[0] as HTMLElement
@@ -142,17 +144,24 @@ describe('duplicateKey', () => {
     )
     expect(copy).toBeTruthy()
     expect(payload.clone).toBe(copy)
+
+    // `end` reports the outcome too — consumers wired only to onEnd (the
+    // React adapter) must be able to tell this was a duplicate.
+    expect(endSpy).toHaveBeenCalledTimes(1)
+    expect((endSpy.mock.calls[0][0] as SortableEvent).pullMode).toBe('clone')
   })
 
   it('same-zone drag without the modifier is a plain move (regression)', () => {
     const ul = makeList(4)
     const cloneSpy = vi.fn()
+    const endSpy = vi.fn()
     sortable = new Sortable(ul, {
       draggable: '.item',
       animation: 0,
       fallbackTolerance: 0,
       duplicateKey: 'alt',
       onClone: cloneSpy,
+      onEnd: endSpy,
     })
 
     const dragged = ul.children[0] as HTMLElement
@@ -165,6 +174,9 @@ describe('duplicateKey', () => {
 
     expect(ul.children.length).toBe(4)
     expect(cloneSpy).not.toHaveBeenCalled()
+    // Plain same-zone reorder: end carries no pullMode.
+    expect(endSpy).toHaveBeenCalledTimes(1)
+    expect((endSpy.mock.calls[0][0] as SortableEvent).pullMode).toBeUndefined()
   })
 
   it('arms duplicate mid-drag on a keydown alone, no pointermove required', () => {
@@ -298,6 +310,7 @@ describe('duplicateKey', () => {
   it('controlled mode same-zone duplicate: zero consumer-DOM mutation, offset-adjusted newIndex', () => {
     const ul = makeList(4)
     const cloneSpy = vi.fn()
+    const endSpy = vi.fn()
     sortable = new Sortable(ul, {
       controlled: true,
       draggable: '.item',
@@ -305,6 +318,7 @@ describe('duplicateKey', () => {
       fallbackTolerance: 0,
       duplicateKey: 'alt',
       onClone: cloneSpy,
+      onEnd: endSpy,
     })
 
     const idsBefore = Array.from(ul.children).map(
@@ -331,6 +345,15 @@ describe('duplicateKey', () => {
     // pending.index (2, hovering children[2]) + offset (1, since the drag's
     // own start index 0 sits <= 2 and so shifts the landing spot by one).
     expect(payload.newIndex).toBe(3)
+
+    // `end` carries the same outcome — controlled consumers (the React
+    // adapter) build their commit intent from this one event, so it must
+    // report pullMode AND the adjusted landing index, not the raw pending.
+    expect(endSpy).toHaveBeenCalledTimes(1)
+    const endPayload = endSpy.mock.calls[0][0] as SortableEvent
+    expect(endPayload.pullMode).toBe('clone')
+    expect(endPayload.newIndex).toBe(3)
+    expect(endPayload.newIndexes).toEqual([3])
   })
 
   it('duplicateKey unset: alt held has no effect (fully inert, plain move)', () => {

--- a/tests/unit/react/useSortable-duplicate.spec.tsx
+++ b/tests/unit/react/useSortable-duplicate.spec.tsx
@@ -1,0 +1,199 @@
+import { describe, it, expect, afterEach, vi } from 'vitest'
+import type { JSX } from 'react'
+import { render, cleanup, act } from '@testing-library/react'
+import { useSortable } from '../../../src/react/index'
+import type { SortIntent, UseSortableOptions } from '../../../src/react/index'
+
+/**
+ * `duplicateKey` through the React adapter. The adapter builds its SortIntent
+ * from the core `end` event, so these tests pin the contract that `end`
+ * carries the drag's outcome: `pullMode: 'clone'` (with the offset-adjusted
+ * landing index for a same-zone duplicate) — the exact signal a controlled
+ * consumer needs to insert a copy instead of committing a move. Regression
+ * coverage for the gap where `end` omitted `pullMode` and every alt-drag
+ * reached consumers as a plain move.
+ *
+ * Pointer pipeline + jsdom `document.elementFromPoint` stub, same technique
+ * as duplicate-key.spec.ts.
+ */
+
+interface HarnessProps {
+  options: UseSortableOptions
+  items: string[]
+}
+
+function Harness({ options, items }: HarnessProps): JSX.Element {
+  const api = useSortable<HTMLUListElement>(options)
+  return (
+    <ul ref={api.ref}>
+      {items.map((id) => (
+        <li key={id} data-id={id} className="sortable-item">
+          {id}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+interface Mods {
+  altKey?: boolean
+}
+
+// jsdom lacks the PointerEvent constructor in some CI configurations — fall
+// back to a plain MouseEvent cast, same pattern as duplicate-key.spec.ts.
+function mkPointer(type: string, pointerId = 1, mods: Mods = {}): PointerEvent {
+  try {
+    return new PointerEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      pointerId,
+      isPrimary: true,
+      button: 0,
+      ...mods,
+    })
+  } catch {
+    const ev = new MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      button: 0,
+      ...mods,
+    }) as unknown as PointerEvent
+    Object.defineProperties(ev, {
+      pointerId: { value: pointerId },
+      isPrimary: { value: true },
+    })
+    return ev
+  }
+}
+
+function pointerDrag(from: HTMLElement, over: HTMLElement, mods: Mods): void {
+  document.elementFromPoint = () => over
+  act(() => {
+    from.dispatchEvent(mkPointer('pointerdown', 7, mods))
+    document.dispatchEvent(mkPointer('pointermove', 7, mods))
+    document.dispatchEvent(mkPointer('pointerup', 7, mods))
+  })
+}
+
+afterEach(() => {
+  cleanup()
+  document.body.innerHTML = ''
+  vi.restoreAllMocks()
+  delete (document as unknown as { elementFromPoint?: unknown })
+    .elementFromPoint
+})
+
+describe('useSortable duplicateKey', () => {
+  it('same-zone alt-drag delivers a clone intent at the offset-adjusted index', () => {
+    const onSort = vi.fn<(intent: SortIntent) => void>()
+    const { container } = render(
+      <Harness
+        options={{
+          animation: 0,
+          fallbackTolerance: 0,
+          duplicateKey: 'alt',
+          onSort,
+        }}
+        items={['a', 'b', 'c', 'd']}
+      />
+    )
+    const list = container.querySelector('ul') as HTMLElement
+
+    pointerDrag(
+      list.children[0] as HTMLElement,
+      list.children[2] as HTMLElement,
+      { altKey: true }
+    )
+
+    expect(onSort).toHaveBeenCalledTimes(1)
+    const intent = onSort.mock.calls[0][0]
+    expect(intent.pullMode).toBe('clone')
+    expect(intent.dataIds).toEqual(['a'])
+    expect(intent.oldIndexes).toEqual([0])
+    // pending.index 2 (hovering children[2]) + offset 1: the drag's own start
+    // slot (0) sits at or before the drop point and the original never leaves
+    // the list, so the copy lands one past the hovered slot.
+    expect(intent.newIndexes).toEqual([3])
+    expect(intent.from).toBe(intent.to)
+    // Consumer DOM untouched — React still owns the order.
+    expect(
+      Array.from(list.children).map((el) => (el as HTMLElement).dataset.id)
+    ).toEqual(['a', 'b', 'c', 'd'])
+  })
+
+  it('cross-zone alt-drag delivers a clone intent into the target zone', () => {
+    const onSortA = vi.fn<(intent: SortIntent) => void>()
+    const onSortB = vi.fn<(intent: SortIntent) => void>()
+    const { container } = render(
+      <div>
+        <Harness
+          options={{
+            id: 'A',
+            group: 'shared',
+            animation: 0,
+            fallbackTolerance: 0,
+            duplicateKey: 'alt',
+            onSort: onSortA,
+          }}
+          items={['a', 'b', 'c']}
+        />
+        <Harness
+          options={{
+            id: 'B',
+            group: 'shared',
+            animation: 0,
+            fallbackTolerance: 0,
+            duplicateKey: 'alt',
+            onSort: onSortB,
+          }}
+          items={['x', 'y']}
+        />
+      </div>
+    )
+    const lists = container.querySelectorAll('ul')
+    const listA = lists[0] as HTMLElement
+    const listB = lists[1] as HTMLElement
+
+    pointerDrag(
+      listA.children[0] as HTMLElement,
+      listB.children[1] as HTMLElement,
+      { altKey: true }
+    )
+
+    // Intent fires on the SOURCE zone's hook, addressed to the target.
+    expect(onSortA).toHaveBeenCalledTimes(1)
+    expect(onSortB).not.toHaveBeenCalled()
+    const intent = onSortA.mock.calls[0][0]
+    expect(intent.pullMode).toBe('clone')
+    expect(intent.dataIds).toEqual(['a'])
+    expect(intent.fromId).toBe('A')
+    expect(intent.toId).toBe('B')
+  })
+
+  it('plain drag (no modifier) still delivers a move intent, pullMode undefined', () => {
+    const onSort = vi.fn<(intent: SortIntent) => void>()
+    const { container } = render(
+      <Harness
+        options={{
+          animation: 0,
+          fallbackTolerance: 0,
+          duplicateKey: 'alt',
+          onSort,
+        }}
+        items={['a', 'b', 'c', 'd']}
+      />
+    )
+    const list = container.querySelector('ul') as HTMLElement
+
+    pointerDrag(
+      list.children[0] as HTMLElement,
+      list.children[2] as HTMLElement,
+      {}
+    )
+
+    expect(onSort).toHaveBeenCalledTimes(1)
+    const intent = onSort.mock.calls[0][0]
+    expect(intent.pullMode).toBeUndefined()
+    expect(intent.newIndexes).toEqual([2])
+  })
+})


### PR DESCRIPTION
## Problem

`duplicateKey` (2.2.0, #146) never works through the React adapter. The adapter builds its `SortIntent` exclusively from the core `end` event (`src/react/index.ts` `onEnd`), but no `end` emit ever carried `pullMode` — so every alt-drag duplicate reached adapter consumers as a plain move. Controlled cross-zone clones had the same blind spot.

Found in the wild: Visibox's alt-drag-duplicate E2E suite failed on all platforms — alt-dragging a song produced a reorder, never a copy (spaceagetv/missioncontrol#4760).

The library's own duplicate tests all assert the `clone` event directly on core, so the gap was invisible: the adapter had zero duplicate coverage.

## Fix

`end` now reports the drag's **outcome**:

- **`endControlledDrag`**: `pullMode: 'clone'` for duplicate/clone drops — and for a same-zone duplicate, the offset-adjusted `newIndex`/`newIndexes` (the same values the `clone`/`update` events already carried) instead of the raw pending index. Cross-zone moves report the source pull mode. Plain reorders stay `pullMode`-less.
- **`endDrag` (uncontrolled)**: same contract for parity, so consumers wired only to `onEnd` can tell a duplicate from a move without also subscribing to `clone`/`remove`.
- `SortableEvent.pullMode` doc updated with the `end`-event semantics.

No adapter change needed — it already forwards `event.pullMode`; it was just always undefined.

## Tests

- New `tests/unit/react/useSortable-duplicate.spec.tsx`: same-zone alt-drag delivers a `pullMode: 'clone'` intent at the offset-adjusted index; cross-zone alt-drag delivers a clone intent addressed to the target zone; plain drag stays a move with `pullMode` undefined. (All three fail on `main`.)
- `duplicate-key.spec.ts`: existing same-zone, controlled, and no-modifier tests now pin the `end` payload too.
- Full suite: 464 passed. `npm run check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PEuEJPJhjA2YGyxhZziMXN

<!-- claude-session:cf26b591-8abc-45c6-8da6-f66794dcaa64 -->
🔖 **Claude agent:** missioncontrol-3f  
session id: `cf26b591-8abc-45c6-8da6-f66794dcaa64`