### PR TITLE
fix(release): stop a prose line triggering a major release, and pin the changelog preset

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -56,7 +56,10 @@
             "type": "chore",
             "release": false
           }
-        ]
+        ],
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE:", "BREAKING-CHANGE:"]
+        }
       }
     ],
     [
@@ -111,6 +114,9 @@
               "hidden": true
             }
           ]
+        },
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE:", "BREAKING-CHANGE:"]
         }
       }
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "@typescript-eslint/parser": "^8.67.0",
         "@vitest/coverage-v8": "^4.1.11",
         "@vitest/ui": "^4.1.11",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "eslint": "^10.9.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.6",
@@ -322,6 +323,19 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
+      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/@commitlint/config-validator": {
@@ -4722,16 +4736,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.4.0.tgz",
-      "integrity": "sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.4.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -145,6 +145,7 @@
     "@typescript-eslint/parser": "^8.67.0",
     "@vitest/coverage-v8": "^4.1.11",
     "@vitest/ui": "^4.1.11",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "eslint": "^10.9.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.6",


### PR DESCRIPTION
The Release workflow on `main` is failing. Two independent faults, and the second one is the only reason the first did not ship.

## 1. semantic-release wanted to publish 3.0.0

The last Release run logged:

```
The release type for the commit is major
Analysis of 18 commits complete: major release
The next release version is 3.0.0
```

Nothing breaking has landed. The cause is commit `6ab75ca`, where a sentence wrapped so that a line *begins* with the words "breaking change":

```
library requires Node 20, and narrowing the published range would be a
breaking change for consumers. Only the dev toolchain moved.
```

The conventionalcommits parser matches a note keyword at the start of a line, case-insensitively, followed by a colon **or whitespace**. So that prose line was read as a `BREAKING CHANGE` footer.

Reproduced against `@semantic-release/commit-analyzer` itself — same body, only the line wrapping differs:

```
line starts with "breaking change" => major
rewrapped                          => null
```

**Fix:** require the colon in `noteKeywords`. Verified through commit-analyzer that every genuine form still produces a major release, and only the prose case stops:

| Input | before | after |
|---|---|---|
| `BREAKING CHANGE: x` footer | major | major |
| `BREAKING-CHANGE: x` footer | major | major |
| `feat!: x` header | major | major |
| prose line "breaking change for ..." | **major** | no release |

This is applied to both `commit-analyzer` and `release-notes-generator` so the two agree.

## 2. generateNotes crashed

```
Missing helper: "conventional-changelog-conventionalcommits requires
conventional-changelog-writer@9 or newer ..."
```

The `conventionalcommits` preset is **not** a dependency of `@semantic-release/release-notes-generator` — it is resolved from the project root via `import-from-esm`, so whichever copy npm hoists is the one that runs. `@commitlint/config-conventional` 21 brought `conventional-changelog-conventionalcommits` 10, which requires `conventional-changelog-writer` 9+, while the semantic-release plugins pin `writer ^8`.

**Fix:** declare the preset directly as a devDependency at `^9`. The release path stops being a side effect of commitlint's dependency tree. commitlint keeps its own nested 10.x and still loads — verified.

## Verification

With both fixes, running the real plugins over the 18 commits since `v2.3.0`:

```
release type: patch

## [2.3.1](https://github.com/jjeff/resortable/compare/v2.3.0...v2.3.1) (2026-08-24)

### Bug Fixes

* **ci:** reformat with prettier 3.9 and cover format:check in npm run check (13ed09d)
```

`npm run check` passes and commitlint still accepts and rejects messages correctly.

## Nothing was published

npm is still on `2.3.0` and the newest tag is `v2.3.0`. Three Release runs skipped with "The local branch main is behind the remote one" because four PRs merged in quick succession; the one run that did proceed died at `generateNotes`. **The changelog crash is the only thing that stopped a wrong 3.0.0 release.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pavgf7FXoZa6Vzv77JUhUt

<!-- claude-session:637c50f1-141f-4859-84ee-5265e0c911be -->
🔖 **Claude agent:** resortable-24  
session id: `637c50f1-141f-4859-84ee-5265e0c911be`