### PR TITLE
feat(marquee): auto-scroll each scoped list's own container

### DIFF
--- a/src/plugins/MarqueeSelectPlugin.ts
+++ b/src/plugins/MarqueeSelectPlugin.ts
@@ -14,6 +14,12 @@
  *  - Optional `scrollContainer`: the marquee anchors to the container's
  *    content (it stretches while the container scrolls) and dragging near
  *    the container's top/bottom edge auto-scrolls it
+ *  - Multi-list `scope` also edge-auto-scrolls each participating list's
+ *    OWN scrollable container, zero-config — every scoped instance's
+ *    nearest scrollable ancestor is resolved automatically and scrolls
+ *    independently as the pointer nears its top/bottom edge, so several
+ *    independently-scrolling columns under one marquee all edge-scroll
+ *    together. Works alongside (and separately from) `scrollContainer`.
  */
 
 import type {
@@ -72,6 +78,13 @@ export interface MarqueeSelectOptions {
    * each item's owning Sortable instance, and applies selection through
    * that instance (so per-instance `select` events fire normally). When
    * omitted, only the installing instance's own items participate.
+   *
+   * Also enables zero-config per-list edge auto-scroll: each participating
+   * instance's own nearest scrollable ancestor is resolved automatically
+   * and auto-scrolls independently as the pointer nears its top/bottom
+   * edge — no extra option needed, and it composes with `scrollContainer`
+   * (which continues to anchor the marquee to one specific container). Use
+   * `autoScrollDistance` / `autoScrollSpeed` to tune it.
    */
   scope?: MarqueeScopeEntry[]
   /**
@@ -79,11 +92,23 @@ export interface MarqueeSelectOptions {
    * appended inside it (content coordinates, so it stretches while the
    * container scrolls) and pointer positions near the container's top or
    * bottom edge auto-scroll it. HTMLElement or CSS selector.
+   *
+   * This is independent of the per-list auto-scroll `scope` enables: only
+   * this one container gets the content-coordinate anchoring (needed so
+   * the marquee rectangle stretches correctly while it scrolls); scoped
+   * instances' own containers auto-scroll without being anchored to.
    */
   scrollContainer?: HTMLElement | string
-  /** Distance (px) from the scrollContainer edge that triggers auto-scroll. Default: 30 */
+  /**
+   * Distance (px) from a container's edge that triggers auto-scroll —
+   * applies to `scrollContainer` and to every container auto-resolved via
+   * `scope`. Default: 30
+   */
   autoScrollDistance?: number
-  /** Auto-scroll speed in px per millisecond. Default: 0.3 */
+  /**
+   * Auto-scroll speed in px per millisecond — applies to `scrollContainer`
+   * and to every container auto-resolved via `scope`. Default: 0.3
+   */
   autoScrollSpeed?: number
 }
 
@@ -118,8 +143,12 @@ interface MarqueeState {
   subtractive: boolean
   /** Scope-entry index the marquee is locked to (null until first hit) */
   lockedKind: number | null
-  /** Edge auto-scroll direction currently engaged */
-  scrolling: 'up' | 'down' | false
+  /**
+   * Per-instance scrollable containers auto-resolved from a multi-list
+   * `scope`, captured at marquee start. Each edge-scrolls independently
+   * of (and in addition to) the explicit `scrollContainer` anchor.
+   */
+  scopeScrollTargets: HTMLElement[]
   scrollRaf: number | null
   /**
    * Scroll container's content size captured at marquee start. The marquee
@@ -176,7 +205,7 @@ function createDefaultState(): MarqueeState {
     additive: false,
     subtractive: false,
     lockedKind: null,
-    scrolling: false,
+    scopeScrollTargets: [],
     scrollRaf: null,
     contentLimit: null,
     holdTimer: null,
@@ -375,6 +404,56 @@ export class MarqueeSelectPlugin extends BasePlugin {
     return out
   }
 
+  /**
+   * Auto-resolve each participating scoped instance's own nearest
+   * scrollable container — zero-config per-list edge auto-scroll for
+   * multi-list `scope`. Only runs when `scope` is configured; single-list
+   * marquees rely on the explicit `scrollContainer` option instead. The
+   * explicit `scrollContainer`, if any, is excluded here since it's
+   * already driven separately (and additionally anchors the marquee
+   * rectangle — see `toMarqueePoint`).
+   */
+  private resolveScopeScrollTargets(
+    sortable: SortableInstance,
+    snapshot: Map<SortableInstance, Set<HTMLElement>>
+  ): HTMLElement[] {
+    if (!this.opts.scope) return []
+    const anchored = this.scrollElement.get(sortable)
+    const seen = new Set<HTMLElement>()
+    const targets: HTMLElement[] = []
+    for (const instance of snapshot.keys()) {
+      const container = this.nearestScrollableAncestor(instance.element)
+      if (!container || container === anchored || seen.has(container)) continue
+      seen.add(container)
+      targets.push(container)
+    }
+    return targets
+  }
+
+  /**
+   * Nearest scrollable ancestor of `root`, starting at `root` itself (a
+   * scoped list's own container is very commonly the scrollable element —
+   * e.g. an independently-scrolling column). Same overflow-and
+   * -actually-overflowing check `AutoScrollPlugin` uses for drag-time edge
+   * scroll, vertical-only to match this plugin's existing edge auto-scroll.
+   */
+  private nearestScrollableAncestor(
+    root: HTMLElement
+  ): HTMLElement | undefined {
+    let el: HTMLElement | null = root
+    while (el && el !== document.body && el !== document.documentElement) {
+      const style = window.getComputedStyle(el)
+      if (
+        (style.overflowY === 'auto' || style.overflowY === 'scroll') &&
+        el.scrollHeight > el.clientHeight
+      ) {
+        return el
+      }
+      el = el.parentElement
+    }
+    return undefined
+  }
+
   /** Selector matching ANY scoped item (alt+drag-on-item path). */
   private scopedItemSelector(sortable: SortableInstance): string {
     return this.scopeEntries(sortable)
@@ -446,6 +525,7 @@ export class MarqueeSelectPlugin extends BasePlugin {
     e.preventDefault()
 
     const touchScroll = this.scrollElement.get(sortable)
+    const touchSnapshot = this.takeSnapshot(sortable)
     const state: MarqueeState = {
       ...createDefaultState(),
       contentLimit: touchScroll
@@ -458,7 +538,11 @@ export class MarqueeSelectPlugin extends BasePlugin {
       lastClientX: startX,
       lastClientY: startY,
       pointerId,
-      snapshot: this.takeSnapshot(sortable),
+      snapshot: touchSnapshot,
+      scopeScrollTargets: this.resolveScopeScrollTargets(
+        sortable,
+        touchSnapshot
+      ),
       isTouchHold: true,
     }
     state.lockedKind = this.kindOfSnapshot(sortable, state.snapshot)
@@ -721,6 +805,7 @@ export class MarqueeSelectPlugin extends BasePlugin {
       : null
 
     const start = this.toMarqueePoint(sortable, e.clientX, e.clientY)
+    const snapshot = this.takeSnapshot(sortable)
     const state: MarqueeState = {
       ...createDefaultState(),
       contentLimit,
@@ -731,7 +816,8 @@ export class MarqueeSelectPlugin extends BasePlugin {
       lastClientX: e.clientX,
       lastClientY: e.clientY,
       pointerId: e.pointerId,
-      snapshot: this.takeSnapshot(sortable),
+      snapshot,
+      scopeScrollTargets: this.resolveScopeScrollTargets(sortable, snapshot),
       // Modifiers are cached at start (legacy parity): releasing shift/alt
       // mid-drag must not flip the mode and blow away the selection.
       additive: e.shiftKey,
@@ -869,7 +955,6 @@ export class MarqueeSelectPlugin extends BasePlugin {
       window.cancelAnimationFrame(state.scrollRaf)
       state.scrollRaf = null
     }
-    state.scrolling = false
 
     // Remove marquee element
     if (state.marqueeEl) {
@@ -915,50 +1000,96 @@ export class MarqueeSelectPlugin extends BasePlugin {
     }
   }
 
-  // ── Edge auto-scroll (scrollContainer only) ────────────────
+  // ── Edge auto-scroll (scrollContainer + scoped per-instance) ────────
 
   /**
-   * Auto-scroll the anchored container while the pointer sits near its
-   * top/bottom edge, stretching the marquee and re-hit-testing as content
-   * moves. Time-based speed (px/ms), not per-event steps.
+   * Auto-scroll every relevant container while the pointer sits near its
+   * top/bottom edge: the explicit anchored `scrollContainer` (unchanged
+   * behavior — it also re-anchors the marquee rectangle since the marquee
+   * lives inside it) PLUS every per-instance container auto-resolved from
+   * a multi-list `scope` (`state.scopeScrollTargets`), each scrolling
+   * independently so side-by-side columns can edge-scroll at the same
+   * time. Time-based speed (px/ms), not per-event steps.
    */
   private updateAutoScroll(
     sortable: SortableInstance,
     state: MarqueeState
   ): void {
-    const scroll = this.scrollElement.get(sortable)
-    if (!scroll || !state.active) return
+    if (!state.active) return
+    const anchored = this.scrollElement.get(sortable)
+    if (!anchored && state.scopeScrollTargets.length === 0) return
+    if (state.scrollRaf !== null) return
 
-    state.scrolling = this.scrollDirection(state, scroll)
-    if (!state.scrolling || state.scrollRaf !== null) return
+    // "Room to scroll down" on the anchored container is measured against
+    // the content captured at marquee start — the marquee element lives
+    // inside it and inflates the live scrollHeight, which made this chase
+    // a bottom edge of its own making. Scoped targets never host the
+    // marquee element, so their live scrollHeight is safe to read as-is.
+    const anchoredDirection = (): 'up' | 'down' | false =>
+      anchored
+        ? this.scrollDirection(
+            state.lastClientY,
+            anchored,
+            state.contentLimit?.h ?? anchored.scrollHeight
+          )
+        : false
 
-    // One loop at a time (guarded by scrollRaf). The frame timestamp lives
-    // in the closure — the loop is the only writer, so re-evaluating the
-    // direction each frame can never reset the clock (a reset made every
-    // elapsed read 0 and the marquee never actually scrolled).
+    const wantsScroll =
+      Boolean(anchoredDirection()) ||
+      state.scopeScrollTargets.some(
+        (target) => this.scopeAutoScrollDirection(state, target) !== false
+      )
+    if (!wantsScroll) return
+
+    // One loop at a time (guarded by scrollRaf), driving every target
+    // together. The frame timestamp lives in the closure — the loop is the
+    // only writer, so re-evaluating direction each frame can never reset
+    // the clock (a reset made every elapsed read 0 and nothing scrolled).
     let last = 0
     const tick = (now: number): void => {
       state.scrollRaf = null
       if (!state.active) return
-      state.scrolling = this.scrollDirection(state, scroll)
-      if (!state.scrolling) return
 
       const elapsed = last === 0 ? 0 : now - last
       last = now
       const delta = Math.round(elapsed * this.opts.autoScrollSpeed)
-      scroll.scrollBy(0, state.scrolling === 'up' ? -delta : delta)
 
-      // The container moved under a stationary pointer: recompute the
-      // current corner from the last raw pointer position, redraw, and
-      // re-run the (throttled) hit test.
-      const point = this.toMarqueePoint(
-        sortable,
-        state.lastClientX,
-        state.lastClientY
-      )
-      state.currentX = point.x
-      state.currentY = point.y
-      this.updateMarqueeVisual(state)
+      let scrolledAnchored = false
+      let scrolledAny = false
+
+      const aDir = anchoredDirection()
+      if (aDir && anchored) {
+        scrolledAny = true
+        scrolledAnchored = true
+        anchored.scrollBy(0, aDir === 'up' ? -delta : delta)
+      }
+
+      for (const target of state.scopeScrollTargets) {
+        const dir = this.scopeAutoScrollDirection(state, target)
+        if (dir) {
+          scrolledAny = true
+          target.scrollBy(0, dir === 'up' ? -delta : delta)
+        }
+      }
+
+      if (!scrolledAny) return
+
+      // A container moved under a stationary pointer: re-run the
+      // (throttled) hit test so every scoped list's items are
+      // re-evaluated against their new rects. Only the anchored
+      // container's scroll requires recomputing the marquee's own
+      // position — scoped targets never host the marquee element, so it
+      // doesn't move when they scroll.
+      if (scrolledAnchored) {
+        const point = this.toMarqueePoint(
+          sortable,
+          state.lastClientX,
+          state.lastClientY
+        )
+        state.currentX = point.x
+        state.currentY = point.y
+        this.updateMarqueeVisual(state)
+      }
       this.throttledUpdateSelection.get(sortable)?.(sortable, state)
 
       state.scrollRaf = window.requestAnimationFrame(tick)
@@ -966,24 +1097,41 @@ export class MarqueeSelectPlugin extends BasePlugin {
     state.scrollRaf = window.requestAnimationFrame(tick)
   }
 
+  /**
+   * Edge test for an auto-resolved per-instance container: same up/down
+   * logic as the anchored `scrollContainer`, gated on the pointer being
+   * horizontally over THIS container. Side-by-side columns share a
+   * vertical band near the top/bottom of the marquee area — without the
+   * horizontal gate, being near one column's edge would scroll ALL of
+   * them. The anchored `scrollContainer` never needed this (there's only
+   * ever one), so it's intentionally NOT applied there.
+   */
+  private scopeAutoScrollDirection(
+    state: MarqueeState,
+    target: HTMLElement
+  ): 'up' | 'down' | false {
+    const rect = target.getBoundingClientRect()
+    if (state.lastClientX < rect.left || state.lastClientX > rect.right) {
+      return false
+    }
+    return this.scrollDirection(state.lastClientY, target, target.scrollHeight)
+  }
+
   /** Edge test: which way should the container scroll for the pointer's
    *  current position — with room left to actually scroll that way. */
   private scrollDirection(
-    state: MarqueeState,
-    scroll: HTMLElement
+    clientY: number,
+    container: HTMLElement,
+    contentHeight: number
   ): 'up' | 'down' | false {
-    const rect = scroll.getBoundingClientRect()
+    const rect = container.getBoundingClientRect()
     const distance = this.opts.autoScrollDistance
-    if (state.lastClientY < rect.top + distance && scroll.scrollTop > 0) {
+    if (clientY < rect.top + distance && container.scrollTop > 0) {
       return 'up'
     }
-    // "Room to scroll down" is measured against the content captured at
-    // marquee start — the marquee element inflates the live scrollHeight,
-    // which made this chase a bottom edge of its own making.
-    const contentHeight = state.contentLimit?.h ?? scroll.scrollHeight
     if (
-      state.lastClientY > rect.bottom - distance &&
-      scroll.scrollTop + scroll.clientHeight < contentHeight
+      clientY > rect.bottom - distance &&
+      container.scrollTop + container.clientHeight < contentHeight
     ) {
       return 'down'
     }

--- a/tests/unit/marquee-select.test.ts
+++ b/tests/unit/marquee-select.test.ts
@@ -1154,6 +1154,278 @@ describe('MarqueeSelectPlugin', () => {
     })
   })
 
+  describe('Per-list edge auto-scroll for multi-list scope', () => {
+    let wrapper: HTMLElement
+    let itemsA: HTMLElement[]
+    let itemsB: HTMLElement[]
+    let sortableA: SortableInstance
+    let sortableB: SortableInstance
+    let scrollByA: ReturnType<typeof vi.fn>
+    let scrollByB: ReturnType<typeof vi.fn>
+
+    /**
+     * Make `el` behave like a real overflow-y:auto column with room to
+     * scroll: a fixed viewport rect, scrollHeight > clientHeight, and a
+     * spy-able `scrollBy` (jsdom doesn't implement it at all).
+     */
+    function makeScrollable(
+      el: HTMLElement,
+      rect: DOMRect
+    ): ReturnType<typeof vi.fn> {
+      vi.spyOn(el, 'getBoundingClientRect').mockReturnValue(rect)
+      Object.defineProperty(el, 'scrollHeight', {
+        value: 600,
+        configurable: true,
+      })
+      Object.defineProperty(el, 'clientHeight', {
+        value: 200,
+        configurable: true,
+      })
+      el.scrollTop = 0
+      const scrollBy = vi.fn()
+      ;(el as unknown as { scrollBy: typeof scrollBy }).scrollBy = scrollBy
+      return scrollBy
+    }
+
+    beforeEach(async () => {
+      vi.useFakeTimers()
+      const { registerInstance } = await import(
+        '../../src/core/InstanceRegistry.js'
+      )
+
+      // Two independently-scrolling columns side by side under one
+      // marquee area (the Visibox two-column use case): A spans x 0-200,
+      // B spans x 210-410, same vertical band.
+      wrapper = document.createElement('div')
+      document.body.appendChild(wrapper)
+
+      itemsA = createItems(3)
+      itemsB = createItems(3)
+      sortableA = createMockSortable(itemsA)
+      sortableB = createMockSortable(itemsB)
+
+      wrapper.appendChild(sortableA.element)
+      wrapper.appendChild(sortableB.element)
+      registerInstance(sortableA.element, sortableA)
+      registerInstance(sortableB.element, sortableB)
+
+      scrollByA = makeScrollable(sortableA.element, new DOMRect(0, 0, 200, 200))
+      scrollByB = makeScrollable(
+        sortableB.element,
+        new DOMRect(210, 0, 200, 200)
+      )
+
+      mockItemRects(
+        itemsA,
+        itemsA.map((_, i) => ({
+          x: 10,
+          y: 10 + i * 50,
+          width: 180,
+          height: 40,
+        }))
+      )
+      mockItemRects(
+        itemsB,
+        itemsB.map((_, i) => ({
+          x: 220,
+          y: 10 + i * 50,
+          width: 180,
+          height: 40,
+        }))
+      )
+
+      vi.spyOn(window, 'getComputedStyle').mockImplementation(
+        (el: Element) =>
+          ({
+            display: 'block',
+            visibility: 'visible',
+            opacity: '1',
+            overflowY:
+              el === sortableA.element || el === sortableB.element
+                ? 'auto'
+                : 'visible',
+          }) as CSSStyleDeclaration
+      )
+
+      plugin = MarqueeSelectPlugin.create({
+        marqueeArea: wrapper,
+        scope: [{ itemSelector: '.sortable-item' }],
+      })
+      plugin.install(sortableA)
+    })
+
+    afterEach(() => {
+      plugin.uninstall(sortableA)
+      wrapper.remove()
+      vi.useRealTimers()
+    })
+
+    it("auto-resolves each scoped list's own container, zero-config, and scrolls only the one near the pointer", () => {
+      wrapper.dispatchEvent(
+        pointerEvent('pointerdown', { clientX: 5, clientY: 5 })
+      )
+      // Pointer over column A (x=100, inside 0-200), near its bottom edge
+      // (y=185, within the default 30px autoScrollDistance of rect.bottom=200).
+      document.dispatchEvent(
+        pointerEvent('pointermove', { clientX: 100, clientY: 185 })
+      )
+
+      vi.advanceTimersByTime(16)
+      vi.advanceTimersByTime(16)
+
+      expect(scrollByA).toHaveBeenCalled()
+      expect(scrollByB).not.toHaveBeenCalled()
+      const calls = scrollByA.mock.calls as [number, number][]
+      const lastCall = calls[calls.length - 1]
+      expect(lastCall[1]).toBeGreaterThan(0) // scrolling down
+    })
+
+    it('scrolls the OTHER column when the pointer is near its edge instead', () => {
+      wrapper.dispatchEvent(
+        pointerEvent('pointerdown', { clientX: 300, clientY: 5 })
+      )
+      // Pointer over column B (x=300, inside 210-410), near its bottom edge.
+      document.dispatchEvent(
+        pointerEvent('pointermove', { clientX: 300, clientY: 185 })
+      )
+
+      vi.advanceTimersByTime(16)
+      vi.advanceTimersByTime(16)
+
+      expect(scrollByB).toHaveBeenCalled()
+      expect(scrollByA).not.toHaveBeenCalled()
+    })
+
+    it('re-runs hit-testing as a scoped column scrolls, selecting items the scroll reveals', () => {
+      // A 4th item in column A starts below the marquee's reach (y=250) —
+      // not selected yet. The scrollBy mock simulates it scrolling into
+      // view, the same way a real auto-scroll moves content under a
+      // stationary pointer; the plugin must re-hit-test to catch it.
+      const itemA4 = createItems(1)[0]
+      sortableA.element.appendChild(itemA4)
+      vi.spyOn(itemA4, 'getBoundingClientRect').mockReturnValue(
+        new DOMRect(10, 250, 180, 40)
+      )
+      scrollByA.mockImplementation(() => {
+        vi.spyOn(itemA4, 'getBoundingClientRect').mockReturnValue(
+          new DOMRect(10, 150, 180, 40)
+        )
+      })
+
+      wrapper.dispatchEvent(
+        pointerEvent('pointerdown', { clientX: 5, clientY: 5 })
+      )
+      document.dispatchEvent(
+        pointerEvent('pointermove', { clientX: 100, clientY: 185 })
+      )
+
+      for (let i = 0; i < 5; i++) vi.advanceTimersByTime(16)
+
+      const smA = sortableA.dragManager!.selectionManager
+      expect(smA.selectedElements.has(itemA4)).toBe(true)
+    })
+
+    it('does not double-drive a container that is BOTH the explicit scrollContainer and a scope-resolved target', () => {
+      plugin.uninstall(sortableA)
+      plugin = MarqueeSelectPlugin.create({
+        marqueeArea: wrapper,
+        scope: [{ itemSelector: '.sortable-item' }],
+        scrollContainer: sortableA.element,
+      })
+      plugin.install(sortableA)
+
+      wrapper.dispatchEvent(
+        pointerEvent('pointerdown', { clientX: 5, clientY: 5 })
+      )
+      document.dispatchEvent(
+        pointerEvent('pointermove', { clientX: 100, clientY: 185 })
+      )
+
+      vi.advanceTimersByTime(16)
+      vi.advanceTimersByTime(16)
+
+      // One scrollBy call per animation frame (anchored path only) — the
+      // scope resolver excludes a target that's already the explicit
+      // scrollContainer, so it must never be driven twice per frame.
+      expect(scrollByA.mock.calls.length).toBe(2)
+    })
+  })
+
+  describe('scrollContainer edge auto-scroll (regression)', () => {
+    let container: HTMLElement
+    let scrollBy: ReturnType<typeof vi.fn>
+
+    beforeEach(() => {
+      vi.useFakeTimers()
+      items = createItems(3)
+      sortable = createMockSortable(items)
+      container = sortable.element
+
+      vi.spyOn(container, 'getBoundingClientRect').mockReturnValue(
+        new DOMRect(0, 0, 300, 200)
+      )
+      Object.defineProperty(container, 'scrollHeight', {
+        value: 600,
+        configurable: true,
+      })
+      Object.defineProperty(container, 'clientHeight', {
+        value: 200,
+        configurable: true,
+      })
+      Object.defineProperty(container, 'scrollWidth', {
+        value: 300,
+        configurable: true,
+      })
+      container.scrollTop = 0
+      scrollBy = vi.fn()
+      ;(container as unknown as { scrollBy: typeof scrollBy }).scrollBy =
+        scrollBy
+
+      mockItemRects(
+        items,
+        items.map((_, i) => ({ x: 10, y: 10 + i * 50, width: 180, height: 40 }))
+      )
+
+      vi.spyOn(window, 'getComputedStyle').mockImplementation(
+        () =>
+          ({
+            display: 'block',
+            visibility: 'visible',
+            opacity: '1',
+            position: 'relative',
+          }) as CSSStyleDeclaration
+      )
+
+      plugin = MarqueeSelectPlugin.create({
+        marqueeArea: container,
+        scrollContainer: container,
+      })
+      plugin.install(sortable)
+    })
+
+    afterEach(() => {
+      plugin.uninstall(sortable)
+      vi.useRealTimers()
+    })
+
+    it('still anchors the marquee to the container and auto-scrolls it near the bottom edge', () => {
+      container.dispatchEvent(
+        pointerEvent('pointerdown', { clientX: 5, clientY: 5 })
+      )
+      document.dispatchEvent(
+        pointerEvent('pointermove', { clientX: 100, clientY: 185 })
+      )
+
+      vi.advanceTimersByTime(16)
+      vi.advanceTimersByTime(16)
+
+      expect(scrollBy).toHaveBeenCalled()
+      const calls = scrollBy.mock.calls as [number, number][]
+      const lastCall = calls[calls.length - 1]
+      expect(lastCall[1]).toBeGreaterThan(0)
+    })
+  })
+
   describe('Global area (html) behavior', () => {
     it('defers user-select disabling until threshold for global areas', () => {
       plugin = MarqueeSelectPlugin.create() // defaults to html


### PR DESCRIPTION
## Summary

`MarqueeSelectPlugin`'s edge auto-scroll was tied to a single optional
`scrollContainer`. With a multi-list `scope` (one lasso selecting across
several sortable lists), only that one anchored container — or none —
could edge-scroll. A UI with several independently-scrolling columns
under one marquee area could only ever auto-scroll one of them.

This adds zero-config, per-instance edge auto-scroll for `scope`: each
participating list's own nearest scrollable ancestor is resolved
automatically and scrolls independently as the pointer nears its
top/bottom edge, in addition to (and without disturbing) the explicit
`scrollContainer` anchor.

## Design decisions

- **Resolution, not configuration.** Each scoped instance's own root
  element is walked upward (starting at the element itself, since a
  list's own `overflow-y:auto` container is the common case) for the
  nearest `overflow-y: auto|scroll` ancestor that actually overflows —
  same check `AutoScrollPlugin` already uses for drag-time edge scroll,
  vertical-only to match this plugin's existing edge auto-scroll. No new
  option; it's on by default whenever `scope` is set, since that's the
  only mode where "which list's container?" is even ambiguous.

- **`scrollContainer` keeps its existing, different job.** `scrollContainer`
  content-anchors the marquee element itself (it's appended *inside* that
  container so the rectangle stretches while it scrolls) — that only
  makes sense for a single container. Scoped per-instance containers are
  never anchored to; the marquee stays in viewport coordinates (as it
  already does whenever `scrollContainer` is unset), so hit-testing keeps
  working correctly as any number of independent containers scroll
  underneath it — nothing extra was needed there. If a scoped instance's
  resolved container happens to BE the explicit `scrollContainer`, it's
  excluded from the scoped set so it isn't driven twice.

- **Horizontal gate for scoped targets only.** The anchored
  `scrollContainer` path only ever checks vertical proximity (there's
  only one target, so X doesn't matter) — left untouched. For scoped
  targets, side-by-side columns can share the same vertical band near the
  marquee's top/bottom, so scrolling requires the pointer to also be
  horizontally over that specific column; otherwise being near the
  bottom of ANY column would scroll ALL of them together.

- **Single shared rAF loop.** Rather than one animation-frame loop per
  container, `updateAutoScroll` drives the anchored container (if any)
  and every scoped target from one loop per marquee session, checking
  each target's direction every frame and re-running the (throttled) hit
  test once if anything scrolled. Keeps the diff small and avoids N
  competing loops.

## Test plan

- [x] `npx vitest run tests/unit/marquee-select.test.ts` — new "Per-list
      edge auto-scroll for multi-list scope" suite (resolves + scrolls the
      near-edge column only, symmetric for the other column, re-hit-tests
      as a column scrolls so newly-revealed items get selected, and
      doesn't double-drive a container that's both the explicit
      `scrollContainer` and a scope-resolved target) plus a
      `scrollContainer` regression suite (that option had zero prior test
      coverage) — all pass, existing suite (44 tests) still green.
- [x] `npm run check` (lint + typecheck) — clean on changed files.
- [x] `npm run build` — passes, bundle sizes well under budget.

<!-- claude-session:322297f7-bb7a-4516-b1a9-57cf50cedbe5 -->
🔖 **Claude agent:** missioncontrol-f2  
session id: `322297f7-bb7a-4516-b1a9-57cf50cedbe5`